### PR TITLE
Revert "Use REST api for completing tasks"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (on main branch only)
 
+- Switch back to Sync API for completing tasks, because REST API doesn't handle subtasks correctly
+
 ## 2024-03-28 v0.5.13
 
 - Add spaces in between tasks in `process` 

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -329,7 +329,7 @@ mod tests {
             .create();
 
         let mock2 = server
-            .mock("POST", "/rest/v2/tasks/999999/close")
+            .mock("POST", "/sync/v9/sync")
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(test::responses::sync())

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -625,17 +625,16 @@ mod tests {
     fn test_handle_task() {
         let mut server = mockito::Server::new();
         let mock = server
-            .mock("POST", "/rest/v2/tasks/999999/close")
+            .mock("POST", "/sync/v9/sync")
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(test::responses::task())
+            .with_body(test::responses::sync())
             .create();
 
         let task = test::fixtures::task();
         let config = test::fixtures::config()
             .mock_url(server.url())
-            .mock_select(0)
-            .set_next_id(&"999999".to_string());
+            .mock_select(0);
         let mut task_count = 3;
         let result = handle_task(&config, task, &mut task_count);
         let expected = Some(Ok(String::from("✓")));
@@ -654,10 +653,10 @@ mod tests {
             .create();
 
         let mock2 = server
-            .mock("POST", "/rest/v2/tasks/999999/close")
+            .mock("POST", "/sync/v9/sync")
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(test::responses::task())
+            .with_body(test::responses::sync())
             .create();
 
         let config = test::fixtures::config()

--- a/src/todoist.rs
+++ b/src/todoist.rs
@@ -186,11 +186,10 @@ pub fn update_task_name(config: &Config, task: Task, new_name: String) -> Result
 
 /// Complete the last task returned by "next task"
 pub fn complete_task(config: &Config) -> Result<String, String> {
-    let id = config.next_id.clone().unwrap_or_default();
-    let url = format!("{REST_V2_TASKS_URL}{id}/close");
-    let body = json!("");
+    let body = json!({"commands": [{"type": "item_close", "uuid": request::new_uuid(), "temp_id": request::new_uuid(), "args": {"id": config.next_id}}]});
+    let url = String::from(SYNC_URL);
 
-    request::post_todoist_rest(config, url, body)?;
+    request::post_todoist_sync(config, url, body)?;
 
     if !cfg!(test) {
         config.clone().clear_next_id().save()?;
@@ -343,7 +342,7 @@ mod tests {
     fn should_complete_a_task() {
         let mut server = mockito::Server::new();
         let mock = server
-            .mock("POST", "/rest/v2/tasks/112233/close")
+            .mock("POST", "/sync/v9/sync")
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(test::responses::sync())


### PR DESCRIPTION
Reverts alanvardy/tod#683

Turns out that the REST Api version doesn't uncheck subtasks when it is a recurring parent issue