### PR TITLE
ci: expand release_check changelog.md header check

### DIFF
--- a/.github/workflows/release_check.yml
+++ b/.github/workflows/release_check.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Check Version Consistency
         run: |
           # Extract version from CHANGELOG.md (first vX.Y.Z in first 7 lines)
-          changelog_version=$(head -n 7 CHANGELOG.md | grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+' | head -n 1)
+          changelog_version=$(head -n 15 CHANGELOG.md | grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+' | head -n 1)
           changelog_version_clean=${changelog_version#v}
           echo "CHANGELOG.md version: ${changelog_version_clean}"
 


### PR DESCRIPTION
expand the release_check height to look at more lines so it doesn't fail (it will still only return the first entry even if multiples matched)