### PR TITLE
feat: allow task name editing

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -270,6 +270,11 @@ pub fn edit_item(config: Config, item: items::Item) {
     let new_name =
         config::get_input("Enter a new name for this item").expect("could not get new name");
 
+    if new_name.is_empty() {
+        println!("No new name entered, keeping current name");
+        return;
+    }
+
     request::update_item_name(config, item, new_name).expect("could not update item name");
 }
 

--- a/src/items.rs
+++ b/src/items.rs
@@ -264,6 +264,15 @@ pub fn set_priority(config: Config, item: items::Item) {
     }
 }
 
+pub fn edit_item(config: Config, item: items::Item) {
+    println!("{}", item.fmt(&config));
+
+    let new_name =
+        config::get_input("Enter a new name for this item").expect("could not get new name");
+
+    request::update_item_name(config, item, new_name).expect("could not update item name");
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ struct Arguments<'a> {
     remove_project: Option<&'a str>,
     sort_inbox: bool,
     prioritize_tasks: bool,
+    edit_tasks: bool,
     scheduled_items: bool,
 }
 
@@ -95,6 +96,9 @@ fn main() {
             flag_arg("prioritize tasks", 'z', "prioritize", "Assign priorities to tasks. Can specify project option, defaults to inbox.")
         )
         .arg(
+            flag_arg("edit tasks", 'd', "edit", "Edit tasks. Can specify project option, defaults to inbox.")
+        )
+        .arg(
             flag_arg("scheduled items", 'e', "scheduled", "Returns items that are today and have a time. Can specify project option, defaults to inbox.")
         )
         .arg(
@@ -130,6 +134,7 @@ fn main() {
             .get_one::<String>("configuration path")
             .map(|s| s.as_str()),
         prioritize_tasks: has_flag(matches.clone(), "prioritize tasks"),
+        edit_tasks: has_flag(matches.clone(), "edit tasks"),
         scheduled_items: has_flag(matches.clone(), "scheduled items"),
     };
 
@@ -159,6 +164,7 @@ fn dispatch(arguments: Arguments) -> Result<String, String> {
             remove_project: None,
             sort_inbox: false,
             prioritize_tasks: false,
+            edit_tasks: false,
             scheduled_items: false,
             config_path: _,
         } => projects::add_item_to_project(config, &task, project),
@@ -172,6 +178,7 @@ fn dispatch(arguments: Arguments) -> Result<String, String> {
             remove_project: None,
             sort_inbox: false,
             prioritize_tasks: false,
+            edit_tasks: false,
             scheduled_items: false,
             config_path: _,
         } => projects::add_item_to_project(config, &task, "inbox"),
@@ -185,6 +192,7 @@ fn dispatch(arguments: Arguments) -> Result<String, String> {
             remove_project: None,
             sort_inbox: false,
             prioritize_tasks: false,
+            edit_tasks: false,
             scheduled_items: false,
             config_path: _,
         } => projects::next_item(config, project),
@@ -198,6 +206,7 @@ fn dispatch(arguments: Arguments) -> Result<String, String> {
             remove_project: None,
             sort_inbox: false,
             prioritize_tasks: false,
+            edit_tasks: false,
             scheduled_items: false,
             config_path: _,
         } => match request::complete_item(config) {
@@ -214,6 +223,7 @@ fn dispatch(arguments: Arguments) -> Result<String, String> {
             remove_project: None,
             sort_inbox: false,
             prioritize_tasks: false,
+            edit_tasks: false,
             scheduled_items: false,
             config_path: _,
         } => projects::list(config),
@@ -227,6 +237,7 @@ fn dispatch(arguments: Arguments) -> Result<String, String> {
             remove_project: None,
             sort_inbox: false,
             prioritize_tasks: false,
+            edit_tasks: false,
             scheduled_items: false,
             config_path: _,
         } => projects::add(config, params),
@@ -240,6 +251,7 @@ fn dispatch(arguments: Arguments) -> Result<String, String> {
             remove_project: Some(project_name),
             sort_inbox: false,
             prioritize_tasks: false,
+            edit_tasks: false,
             scheduled_items: false,
             config_path: _,
         } => projects::remove(config, project_name),
@@ -253,6 +265,7 @@ fn dispatch(arguments: Arguments) -> Result<String, String> {
             remove_project: None,
             sort_inbox: true,
             prioritize_tasks: false,
+            edit_tasks: false,
             scheduled_items: false,
             config_path: _,
         } => projects::sort_inbox(config),
@@ -266,6 +279,7 @@ fn dispatch(arguments: Arguments) -> Result<String, String> {
             remove_project: None,
             sort_inbox: false,
             prioritize_tasks: true,
+            edit_tasks: false,
             scheduled_items: false,
             config_path: _,
         } => projects::prioritize_items(&config, "inbox"),
@@ -279,6 +293,7 @@ fn dispatch(arguments: Arguments) -> Result<String, String> {
             remove_project: None,
             sort_inbox: false,
             prioritize_tasks: true,
+            edit_tasks: false,
             scheduled_items: false,
             config_path: _,
         } => projects::prioritize_items(&config, project_name),
@@ -292,6 +307,35 @@ fn dispatch(arguments: Arguments) -> Result<String, String> {
             remove_project: None,
             sort_inbox: false,
             prioritize_tasks: false,
+            edit_tasks: true,
+            scheduled_items: false,
+            config_path: _,
+        } => projects::edit_items(&config, "inbox"),
+        Arguments {
+            new_task: None,
+            project: Some(project_name),
+            next_task: false,
+            complete_task: false,
+            list_projects: false,
+            add_project: None,
+            remove_project: None,
+            sort_inbox: false,
+            prioritize_tasks: false,
+            edit_tasks: true,
+            scheduled_items: false,
+            config_path: _,
+        } => projects::edit_items(&config, project_name),
+        Arguments {
+            new_task: None,
+            project: None,
+            next_task: false,
+            complete_task: false,
+            list_projects: false,
+            add_project: None,
+            remove_project: None,
+            sort_inbox: false,
+            prioritize_tasks: false,
+            edit_tasks: false,
             scheduled_items: true,
             config_path: _,
         } => projects::scheduled_items(&config, "inbox"),
@@ -305,6 +349,7 @@ fn dispatch(arguments: Arguments) -> Result<String, String> {
             remove_project: None,
             sort_inbox: false,
             prioritize_tasks: false,
+            edit_tasks: false,
             scheduled_items: true,
             config_path: _,
         } => projects::scheduled_items(&config, project_name),
@@ -318,6 +363,7 @@ fn dispatch(arguments: Arguments) -> Result<String, String> {
             remove_project: None,
             sort_inbox: false,
             prioritize_tasks: false,
+            edit_tasks: false,
             scheduled_items: false,
             config_path: _,
         } => projects::all_items(&config, project_name),
@@ -331,6 +377,7 @@ fn dispatch(arguments: Arguments) -> Result<String, String> {
             remove_project: None,
             sort_inbox: false,
             prioritize_tasks: false,
+            edit_tasks: false,
             scheduled_items: false,
             config_path: _,
         } => Err(String::from(

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -150,6 +150,27 @@ pub fn prioritize_items(config: &Config, project_name: &str) -> Result<String, S
     }
 }
 
+/// Prioritize all unprioritized items in a project
+pub fn edit_items(config: &Config, project_name: &str) -> Result<String, String> {
+    let inbox_id = projects::project_id(config, project_name)?;
+
+    let items = request::items_for_project(config, &inbox_id)?;
+
+    if items.is_empty() {
+        Ok(format!("No tasks to edit in {project_name}")
+            .green()
+            .to_string())
+    } else {
+        for item in items.iter() {
+            // items::set_priority(config.clone(), item.to_owned());
+            items::edit_item(config.clone(), item.to_owned());
+        }
+        Ok(format!("Successfully edited items in {project_name}")
+            .green()
+            .to_string())
+    }
+}
+
 pub fn move_item_to_project(config: Config, item: Item) -> Result<String, String> {
     println!("{}", item.fmt(&config));
 

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -162,7 +162,6 @@ pub fn edit_items(config: &Config, project_name: &str) -> Result<String, String>
             .to_string())
     } else {
         for item in items.iter() {
-            // items::set_priority(config.clone(), item.to_owned());
             items::edit_item(config.clone(), item.to_owned());
         }
         Ok(format!("Successfully edited items in {project_name}")

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -150,7 +150,7 @@ pub fn prioritize_items(config: &Config, project_name: &str) -> Result<String, S
     }
 }
 
-/// Prioritize all unprioritized items in a project
+/// Edit items in a project
 pub fn edit_items(config: &Config, project_name: &str) -> Result<String, String> {
     let inbox_id = projects::project_id(config, project_name)?;
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -71,6 +71,16 @@ pub fn update_item_priority(config: Config, item: Item, priority: u8) -> Result<
     Ok(String::from("✓"))
 }
 
+/// Update the priority of an item by ID
+pub fn update_item_name(config: Config, item: Item, new_name: String) -> Result<String, String> {
+    let body = json!({ "content": new_name });
+    let url = format!("{}{}", REST_V2_TASKS_URL, item.id);
+
+    post_todoist_rest(config.token, url, body)?;
+    // Does not pass back an item
+    Ok(String::from("✓"))
+}
+
 /// Complete the last item returned by "next item"
 pub fn complete_item(config: Config) -> Result<String, String> {
     let body = json!({"commands": [{"type": "item_close", "uuid": new_uuid(), "temp_id": new_uuid(), "args": {"id": config.next_id}}]});

--- a/src/request.rs
+++ b/src/request.rs
@@ -71,7 +71,7 @@ pub fn update_item_priority(config: Config, item: Item, priority: u8) -> Result<
     Ok(String::from("✓"))
 }
 
-/// Update the priority of an item by ID
+/// Update the name of an item by ID
 pub fn update_item_name(config: Config, item: Item, new_name: String) -> Result<String, String> {
     let body = json!({ "content": new_name });
     let url = format!("{}{}", REST_V2_TASKS_URL, item.id);


### PR DESCRIPTION
I tried adding the logic for the editing part and it seems to work. I miss unit tests thought. What part of the logic would you test? I noticed that the functions [`prioritize_items`][prioritize_items] and [`items::set_priority`][set_priority] are not tested, but [`update_item_priority`][update_item_priority] yes. So I guess I should test [`update_item_name`][update_item_name], right?

Speaking of that, do you think the naming is ok? In `main`, in `projects` and in `items` I called it "edit_item(s)", but then inside [`items.rs#edit_item`][edit_item] I call only the method that edits the item NAME, not all of it.

[prioritize_items]: https://github.com/alanvardy/tod/blob/a45e936c47f5835b9c72a091e8610c73ac184e99/src/projects.rs#L129
[set_priority]: https://github.com/alanvardy/tod/blob/a45e936c47f5835b9c72a091e8610c73ac184e99/src/items.rs#L244
[update_item_priority]: https://github.com/alanvardy/tod/blob/a45e936c47f5835b9c72a091e8610c73ac184e99/src/request.rs#L65
[update_item_name]: https://github.com/BobToninho/tod/blob/3d086594af423b1544c461770c6d5e6181bdca1f/src/request.rs#L75
[edit_item]: https://github.com/BobToninho/tod/blob/3d086594af423b1544c461770c6d5e6181bdca1f/src/items.rs#L267