### PR TITLE
refactor priority status to make it typed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,6 +1258,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,7 +1469,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tod"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -1473,6 +1484,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_repr",
  "spinners",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ colored = "2.0.0"
 clap = "4.2.7"
 spinners = "4.1.0"
 inquire = "0.6.2"
+serde_repr = "0.1.12"
 
 [dev-dependencies]
 mockito = "1.0.0"

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -1,5 +1,5 @@
 use crate::config::Config;
-use crate::items::{FormatType, Item};
+use crate::items::{FormatType, Item, Priority};
 use crate::{config, items, projects, request};
 use colored::*;
 
@@ -170,7 +170,7 @@ pub fn prioritize_items(config: &Config, project_name: &str) -> Result<String, S
 
     let unprioritized_items: Vec<Item> = items
         .into_iter()
-        .filter(|item| item.priority == 1)
+        .filter(|item| item.priority == Priority::Default)
         .collect::<Vec<Item>>();
 
     if unprioritized_items.is_empty() {

--- a/src/request.rs
+++ b/src/request.rs
@@ -304,7 +304,7 @@ mod tests {
             add_item_to_inbox(&config, "testy test"),
             Ok(Item {
                 id: String::from("5149481867"),
-                priority: 1,
+                priority: items::Priority::Default,
                 content: String::from("testy test"),
                 checked: false,
                 description: String::from(""),
@@ -347,7 +347,7 @@ mod tests {
                     is_recurring: true,
                     timezone: None,
                 }),
-                priority: 3,
+                priority: items::Priority::Normal,
                 is_deleted: false,
             }])
         );

--- a/src/test.rs
+++ b/src/test.rs
@@ -21,7 +21,7 @@ pub mod helpers {
                 is_recurring: false,
                 timezone: Some(String::from("America/Los_Angeles")),
             }),
-            priority: 3,
+            priority: crate::items::Priority::Normal,
             is_deleted: false,
         }
     }


### PR DESCRIPTION
Hi, @alanvardy 
How about something like this in terms of priority refactoring that was mentioned in https://github.com/alanvardy/tod/issues/336

I have one todo to consider(convert priority to u8) but it looks solid

also, I must admit I have trouble with set_priority_works. I don't understand how it is supposed to work, it feels incomplete
```rust
    #[test]
    fn set_priority_works() {
        let config = test::helpers::config_fixture();
        let item = test::helpers::item_fixture();
        set_priority(&config, item)
    }
```

I would appreciate some help with it, maybe I missed something