### PR TITLE
ci: cargo-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
-on:
-  [push, pull_request]
+# This file performs CI testing for Tod using GitHub Actions.
+# It runs tests, checks code quality, and ensures no TODO/FIXME comments are left in the code.
+
+
+on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always
@@ -17,6 +20,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Run all tests using nextest
     name: Cargo CI Tests
     steps:
       - uses: actions/checkout@v4
@@ -40,7 +44,7 @@ jobs:
           cache-all-crates: true
       - name: Check
         run: cargo check --locked --all-features
-
+#Lint Check for any TODO or FIXME comments in the codebase.
   todos:
     name: TODO and FIXME 
     runs-on: ubuntu-latest
@@ -55,7 +59,7 @@ jobs:
       - run: ./scripts/lint_string.sh "fixme "
       - run: ./scripts/lint_string.sh "fixme:"
       - run: ./scripts/lint_string.sh "dbg!"
-
+  #Ensure code is formatted correctly using Rust's formatting tool (rustfmt).
   fmt:
     name: Rust-fmt (Cargo Format)
     runs-on: ubuntu-latest
@@ -67,7 +71,7 @@ jobs:
          cache-all-crates: true
       - run: rustup component add rustfmt
       - run: cargo fmt --all -- --check
-
+# Lint code using Clippy, a Rust linter that helps catch common mistakes and improve code quality.
   clippy:
     name: Clippy (Cargo Clippy Lint Check)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_codecov.yml
+++ b/.github/workflows/ci_codecov.yml
@@ -1,3 +1,5 @@
+# This workflow is designed to run tests and collect code coverage data using Codecov to ensure code quality.
+
 name: Codecov
 
 permissions:
@@ -33,6 +35,7 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-tarpaulin
+          # Run cargo-tarpaulin to collect code coverage data and upload it to Codecov
       - name: Run tests with coverage
         run: cargo tarpaulin --all-features --out xml --frozen --skip-clean
       - name: Upload to codecov.io

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,3 +1,5 @@
+# This workflow runs on all PRs and ensures they are formatted using Conventional Commits (https://www.conventionalcommits.org/), rejecting any that do not conform to the commit message standards.
+
 name: Commit Lint (main branch)
 
 on: [pull_request]  

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,6 +1,6 @@
 # This workflow runs on all PRs and ensures they are formatted using Conventional Commits (https://www.conventionalcommits.org/), rejecting any that do not conform to the commit message standards.
 
-name: Commit Lint (main branch)
+name: Commit Lint
 
 on: [pull_request]  
 

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -1,5 +1,6 @@
 # This job will only run for pull requests, specifically those created by Dependabot.
 # This will auto-merge Dependabot PRs that are minor updates and if they pass all tests.
+
 name: Auto Merge
 permissions:
   pull-requests: write  # Allow the workflow to write to pull requests

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -1,4 +1,4 @@
-
+# This workflow checks if a pull request is labeled with "do not merge" or "WIP" and fails any jobs if the tag exists.
 
 name: 'Check PR Merge' 
 permissions:

--- a/.github/workflows/release_cargo.yml
+++ b/.github/workflows/release_cargo.yml
@@ -1,0 +1,45 @@
+
+# This GitHub Actions workflow tests and then releases the tod application to the Cargo registry.
+
+name: Cargo Build & Release
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch: #Allow manual triggering of the workflow for testing
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_PROFILE_TEST_DEBUG: 0
+  CARGO_PROFILE_RELEASE_LTO: true
+  CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
+
+jobs:
+  cargo-release:
+    name: Cargo Build & Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true # Cache all crates to speed up builds
+
+      - uses: taiki-e/install-action@v2 # Install nextest for running tests
+        with:
+          tool: nextest
+
+      - name: Run platform tests # Run all tests with nextest.
+        run: cargo nextest run --all-features
+
+      - name: Release to cargo registry (crates.io) # Submit the package to the Cargo registry
+        run: |
+          cargo install auto-release
+          auto-release -p tod
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }} #Use the Cargo registry token from GitHub secrets
+

--- a/.github/workflows/release_check.yml
+++ b/.github/workflows/release_check.yml
@@ -1,3 +1,4 @@
+# This workflow checks for version consistency between the CHANGELOG.md and Cargo.toml files in a pull request. 
 name: Release Check
 
 on:

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -1,9 +1,9 @@
-name: Linux Build & Release & Cargo Registry
 # This GitHub Actions workflow builds the tod application for Linux x86_64 and ARM64,
-# packages the binaries, uploads them to a GitHub release, and publishes the package to the Cargo registry.
+# packages the binaries, uploads them to a GitHub release.
 # It also runs tests using nextest to ensure code quality before the release.
 # It is triggered by a push with a version tag (e.g., v1.0.0), typically from a release-please release.
 
+name: Linux Build & Release
 on:
   push:
     tags:
@@ -115,15 +115,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.TOD_CONTENTS_READ_WRITE }}
           VERSION: ${{ env.VERSION }}
-  
-  linux-cargo-release:
-    name: Release Cargo Registry
-    runs-on: ubuntu-latest
-    needs: [linux-build-x86] # Wait for build to complete before uploading to cargo registry
-    steps:
-      - uses: actions/checkout@v4
-      - run: cargo install auto-release
-      - run: auto-release -p <package>
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -115,15 +115,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.TOD_CONTENTS_READ_WRITE }}
           VERSION: ${{ env.VERSION }}
-  
-  linux-cargo-release:
-    name: Release to Cargo Registry
-    runs-on: ubuntu-latest
-    needs: [linux-build-x86] # Wait for build to complete before uploading to cargo registry
-    steps:
-      - uses: actions/checkout@v4
-      - run: cargo install auto-release
-      - run: auto-release -p <package>
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -115,3 +115,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.TOD_CONTENTS_READ_WRITE }}
           VERSION: ${{ env.VERSION }}
+  
+  linux-cargo-release:
+    name: Release to Cargo Registry
+    runs-on: ubuntu-latest
+    needs: [linux-build-x86] # Wait for build to complete before uploading to cargo registry
+    steps:
+      - uses: actions/checkout@v4
+      - run: cargo install auto-release
+      - run: auto-release -p <package>
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -1,8 +1,7 @@
-name: macOS Build & Release
 # This runs an OS-specific test, then builds and releases binaries for macOS (ARM and Intel) and publishes them to GitHub.
 # It is triggered by push with a version tag is present (generally from a release-please release)
 
-
+name: macOS Build & Release
 permissions:
   contents: write  # Allow the workflow to write to the repository contents
   pull-requests: write  # Allow the workflow to write to pull requests

--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -1,3 +1,5 @@
+# This workflow uses the release-please GitHub Action to automate the release process. It automatically creates new releases based on the commit history and versioning strategy defined in the Cargo.toml file. The action is triggered on pushes to the main branch.
+
 on:
     push:
       branches:

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -1,9 +1,8 @@
-name: Windows Build & Release
 # This workflow builds the Windows x86_64 binary and uploads it to a GitHub release.
 # It is triggered by a push with a version tag (e.g., v1.0.0), typically from a release-please release.
 # It also allows manual triggering for testing purposes.
 
-
+name: Windows Build & Release
 on:
   push:
     tags:
@@ -63,16 +62,16 @@ jobs:
       - name: Zip the Windows binary
         run: |
           Compress-Archive -Path target\x86_64-pc-windows-msvc\release\tod.exe `
-                          -DestinationPath target\release\tod-${env:VERSION}-windows-x86_64.zip
+                          -DestinationPath target\release\tod-${env:VERSION}-Windows-x86_64.zip
 
       - name: Hash the ZIP
         run: |
-          Get-FileHash target\release\tod-${env:VERSION}-windows-x86_64.zip -Algorithm SHA256
+          Get-FileHash target\release\tod-${env:VERSION}-Windows-x86_64.zip -Algorithm SHA256
 
       - name: Upload to GitHub Release
         run: |
           gh release upload "$env:VERSION" `
-          "target/release/tod-${env:VERSION}-windows-x86_64.zip" `
+          "target/release/tod-${env:VERSION}-Windows-x86_64.zip" `
           --repo "$env:GITHUB_REPOSITORY" `
           --clobber
         env:


### PR DESCRIPTION
This fixes the missing package tag from the cargo release command, fixing cargo release generation.

It splits out the cargo release to be separate from the Linux build release file.

It also adds several comments to each of the release files.