### PR TITLE
feat: dynamic max comment length

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,6 +124,8 @@ Holds a string date, i.e. `"2023-08-30"` representing the last time crates.io wa
 
 The maximum number of characters that will be printed in total when showing comments.
 
+If not set, this is dynamically calculated at runtime based on terminal window size (using the `term_size` crate).
+
 ### next_id
 
 ``` json

--- a/src/config.rs
+++ b/src/config.rs
@@ -1016,4 +1016,29 @@ mod tests {
         assert!(debug_output.contains("Config"));
         assert!(debug_output.contains("/tmp/test.cfg"));
     }
+    // Test function for max_comment_length
+    #[test]
+    fn max_comment_length_should_return_configured_value() {
+        let config = Config {
+            max_comment_length: Some(1234),
+            ..Config::default_test()
+        };
+
+        assert_eq!(config.max_comment_length(), 1234);
+    }
+
+    #[test]
+    fn max_comment_length_should_fallback_when_not_set() {
+        let config = Config {
+            max_comment_length: None,
+            ..Config::default_test()
+        };
+
+        let result = config.max_comment_length();
+
+        // In CI or test environments terminal_size might return None
+        // so just ensure it's a positive, nonzero value
+        assert!(result > 0);
+        assert!(result <= MAX_COMMENT_LENGTH);
+    }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -200,7 +200,7 @@ pub fn multi_select<T: Display>(
 }
 
 /// Gets the desired number of visible options for select menu and adjusts size
-fn page_size() -> usize {
+pub fn page_size() -> usize {
     match terminal_size() {
         Some((Width(_), Height(height))) if height >= 6 => (height - 3).into(),
         // We don't want less than 3 options

--- a/src/input.rs
+++ b/src/input.rs
@@ -199,7 +199,7 @@ pub fn multi_select<T: Display>(
     }
 }
 
-/// Gets the desired number of visible options for select menu
+/// Gets the desired number of visible options for select menu and adjusts size
 fn page_size() -> usize {
     match terminal_size() {
         Some((Width(_), Height(height))) if height >= 6 => (height - 3).into(),

--- a/src/tasks/format.rs
+++ b/src/tasks/format.rs
@@ -148,7 +148,7 @@ pub async fn render_comments(config: &Config, comments: Vec<Comment>) -> Result<
 
     if formatted_string.len() > max_comment_length {
         formatted_string.truncate(max_comment_length);
-        formatted_string.push_str("[TRUNCATED]");
+        formatted_string.push_str("...");
     };
 
     Ok(formatted_string)


### PR DESCRIPTION
max comment length is now returned if set; otherwise function returns a dynamically calculated (Estimated) max comment length 