### PR TITLE
Ignore is_deleted attachments & comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased (on main branch only)
 
+- Handle `ImageAttachment` comment/file format
+- Reject invalid config file with error message
+- Ignore `is_deleted: true` attachments/comments
+
 ## 2025-05-04 v0.7.4
 
 - Handle Workspace projects by making `inbox_project` field optional on Project struct

--- a/src/comments.rs
+++ b/src/comments.rs
@@ -147,3 +147,114 @@ pub fn json_to_comment(json: String) -> Result<Comment, Error> {
     let comment: Comment = serde_json::from_str(&json)?;
     Ok(comment)
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::comments::json_to_comment_response;
+    use crate::test::fixtures; // 👈 access fixtures::config()
+    use std::fs;
+
+    async fn load_comments() -> Vec<Comment> {
+        let json = fs::read_to_string("tests/fixtures/comments_all_types.json").unwrap();
+        let response = json_to_comment_response(json).unwrap();
+        response
+            .results
+            .into_iter()
+            .filter(|c| !c.is_deleted)
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_filters_deleted_comment() {
+        let comments = load_comments().await;
+        assert_eq!(
+            comments.len(),
+            7,
+            "One deleted comment should be filtered out"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fmt_file_attachment() {
+        let config = fixtures::config().await;
+        let comment = load_comments()
+            .await
+            .into_iter()
+            .find(|c| c.id == "file-1")
+            .unwrap();
+        let output = comment.fmt(&config).unwrap();
+        assert!(output.contains("file.pdf"));
+    }
+
+    #[tokio::test]
+    async fn test_fmt_video_attachment() {
+        let config = fixtures::config().await;
+        let comment = load_comments()
+            .await
+            .into_iter()
+            .find(|c| c.id == "video-1")
+            .unwrap();
+        let output = comment.fmt(&config).unwrap();
+        assert!(output.contains("Test Video"));
+    }
+
+    #[tokio::test]
+    async fn test_fmt_image_attachment() {
+        let config = fixtures::config().await;
+        let comment = load_comments()
+            .await
+            .into_iter()
+            .find(|c| c.id == "image-1")
+            .unwrap();
+        let output = comment.fmt(&config).unwrap();
+        assert!(output.contains("Example Image"));
+    }
+
+    #[tokio::test]
+    async fn test_fmt_url_attachment() {
+        let config = fixtures::config().await;
+        let comment = load_comments()
+            .await
+            .into_iter()
+            .find(|c| c.id == "url-1")
+            .unwrap();
+        let output = comment.fmt(&config).unwrap();
+        assert!(output.contains("Interesting Article"));
+    }
+
+    #[tokio::test]
+    async fn test_fmt_short_url_attachment() {
+        let config = fixtures::config().await;
+        let comment = load_comments()
+            .await
+            .into_iter()
+            .find(|c| c.id == "shorturl-1")
+            .unwrap();
+        let output = comment.fmt(&config).unwrap();
+        assert!(output.contains("Shortened Link"));
+    }
+
+    #[tokio::test]
+    async fn test_fmt_rich_attachment() {
+        let config = fixtures::config().await;
+        let comment = load_comments()
+            .await
+            .into_iter()
+            .find(|c| c.id == "rich-1")
+            .unwrap();
+        let output = comment.fmt(&config).unwrap();
+        assert!(output.contains("News Story"));
+    }
+
+    #[tokio::test]
+    async fn test_fmt_no_attachment() {
+        let config = fixtures::config().await;
+        let comment = load_comments()
+            .await
+            .into_iter()
+            .find(|c| c.id == "noattach-1")
+            .unwrap();
+        let output = comment.fmt(&config).unwrap();
+        assert!(output.contains("Just a plain comment"));
+    }
+}

--- a/tests/fixtures/comments_all_types.json
+++ b/tests/fixtures/comments_all_types.json
@@ -1,0 +1,157 @@
+{
+    "results": [
+        {
+            "id": "file-1",
+            "content": "File upload",
+            "is_deleted": false,
+            "posted_uid": "123",
+            "uids_to_notify": null,
+            "posted_at": "2025-01-01T12:00:00Z",
+            "reactions": null,
+            "item_id": "task-1",
+            "file_attachment": {
+                "file_name": "file.pdf",
+                "file_size": 123456,
+                "file_type": "application/pdf",
+                "file_url": "https://example.com/file.pdf",
+                "image": null,
+                "image_height": null,
+                "image_width": null,
+                "resource_type": "file",
+                "upload_state": "completed",
+                "tn_s": null,
+                "tn_m": null,
+                "tn_l": null
+            }
+        },
+        {
+            "id": "video-1",
+            "content": "Video link",
+            "is_deleted": false,
+            "posted_uid": "123",
+            "uids_to_notify": null,
+            "posted_at": "2025-01-01T12:01:00Z",
+            "reactions": null,
+            "item_id": "task-1",
+            "file_attachment": {
+                "html": "<iframe src=\"https://example.com/embed/video\"></iframe>",
+                "image": "https://example.com/preview.jpg",
+                "image_height": 360,
+                "image_width": 480,
+                "resource_type": "video",
+                "site_name": "YouTube",
+                "title": "Test Video",
+                "url": "https://example.com/video",
+                "tn_s": null,
+                "tn_m": null,
+                "tn_l": null,
+                "upload_state": "completed"
+            }
+        },
+        {
+            "id": "image-1",
+            "content": "Image preview",
+            "is_deleted": false,
+            "posted_uid": "123",
+            "uids_to_notify": null,
+            "posted_at": "2025-01-01T12:02:00Z",
+            "reactions": null,
+            "item_id": "task-1",
+            "file_attachment": {
+                "resource_type": "image",
+                "url": "https://example.com/image.jpg",
+                "image": "https://example.com/image.jpg",
+                "image_height": 600,
+                "image_width": 800,
+                "site_name": "ImageHost",
+                "title": "Example Image",
+                "tn_s": null,
+                "tn_m": null,
+                "tn_l": null
+            }
+        },
+        {
+            "id": "url-1",
+            "content": "Full URL",
+            "is_deleted": false,
+            "posted_uid": "123",
+            "uids_to_notify": null,
+            "posted_at": "2025-01-01T12:03:00Z",
+            "reactions": null,
+            "item_id": "task-1",
+            "file_attachment": {
+                "resource_type": "url",
+                "description": "A useful article",
+                "favicon": "https://site.com/favicon.ico",
+                "image": "https://site.com/image.png",
+                "image_height": 100,
+                "image_width": 200,
+                "site_name": "SiteName",
+                "title": "Interesting Article",
+                "url": "https://site.com/article"
+            }
+        },
+        {
+            "id": "shorturl-1",
+            "content": "Short URL",
+            "is_deleted": false,
+            "posted_uid": "123",
+            "uids_to_notify": null,
+            "posted_at": "2025-01-01T12:04:00Z",
+            "reactions": null,
+            "item_id": "task-1",
+            "file_attachment": {
+                "resource_type": "url_short",
+                "title": "Shortened Link",
+                "url": "https://bit.ly/xyz123"
+            }
+        },
+        {
+            "id": "rich-1",
+            "content": "Rich embed",
+            "is_deleted": false,
+            "posted_uid": "123",
+            "uids_to_notify": null,
+            "posted_at": "2025-01-01T12:05:00Z",
+            "reactions": null,
+            "item_id": "task-1",
+            "file_attachment": {
+                "html": "<iframe src=\"https://nytimes.com/embed\"></iframe>",
+                "image": "https://nytimes.com/thumb.jpg",
+                "image_height": 400,
+                "image_width": 800,
+                "resource_type": "rich",
+                "site_name": "New York Times",
+                "title": "News Story",
+                "url": "https://nytimes.com/story",
+                "tn_s": null,
+                "tn_m": null,
+                "tn_l": null,
+                "upload_state": "completed"
+            }
+        },
+        {
+            "id": "noattach-1",
+            "content": "Just a plain comment",
+            "is_deleted": false,
+            "posted_uid": "123",
+            "uids_to_notify": null,
+            "posted_at": "2025-01-01T12:06:00Z",
+            "reactions": null,
+            "item_id": "task-1",
+            "file_attachment": null
+        },
+        {
+            "id": "deleted-1",
+            "content": "Should be skipped",
+            "is_deleted": true,
+            "posted_uid": "123",
+            "uids_to_notify": null,
+            "posted_at": "2025-01-01T12:07:00Z",
+            "reactions": null,
+            "item_id": "task-1",
+            "file_attachment": null
+        }
+    ],
+    "next_cursor": null
+}


### PR DESCRIPTION
Added logic for is_deleted comments/attachments (#1131 ) to be ignored.

Also added additional test_cases for comments (added a test comment JSON fixture for validation) and updated changelog

Definitely pending response from Todoist API team on further improvements necessary (ideally don't have to pull all comments) but this addresses issues for now!