### PR TITLE
chore: Add cz and commitlint (on main only)

### DIFF
--- a/.cz.json
+++ b/.cz.json
@@ -1,0 +1,10 @@
+{
+  "commitizen": {
+    "name": "cz_conventional_commits",
+    "tag_format": "v$version",
+    "version_scheme": "semver",
+    "version_provider": "cargo",
+    "major_version_zero": true
+  }
+}
+

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -14,3 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wagoid/commitlint-github-action@v6
+      

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,16 @@
+name: Lint Commit Message
+on:
+    push:
+      branches:
+        - main
+  
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: wagoid/commitlint-github-action@v6

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,4 +1,4 @@
-name: Lint Commit Message
+name: Commit Lint (main branch)
 on:
     push:
       branches:


### PR DESCRIPTION
Adds a .cz.json for new users to use Commitizen (if they are unfamiliar with conventional commits)
Adds commitlint for push on (on main branch only).