### PR TITLE
Resolve a few clippy warnings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -406,7 +406,7 @@ mod tests {
         // get_or_create (create)
         let config = get_or_create(None);
         assert_eq!(
-            config.clone(),
+            config,
             Ok(Config {
                 token: String::from("Africa/Asmera"),
                 projects: HashMap::new(),
@@ -450,7 +450,7 @@ mod tests {
             .unwrap();
         let legacy_path = generate_legacy_path().unwrap();
         let proper_path = generate_path().unwrap();
-        fs::rename(proper_path, &legacy_path).unwrap();
+        fs::rename(proper_path, legacy_path).unwrap();
         let config = get_or_create(None);
         assert_eq!(
             config.clone(),
@@ -462,7 +462,7 @@ mod tests {
                 spinners: Some(true),
                 last_version_check: Some(time::today_string(&config.unwrap())),
                 timezone: Some(String::from("Africa/Asmera")),
-                mock_url: mock_url,
+                mock_url,
             })
         );
         delete_config(&path);

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -283,7 +283,6 @@ pub fn green_string(str: &str) -> String {
 mod tests {
     use super::*;
     use crate::test;
-    use mockito;
     use pretty_assertions::assert_eq;
 
     /// Need to adjust this value forward or back an hour when timezone changes
@@ -328,7 +327,7 @@ mod tests {
             .mock("POST", "/sync/v9/projects/get_data")
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(&test::responses::items())
+            .with_body(test::responses::items())
             .create();
 
         let config = Config::new("12341234", Some(server.url()))
@@ -341,7 +340,7 @@ mod tests {
             timezone: Some(String::from("US/Pacific")),
             path: format!("{config_dir}/test2"),
             mock_url: Some(server.url()),
-            ..config.clone()
+            ..config
         };
 
         config_with_timezone.clone().create().unwrap();
@@ -352,10 +351,7 @@ mod tests {
             format!("Put out recycling\nDue: {TIME} ↻")
         };
 
-        assert_eq!(
-            next_item(config_with_timezone, "good"),
-            Ok(String::from(string))
-        );
+        assert_eq!(next_item(config_with_timezone, "good"), Ok(string));
     }
 
     #[test]
@@ -365,7 +361,7 @@ mod tests {
             .mock("POST", "/sync/v9/projects/get_data")
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(&test::responses::items())
+            .with_body(test::responses::items())
             .create();
 
         let config = Config::new("12341234", Some(server.url()))
@@ -401,7 +397,7 @@ mod tests {
             .mock("POST", "/sync/v9/projects/get_data")
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(&test::responses::items())
+            .with_body(test::responses::items())
             .create();
 
         let config = Config::new("12341234", Some(server.url()))


### PR DESCRIPTION
I just figured out how to add clippy to the rust-analyzer LSP and it is showing up in my editor now, here is the config if you are interested:

```toml
[[language]]
name = "rust"
auto-format = false
language-servers = ["rust-analyzer"]

[language-server.rust-analyzer]
command = "/home/vardy/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rust-analyzer"
# This is the important line
config = { checkOnSave = { command = "clippy" } }

```

I'm using helix `main` branch which now supports multiple LSPs so you may have to adapt this if you are using the regular releases.