### PR TITLE
ci: remove workflow_dispatch

### DIFF
--- a/.github/workflows/release_cargo.yml
+++ b/.github/workflows/release_cargo.yml
@@ -6,7 +6,6 @@ on:
   push:
     tags:
       - 'v*.*.*'
-  workflow_dispatch: #Allow manual triggering of the workflow for testing
 
 permissions:
   contents: write

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -8,7 +8,6 @@ on:
   push:
     tags:
       - 'v*.*.*'
-  workflow_dispatch: #Allow manual triggering of the workflow for testing
 
 permissions:
   contents: write

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -7,7 +7,6 @@ on:
   push:
     tags:
       - 'v*.*.*'
-  workflow_dispatch: # Allow manual triggering of the workflow for testing
 
 permissions:
   contents: write


### PR DESCRIPTION
Now that windows builds and linux builds have been confirmed to work, removing manual workflow_dispatch trigger so they will only run on release in the future.

Needs final resolution of cargo build API key issue before merging (#1260 )