### PR TITLE
ci: release_homebrew.yaml

### DIFF
--- a/.github/workflows/release_homebrew.yaml
+++ b/.github/workflows/release_homebrew.yaml
@@ -1,0 +1,26 @@
+name: Release Homebrew Formula
+
+on:
+  workflow_dispatch:  # Allows manual triggering
+
+  workflow_run:       # Automatically trigger when both jobs succeed
+    workflows: ["macOS Build & Release", "Linux Build & Release"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  trigger-homebrew-update:
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    name: Dispatch to homebrew-tod
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger homebrew-tod update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.TOD_CONTENTS_READ_WRITE }}
+          repository: alanvardy/homebrew-tod
+          event-type: update-homebrew


### PR DESCRIPTION
adds automatic triggering of remote homebrew build

# 📦 Pull Request

## Summary
Adds the 'release_homebrew' that triggers the remote dispatch on the homebrew-tod repository.

## Type of Change

- [ ] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fixes)
- [ ] 📝 Docs (documentation only)
- [ ] 🎨 Style (formatting, missing semi colons, etc.)
- [ ] ♻️ Refactor (non-breaking change, no new features)
- [x] 🚨 Tests (adding or updating tests)
- [x] 🔧 Chore (maintenance, tooling, or other misc items)

## Requirements

> Please confirm all items below before requesting a review:

- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format  
- [x] All CI checks pass  
- [x] Documentation was updated if necessary  
- [x] This PR is ready for **review**  

## Related Issues

> Link any related issues here using `Closes #issue-number`, `Fixes #issue-number`, etc.
