### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@
 
 - Fix `DateTime` sorting
 
-- Divide page size (from term size in last commit) by two to fix prompt spacing bug.
-
 ## 2024-06-09 v0.6.9
 
 - Add `list timebox`
@@ -31,7 +29,7 @@
 
 - Put the error channel transmitter in `Config`, removing the need to pass around the additional argument in many places
 - Add `config set-timezone`
-- Format Markdown links as OSC8 links in supported terminals. Falls back in unsupported terminal
+- Format Markdown links as OSC8 links in supported terminals using `supports-hyperlinks` crate. Falls back in unsupported terminal
 - Added `disable-links` configuration option
 
 ## 2024-05-26 v0.6.6


### PR DESCRIPTION
Fixes duplicate "divide page size" comment and reformats two comments.