### PR TITLE
ci: do not merge tag

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -1,6 +1,8 @@
 
 
 name: 'Check Mergable by label ✅' 
+permissions:
+  contents: read
 on:
     pull_request:
         branches:

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -1,0 +1,24 @@
+
+
+name: 'Check Mergable by label ✅' 
+on:
+    pull_request:
+        branches:
+            - main
+        types:
+            - opened
+            - reopened
+            - synchronize
+            - edited
+            - labeled
+            - unlabeled
+
+jobs:
+  fail-by-label:
+    if: contains(github.event.pull_request.labels.*.name, 'Do Not Merge') || contains(github.event.pull_request.labels.*.name, 'do not merge') || contains(github.event.pull_request.labels.*.name, 'DNM') || contains(github.event.pull_request.labels.*.name, 'WIP')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if PR is labeled "do not merge"
+        run: |
+          echo "This PR is labeled as do not merge!"
+          exit 1

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -17,10 +17,11 @@ on:
 
 jobs:
   fail-by-label:
-    if: contains(github.event.pull_request.labels.*.name, 'Do Not Merge') || contains(github.event.pull_request.labels.*.name, 'do not merge') || contains(github.event.pull_request.labels.*.name, 'DNM') || contains(github.event.pull_request.labels.*.name, 'WIP')
+    if: contains(github.event.pull_request.labels.*.name, 'do not merge') || contains(github.event.pull_request.labels.*.name, 'WIP')
     runs-on: ubuntu-latest
     steps:
-      - name: Fail if PR is labeled "do not merge"
+      - name: Fail if PR is labeled "do not merge" or "WIP"
+        # This step will fail the job if the PR has the "do not merge" or "WIP" label.
         run: |
-          echo "This PR is labeled as do not merge!"
+          echo "This PR is labeled 'do not merge' or 'WIP'. Please remove the label to proceed with merging."
           exit 1


### PR DESCRIPTION
Adding check to block merging.

In order for this to be fully functional, you will need to move CI from optional to enforced (also fixes #1247 )

@alanvardy let me know if there is a more specific tag you'd like to use (i.e. "WIP" or something similar) - I imagine Graphite should have a feature to always submit something specific.

