### PR TITLE
ci: cargo-release

### DIFF
--- a/.github/workflows/release_linux_cargo.yml
+++ b/.github/workflows/release_linux_cargo.yml
@@ -38,8 +38,14 @@ jobs:
         with:
           tool: nextest
 
-      - name: Run tests
+      - name: Run platform tests
         run: cargo nextest run --all-features
+
+      - name: Install Cargo Get
+        id: cargo-get
+        uses: nicolaiunrein/cargo-get@master
+        with:
+          subcommand: package.version
 
       - name: Get version
         id: version
@@ -54,7 +60,7 @@ jobs:
             -C target/x86_64-unknown-linux-gnu/release tod
           shasum -a 256 target/release/tod-${{ env.VERSION }}-Linux-x86_64.tar.gz
 
-      - name: Upload to release
+      - name: Upload to Github
         run: |
           gh release upload "$VERSION" \
             target/release/tod-${VERSION}-Linux-x86_64.tar.gz \
@@ -79,8 +85,14 @@ jobs:
         with:
           tool: nextest
 
-      - name: Run tests
+      - name: Run platform tests
         run: cargo nextest run --all-features
+
+      - name: Install Cargo Get
+        id: cargo-get
+        uses: nicolaiunrein/cargo-get@master
+        with:
+          subcommand: package.version
 
       - name: Get version
         id: version
@@ -95,7 +107,7 @@ jobs:
             -C target/aarch64-unknown-linux-gnu/release tod
           shasum -a 256 target/release/tod-${{ env.VERSION }}-Linux-arm64.tar.gz
 
-      - name: Upload to release
+      - name: Upload to Github
         run: |
           gh release upload "$VERSION" \
             target/release/tod-${VERSION}-Linux-arm64.tar.gz \
@@ -105,7 +117,7 @@ jobs:
           VERSION: ${{ env.VERSION }}
   
   linux-cargo-release:
-    name: Release to Cargo Registry
+    name: Release Cargo Registry
     runs-on: ubuntu-latest
     needs: [linux-build-x86] # Wait for build to complete before uploading to cargo registry
     steps:

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -27,13 +27,32 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - name: Checkout repo
+      # Checkout the repository
+      - name: Checkout repository
         uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
 
-      - name: Install Rust target (if needed)
+      # Run Platform Tests
+      - name: Run tests using cargo-nextest
+        run: cargo nextest run --all-features  # Run all tests with nextest.
+        continue-on-error: false  # Fail the job if tests do not pass
+
+      - name: Install Rust target for Windows
         run: rustup target add x86_64-pc-windows-msvc
 
-      - name: Get version
+      # Get version from Cargo.toml
+      - name: get VERSION from Cargo.toml
+        id: cargo-get
+        uses: nicolaiunrein/cargo-get@master
+        with:
+          subcommand: package.version 
+      
+      - name: Set version variable
         id: version
         shell: bash
         run: echo "VERSION=$(cargo get package.version --pretty)" >> $GITHUB_ENV
@@ -53,8 +72,8 @@ jobs:
       - name: Upload to GitHub Release
         run: |
           gh release upload "$env:VERSION" `
-            "target/release/tod-${env:VERSION}-windows-x86_64.zip" `
-            --repo "$env:GITHUB_REPOSITORY" `
-            --clobber
+          "target/release/tod-${env:VERSION}-windows-x86_64.zip" `
+          --repo "$env:GITHUB_REPOSITORY" `
+          --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.TOD_CONTENTS_READ_WRITE }}


### PR DESCRIPTION
Earlier PR didn't include cargo-get on Linux images by accident, which the current release build process relies upon (as versions are build/pushed/released based on the cargo.toml version tag).

Updating releases to successfully complete.