### PR TITLE
Implement tod config set-timezone

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -133,7 +133,7 @@ impl Config {
 
     pub async fn check_for_timezone(self: Config) -> Result<Config, Error> {
         if self.timezone.is_none() {
-            let desc = "Please select your timezone";
+            let desc = "Please select your timezone. This should match your Timezone setting within Todoist";
             let mut options = TZ_VARIANTS
                 .to_vec()
                 .iter()

--- a/src/config.rs
+++ b/src/config.rs
@@ -140,7 +140,7 @@ impl Config {
         }
     }
 
-    async fn set_timezone(self) -> Result<Config, Error> {
+    pub async fn set_timezone(self) -> Result<Config, Error> {
         let desc = "Please select your timezone. This should match your Timezone setting within Todoist.";
         let mut options = TZ_VARIANTS
             .to_vec()

--- a/src/config.rs
+++ b/src/config.rs
@@ -152,7 +152,8 @@ impl Config {
     }
 
     pub async fn set_timezone(self) -> Result<Config, Error> {
-        let desc = "Please select your timezone. This should match your Timezone setting within Todoist.";
+        let desc =
+            "Please select your timezone. This should match your Timezone setting within Todoist.";
         let mut options = TZ_VARIANTS
             .to_vec()
             .iter()

--- a/src/config.rs
+++ b/src/config.rs
@@ -131,28 +131,33 @@ impl Config {
         Ok(())
     }
 
-    pub async fn check_for_timezone(self: Config) -> Result<Config, Error> {
+    pub async fn check_for_timezone(self) -> Result<Config, Error> {
         if self.timezone.is_none() {
-            let desc = "Please select your timezone. This should match your Timezone setting within Todoist";
-            let mut options = TZ_VARIANTS
-                .to_vec()
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>();
-            options.sort();
-
-            let tz = input::select(desc, options, self.mock_select)?;
-            let config = Config {
-                timezone: Some(tz),
-                ..self
-            };
-
-            config.clone().save().await?;
-
+            let config = self.set_timezone().await?;
             Ok(config)
         } else {
             Ok(self)
         }
+    }
+
+    async fn set_timezone(self) -> Result<Config, Error> {
+        let desc = "Please select your timezone. This should match your Timezone setting within Todoist.";
+        let mut options = TZ_VARIANTS
+            .to_vec()
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<String>>();
+        options.sort();
+
+        let tz = input::select(desc, options, self.mock_select)?;
+        let config = Config {
+            timezone: Some(tz),
+            ..self
+        };
+
+        config.clone().save().await?;
+
+        Ok(config)
     }
 
     pub fn clear_next_id(self) -> Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -145,8 +145,7 @@ impl Config {
 
     pub async fn check_for_timezone(self) -> Result<Config, Error> {
         if self.timezone.is_none() {
-            let config = self.set_timezone().await?;
-            Ok(config)
+            self.set_timezone().await
         } else {
             Ok(self)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -351,7 +351,12 @@ struct ConfigCheckVersion {}
 struct ConfigReset {}
 
 #[derive(Parser, Debug, Clone)]
-struct ConfigSetTimezone {}
+struct ConfigSetTimezone {
+    #[arg(short, long)]
+    /// TimeZone to add, i.e. "Canada/Pacific"
+    timezone: Option<String>,
+
+}
 
 enum Flag {
     Project(Project),

--- a/src/main.rs
+++ b/src/main.rs
@@ -355,7 +355,6 @@ struct ConfigSetTimezone {
     #[arg(short, long)]
     /// TimeZone to add, i.e. "Canada/Pacific"
     timezone: Option<String>,
-
 }
 
 enum Flag {
@@ -418,7 +417,9 @@ async fn main() {
             config_check_version(cli.clone(), args, tx).await
         }
         Commands::Config(ConfigCommands::Reset(args)) => config_reset(cli.clone(), args, tx).await,
-        Commands::Config(ConfigCommands::SetTimezone(args)) => tz_reset(cli.clone(), args, tx).await,
+        Commands::Config(ConfigCommands::SetTimezone(args)) => {
+            tz_reset(cli.clone(), args, tx).await
+        }
     };
 
     while let Some(e) = rx.recv().await {
@@ -765,7 +766,11 @@ async fn config_reset(
 }
 
 #[cfg(not(tarpaulin_include))]
-async fn tz_reset(cli: Cli, _args: &ConfigSetTimezone, tx: UnboundedSender<Error>) -> Result<String, Error> {
+async fn tz_reset(
+    cli: Cli,
+    _args: &ConfigSetTimezone,
+    tx: UnboundedSender<Error>,
+) -> Result<String, Error> {
     let config = fetch_config(cli, tx).await?;
 
     match config.set_timezone().await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -764,7 +764,7 @@ async fn tz_reset(cli: Cli, _args: &ConfigSetTimezone, tx: UnboundedSender<Error
     let config = fetch_config(cli, tx).await?;
 
     match config.set_timezone().await {
-        Ok(_) => Ok(format!("Timezone set successfully")),
+        Ok(_) => Ok("Timezone set successfully.".to_string()),
         Err(e) => Err(error::new(
             "tz_reset",
             &format!("Could not reset timezone in config. {e}"),


### PR DESCRIPTION
Implements Add tod config set-timezone #317 

I split the existing get_or_set tz function into two functions, then added a function that calls set_tz

however, I was not smart enough to implement the arguments for it to take in an argument. If you can implement that I will absolutely look at the diff and figure it out so I can do the same thing for the other options. Feedback absolutely welcome - thank you!

Thanks!