### PR TITLE
chore: run codecov on all pushes

### DIFF
--- a/.github/workflows/ci_codecov.yml
+++ b/.github/workflows/ci_codecov.yml
@@ -1,17 +1,14 @@
-name: PR Tests
-# This workflow runs on pull requests to check code coverage using Codecov.
+name: Codecov
 
 permissions:
   contents: read  # Allow the workflow to read repository contents
   pull-requests: write  # Allow the workflow to write to pull requests
 
 on:
-  pull_request:
-    # Trigger the workflow on PR events, specifically when opened or updated.
-    
+  push:
+    # Trigger the workflow on push    
     paths:
       - '**/*.rs'  # Run only if there are changes in Rust source files.
-    types: [opened, synchronize, reopened]  # Triggers when the PR is opened, synchronized, or reopened.
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
![Screenshot 2025-06-08 at 18 53 29](https://github.com/user-attachments/assets/2a66794f-6301-4123-a999-e1673d42cf5e)

Codecov needs to run on main as well so that they can compare that with the PRs that we open. Right now it is 15 commits behind on main, so I can't view which lines are not covered and it gives inaccurate results.