### PR TITLE
[WIP] Ability to use '~' alias in config file location string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.52.0",
 ]
@@ -280,7 +281,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.9.0",
  "scopeguard",
 ]
 
@@ -556,6 +557,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
+name = "homedir"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22074da8bba2ef26fc1737ae6c777b5baab5524c2dc403b5c6a76166766ccda5"
+dependencies = [
+ "cfg-if",
+ "nix",
+ "serde",
+ "widestring",
+ "windows-sys",
+ "wmi",
+]
+
+[[package]]
 name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,7 +652,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.51.1",
 ]
 
 [[package]]
@@ -772,6 +787,15 @@ checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
@@ -850,6 +874,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f71d09d5c87634207f894c6b31b6a2b2c64ea3bdcf71bd5599fdbbe1600c00f"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
 ]
 
 [[package]]
@@ -1549,6 +1586,7 @@ dependencies = [
  "clap",
  "colored",
  "dirs",
+ "homedir",
  "inquire",
  "matches",
  "mockito",
@@ -1815,6 +1853,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1837,12 +1881,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-implement",
+ "windows-interface",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12168c33176773b86799be25e2a2ba07c7aab9968b37541f1094dbd7a60c8946"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.46",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d8dc32e0095a7eeccebd0e3f09e9509365ecb3fc6ac4d6f5f14a3f6392942d1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -1976,6 +2063,20 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys",
+]
+
+[[package]]
+name = "wmi"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff298e96fd8ef6bb55dcb2a7fd2f26969f962bf428ffa6b267457dd804d64d8"
+dependencies = [
+ "chrono",
+ "futures",
+ "log",
+ "serde",
+ "thiserror",
+ "windows",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ rand = "0.8.5"
 rayon = "1.8.1"
 pad = "0.1.6"
 urlencoding = "2.1.3"
+homedir = "0.2.1"
 
 [dev-dependencies]
 mockito = "1.2.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -266,12 +266,9 @@ pub fn generate_path() -> Result<String, String> {
 fn alias_check(config_path: &mut String) {
     let alias = config_path.find('~');
 
-    match alias {
-        Some(alias) => {
-            let home = env::home_dir().unwrap();
-            config_path.replace_range(..alias+1, home.to_str().unwrap());
-        }
-        _ => (),
+    if let Some(path) = alias {
+        let home = env::home_dir().unwrap();
+        config_path.replace_range(..path+1, home.to_str().unwrap());
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::fs;
 use std::io::{Read, Write};
+use std::env;
 
 /// App configuration, serialized as json in $XDG_CONFIG_HOME/tod.cfg
 #[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Debug)]
@@ -256,6 +257,21 @@ pub fn generate_path() -> Result<String, String> {
         Ok(format!("tests/{random_string}.testcfg"))
     } else {
         Ok(format!("{config_directory}/tod.cfg"))
+    }
+}
+
+/// Checks if the config path contains the user home directory alias "~"
+/// and expands it to a full absolute path
+/// e.g., "~/.config/tod.cfg" --> "/home/user/.config/tod.cfg"
+fn alias_check(config_path: &mut String) -> {
+    let alias = config_path.find('~');
+
+    match alias {
+        Some(alias) => {
+            let home = env::home_dir().unwrap();
+            config_path.replace_range(..alias+1, home.to_str().unwrap());
+        }
+        None => _,
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -263,7 +263,7 @@ pub fn generate_path() -> Result<String, String> {
 /// Checks if the config path contains the user home directory alias "~"
 /// and expands it to a full absolute path
 /// e.g., "~/.config/tod.cfg" --> "/home/user/.config/tod.cfg"
-fn alias_check(config_path: &mut String) -> {
+fn alias_check(config_path: &mut String) {
     let alias = config_path.find('~');
 
     match alias {
@@ -271,7 +271,7 @@ fn alias_check(config_path: &mut String) -> {
             let home = env::home_dir().unwrap();
             config_path.replace_range(..alias+1, home.to_str().unwrap());
         }
-        None => _,
+        _ => (),
     }
 }
 


### PR DESCRIPTION
I am starting to add the ability for users to use the '~' home directory alias instead of having to type out the entire absolute path.

I started by writing a function that would take in the path at every time it is handled and check if it is relative. If so, expand the '~' ... if not, leave it.

Let me know if you think this is a good start. I am new to Rust so please pointers on ways in which my code style in general could improve.

Important note: std::env::home_dir() is deprecated. I used it because it is in the standard library and wanted to get permission before I start throwing crates into the code base. There is a small crate called [homedir](https://docs.rs/homedir/latest/homedir/) that would do just this. And it works for Windows. As always, let me know what you think!