### PR TITLE
Added newline to 'tod list process' for projects

### DIFF
--- a/src/projects.rs
+++ b/src/projects.rs
@@ -277,6 +277,7 @@ pub async fn process_tasks(config: &Config, project: &Project) -> Result<String,
     let mut task_count = tasks.len() as i32;
     let mut handles = Vec::new();
     for task in tasks {
+        println!(" ");
         match tasks::process_task(&config.reload().await?, task, &mut task_count, false).await {
             Some(handle) => handles.push(handle),
             None => return Ok(color::green_string("Exited")),


### PR DESCRIPTION
When you invoke `tod list process` using a project, there are no newlines separating one task from another. However, if you invoke the same command using a filter, there is a newline separating. I changed `process_tasks()` in `projects.rs` to match the functionality of the same function in `filters.rs`. The resulting change amounts to a one line addition.