### PR TITLE
refactor: config cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1512,7 +1512,7 @@ checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -1739,17 +1739,6 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_merge"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "606e91878516232ac3b16c12e063d4468d762f16d77e7aef14a1f2326c5f409b"
-dependencies = [
- "serde",
- "serde_json",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2032,31 +2021,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.12",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.103",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2114,7 +2083,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_merge",
  "serde_regex",
  "serde_repr",
  "spinners",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -58,36 +58,36 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -109,9 +109,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
@@ -202,9 +202,9 @@ checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "byteorder"
@@ -220,18 +220,18 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.23"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -314,20 +314,20 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colored"
@@ -428,7 +428,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -439,7 +439,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -571,7 +571,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -630,7 +630,7 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -672,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
@@ -769,11 +769,10 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "futures-util",
  "http",
  "hyper",
  "hyper-util",
@@ -802,13 +801,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
+checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -1030,9 +1030,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libredox"
@@ -1058,9 +1058,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1092,9 +1092,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "mime"
@@ -1104,9 +1104,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
@@ -1119,19 +1119,19 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1221,10 +1221,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "openssl"
-version = "0.10.72"
+name = "once_cell_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
@@ -1243,7 +1249,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1254,9 +1260,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.108"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -1281,9 +1287,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1291,9 +1297,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1421,9 +1427,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -1491,9 +1497,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -1506,7 +1512,7 @@ checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1594,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustix"
@@ -1613,9 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.27"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -1646,9 +1652,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -1720,7 +1726,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1736,12 +1742,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_merge"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "606e91878516232ac3b16c12e063d4468d762f16d77e7aef14a1f2326c5f409b"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
 dependencies = [
  "itoa",
+ "serde",
+]
+
+[[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
  "serde",
 ]
 
@@ -1753,7 +1780,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1818,24 +1845,21 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1905,7 +1929,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1933,9 +1957,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1959,7 +1983,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2008,11 +2032,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2023,17 +2067,16 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -2071,6 +2114,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_merge",
+ "serde_regex",
  "serde_repr",
  "spinners",
  "strum 0.27.1",
@@ -2092,7 +2137,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 1.0.3",
+ "mio 1.0.4",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -2109,7 +2154,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2204,9 +2249,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
 ]
@@ -2309,9 +2354,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -2344,7 +2389,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
  "wasm-bindgen-shared",
 ]
 
@@ -2379,7 +2424,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2472,7 +2517,7 @@ dependencies = [
  "windows-interface 0.59.1",
  "windows-link",
  "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-strings",
 ]
 
 [[package]]
@@ -2483,7 +2528,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2494,7 +2539,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2505,7 +2550,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2516,24 +2561,24 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-registry"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
 dependencies = [
+ "windows-link",
  "windows-result 0.3.4",
- "windows-strings 0.3.1",
- "windows-targets 0.53.0",
+ "windows-strings",
 ]
 
 [[package]]
@@ -2550,15 +2595,6 @@ name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
  "windows-link",
 ]
@@ -2600,6 +2636,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2632,9 +2677,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
@@ -2825,28 +2870,28 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2866,7 +2911,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
  "synstructure",
 ]
 
@@ -2906,5 +2951,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ strum = { version = "0.27.1", features = ["strum_macros"] }
 strum_macros = "0.27.1"
 axum = "0.8.4"
 serde_regex = "1.1.0"
-serde_merge = "0.1.3"
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,21 +14,21 @@ categories = ["command-line-utilities"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde_json = "1"
-serde = { version = "1.0", features = ["derive"] }
-reqwest = { version = "0.12", features = ["json"] }
+serde_json = "1.0.140"
+serde = { version = "1.0.219", features = ["derive"] }
+reqwest = { version = "0.12.20", features = ["json"] }
 uuid = { version = "1.17", features = ["serde", "v4"] }
-dirs = "6"
+dirs = "6.0.0"
 matches = "0.1.10"
-regex = "1"
+regex = "1.11.1"
 chrono = "0.4.41"
 chrono-tz = "0.10.3"
-colored = "3"
+colored = "3.0.0"
 clap = { version = "4.5.40", features = ["derive"] }
 spinners = "4.1.1"
 inquire = { version = "0.7.5", features = ["date"] }
 serde_repr = "0.1.20"
-rand = "0.9"
+rand = "0.9.1"
 rayon = "1.10.0"
 pad = "0.1.6"
 urlencoding = "2.1.3"
@@ -43,6 +43,8 @@ once_cell = "1.21.3"
 strum = { version = "0.27.1", features = ["strum_macros"] }
 strum_macros = "0.27.1"
 axum = "0.8.4"
+serde_regex = "1.1.0"
+serde_merge = "0.1.3"
 
 
 [dev-dependencies]

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use crate::tasks::Task;
 use crate::time::{SystemTimeProvider, TimeProviderEnum};
 use crate::{VERSION, cargo, color, debug, input, oauth, time, todoist};
 use rand::distr::{Alphanumeric, SampleString};
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use terminal_size::{Height, Width, terminal_size};
@@ -33,7 +34,7 @@ pub struct Completed {
 
 /// App configuration, serialized as json in $XDG_CONFIG_HOME/tod.cfg
 #[derive(Clone, Serialize, Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
     /// The Todoist Api token
     pub token: Option<String>,
@@ -62,6 +63,9 @@ pub struct Config {
     pub task_complete_command: Option<String>,
     /// A command to run on task comment creation
     pub task_comment_command: Option<String>,
+    /// Regex to exclude tasks
+    #[serde(with = "serde_regex")]
+    pub task_exclude_regex: Option<Regex>,
     /// The timezone to use for the config
     timezone: Option<String>,
     pub timeout: Option<u64>,
@@ -75,8 +79,12 @@ pub struct Config {
     #[serde(default)]
     pub disable_links: bool,
     pub completed: Option<Completed>,
-    // Maximum length for printing comments
+    /// Maximum length for printing comments
     pub max_comment_length: Option<u32>,
+    /// Regex to exclude specific comments
+    #[serde(with = "serde_regex")]
+    pub comment_exclude_regex: Option<Regex>,
+
     pub verbose: Option<bool>,
     /// Don't ask for sections
     pub no_sections: Option<bool>,
@@ -104,7 +112,6 @@ pub struct Args {
     pub verbose: bool,
     pub timeout: Option<u64>,
 }
-
 #[derive(Default, Clone, Debug)]
 pub struct Internal {
     pub tx: Option<UnboundedSender<Error>>,
@@ -370,6 +377,8 @@ impl Config {
             mock_string: None,
             mock_select: None,
             max_comment_length: None,
+            comment_exclude_regex: None,
+            task_exclude_regex: None,
             verbose: None,
             internal: Internal { tx },
             args: Args {
@@ -522,8 +531,8 @@ fn config_load_error(error: serde_json::Error, path: &str) -> Error {
         "\n{}",
         color::red_string(&format!(
             "Error loading config file '{}':\n{}\n\
-                    \nYour config may contain an invalid value (e.g., a number over 255 in a `u8` field like `sort_value`).\n\
-                    Please manually fix or delete the file.",
+                    \nYour config contains an invalid value \n\
+                    Please run manually fix or run 'tod config reset' to delete the file.",
             path, error
         ))
     );
@@ -545,6 +554,8 @@ impl Default for Config {
             task_create_command: None,
             task_complete_command: None,
             task_comment_command: None,
+            task_exclude_regex: None,
+            comment_exclude_regex: None,
             sort_value: Some(SortValue::default()),
             timezone: None,
             completed: None,
@@ -576,44 +587,34 @@ pub async fn get_or_create(
     timeout: Option<u64>,
     tx: &UnboundedSender<Error>,
 ) -> Result<Config, Error> {
-    match get(config_path.clone(), verbose, timeout, tx).await {
-        Ok(config) => config.maybe_set_token().await,
-        Err(_) => {
-            // File not found or unreadable — prompt for token
-            create_config(tx).await?.maybe_set_token().await
-        }
-    }
-}
-//Fn to set token
-pub async fn create_config(tx: &UnboundedSender<Error>) -> Result<Config, Error> {
-    Config::new(Some(tx.clone())).await?.create().await
-}
-
-pub async fn get(
-    config_path: Option<String>,
-    verbose: bool,
-    timeout: Option<u64>,
-    tx: &UnboundedSender<Error>,
-) -> Result<Config, Error> {
-    let path: String = match config_path {
+    let path = match config_path {
         None => generate_path().await?,
         Some(path) => maybe_expand_home_dir(path)?,
     };
 
     let config = match fs::File::open(&path).await {
         Ok(_) => Config::load(&path).await,
-        Err(_) => Err(Error {
-            message: format!("Configuration file does not exist at {path}"),
-            source: "config.rs".to_string(),
-        }),
-    }
-    .map(|config| Config {
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            let tmp_config = Config::default();
+            debug::maybe_print(
+                &tmp_config,
+                "Config file not found, creating new config".to_string(),
+            );
+            create_config(tx).await
+        }
+        Err(err) => Err(Error::new(
+            "config.rs",
+            &format!("Failed to open config file: {err}"),
+        )),
+    }?;
+
+    let config = Config {
         args: Args { timeout, verbose },
         internal: Internal {
             tx: Some(tx.clone()),
         },
         ..config
-    })?;
+    };
 
     let redacted_config = Config {
         token: Some("REDACTED".into()),
@@ -622,8 +623,24 @@ pub async fn get(
     debug::maybe_print(&config, format!("{:#?}", redacted_config));
     Ok(config)
 }
-/// Generates the path to the config file
-///
+//Fn to create the config file with settings
+pub async fn create_config(tx: &UnboundedSender<Error>) -> Result<Config, Error> {
+    // Create the default in-memory config
+    let mut config = Config::new(Some(tx.clone())).await?;
+    // Create the empty file
+    config = config.create().await?;
+
+    // Populate the required fields - prompt for token, or use existing token logic
+    config = config.maybe_set_token().await?;
+
+    // Populate the required timezone
+    config = config.maybe_set_timezone().await?;
+
+    // Now that config is fully populated, write it to disk
+    config.save().await?;
+
+    Ok(config)
+}
 pub async fn generate_path() -> Result<String, Error> {
     let config_directory = dirs::config_dir()
         .ok_or_else(|| Error::new("dirs", "Could not find config directory"))?
@@ -685,6 +702,8 @@ mod tests {
                 task_create_command: None,
                 task_complete_command: None,
                 task_comment_command: None,
+                task_exclude_regex: None,
+                comment_exclude_regex: None,
 
                 timezone: Some("UTC".to_string()),
                 timeout: None,
@@ -848,7 +867,7 @@ mod tests {
 
         // --- GET_OR_CREATE (get) ---
 
-        let fetched_config = get(Some(config_loaded.path), false, None, &tx()).await;
+        let fetched_config = get_or_create(Some(config_loaded.path), false, None, &tx()).await;
         assert_matches!(fetched_config, Ok(Config { .. }));
         delete_config(&fetched_config.unwrap().path).await;
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1088,4 +1088,59 @@ mod tests {
         let err = result.unwrap_err().to_string();
         assert!(err.contains("unknown field `Bobby`"));
     }
+    #[tokio::test]
+    async fn test_create_config_saves_file() {
+        let mut config = Config::default_test(); // ✅ Uses mock_url, token, timezone, etc.
+        config = config.create().await.expect("Should create file");
+        config.save().await.expect("Should save file");
+
+        // Check that required fields are populated
+        assert!(config.token.is_some(), "Token should be set");
+        assert!(config.timezone.is_some(), "Timezone should be set");
+
+        // Check that the file exists
+        assert!(
+            tokio::fs::try_exists(&config.path).await.unwrap(),
+            "Config file should exist at {}",
+            config.path
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_path_in_test_mode() {
+        // Ensure test mode returns a path in the "tests/" directory
+        let path = generate_path().await.expect("Should return a test path");
+        assert!(
+            path.starts_with("tests/") && path.ends_with(".testcfg"),
+            "Test path should be generated, got {}",
+            path
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_config_populates_token_and_timezone() {
+        // Manually set token and timezone and ensure they're saved
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut config = Config::new(Some(tx.clone()))
+            .await
+            .expect("Init default config");
+
+        config.token = Some("test-token-123".into());
+        config.timezone = Some("UTC".into());
+        config = config.create().await.expect("Should create file");
+        config.save().await.expect("Should save config");
+
+        // Reload from disk and validate contents
+        let contents = tokio::fs::read_to_string(&config.path)
+            .await
+            .expect("File should exist");
+        assert!(
+            contents.contains("test-token-123"),
+            "Saved config should contain token"
+        );
+        assert!(
+            contents.contains("UTC"),
+            "Saved config should contain timezone"
+        );
+    }
 }

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -279,20 +279,27 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     #[tokio::test]
-    async fn test_import() {
+    // Test importing the import_tasks.txt file creates 14 tasks
+    /// This file is used to test the import functionality
+    async fn test_import_creates_14_tasks() {
         let mut server = mockito::Server::new_async().await;
+        // File to import and quantity specified here - expects 14 items
+        let import_file = "tests/inputs/import_tasks.txt";
+        let import_qty = 14;
+
+        // Expect 14 POSTs to /api/v1/tasks/quick
         let mock = server
             .mock("POST", "/api/v1/tasks/quick")
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(ResponseFromFile::TodayTask.read().await)
+            .expect(import_qty)
             .create_async()
             .await;
 
         let config = test::fixtures::config().await.with_mock_url(server.url());
-        config.clone().create().await.unwrap();
 
-        assert_eq!(import(&config, &config.path).await, Ok(String::from("✓")));
+        assert_eq!(import(&config, import_file).await, Ok(String::from("✓")));
 
         mock.assert();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1469,7 +1469,7 @@ async fn find_config(cli: &Cli, tx: &UnboundedSender<Error>) -> Result<Config, E
     let verbose = verbose.to_owned();
     let timeout = timeout.to_owned();
 
-    config::get(config_path, verbose, timeout, tx).await
+    config::get_or_create(config_path, verbose, timeout, tx).await
 }
 
 fn fetch_string(

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,8 @@ use tasks::{SortOrder, TaskAttribute, priority};
 use tokio::sync::mpsc::UnboundedSender;
 use walkdir::WalkDir;
 
+use crate::config::config_reset;
+
 mod cargo;
 mod color;
 mod comments;
@@ -555,7 +557,11 @@ struct ConfigCheckVersion {}
 struct TestAll {}
 
 #[derive(Parser, Debug, Clone)]
-struct ConfigReset {}
+struct ConfigReset {
+    /// Skip confirmation prompt and force deletion
+    #[arg(long)]
+    force: bool,
+}
 
 #[derive(Parser, Debug, Clone)]
 struct ConfigSetTimezone {
@@ -879,17 +885,14 @@ async fn select_command(
         Commands::Config(ConfigCommands::CheckVersion(args)) => {
             (true, true, config_check_version(args).await)
         }
-        Commands::Config(ConfigCommands::Reset(args)) => {
-            let config = match find_config(&cli, &tx).await {
-                Ok(config) => config,
-                Err(e) => return (true, true, Err(e)),
-            };
-            (
-                config.bell_on_success,
-                config.bell_on_failure,
-                config_reset(config, args).await,
-            )
-        }
+
+        // Command to delete the config file. Checks the default path, does not rely on the config struct.
+        Commands::Config(ConfigCommands::Reset(args)) => (
+            false,
+            false,
+            config_reset(cli.config.clone(), args.force).await,
+        ),
+
         Commands::Config(ConfigCommands::SetTimezone(args)) => {
             let config = match fetch_config(&cli, &tx).await {
                 Ok(config) => config,
@@ -1405,20 +1408,6 @@ async fn config_check_version(_args: &ConfigCheckVersion) -> Result<String, Erro
     }
 }
 
-async fn config_reset(config: Config, _args: &ConfigReset) -> Result<String, Error> {
-    use tokio::fs;
-
-    let path = config.path;
-
-    match fs::remove_file(path.clone()).await {
-        Ok(_) => Ok(format!("{path} deleted successfully")),
-        Err(e) => Err(Error::new(
-            "config_reset",
-            &format!("Could not delete config at path: {path}, {e}"),
-        )),
-    }
-}
-
 async fn tz_reset(config: Config, _args: &ConfigSetTimezone) -> Result<String, Error> {
     match config.set_timezone().await {
         Ok(updated_config) => {
@@ -1454,22 +1443,6 @@ async fn fetch_config(cli: &Cli, tx: &UnboundedSender<Error>) -> Result<Config, 
     tokio::spawn(async move { async_config.check_for_latest_version().await });
 
     config.maybe_set_timezone().await
-}
-
-/// Find config without creating
-async fn find_config(cli: &Cli, tx: &UnboundedSender<Error>) -> Result<Config, Error> {
-    let Cli {
-        verbose,
-        config: config_path,
-        timeout,
-        command: _,
-    } = cli;
-
-    let config_path = config_path.to_owned();
-    let verbose = verbose.to_owned();
-    let timeout = timeout.to_owned();
-
-    config::get_or_create(config_path, verbose, timeout, tx).await
 }
 
 fn fetch_string(

--- a/tests/inputs/import_tasks.txt
+++ b/tests/inputs/import_tasks.txt
@@ -1,0 +1,14 @@
+Email quarterly report to manager
+Buy groceries for dinner
+Call the dentist to reschedule appointment
+Plan weekend trip itinerary
+Review pull requests on GitHub
+Pay utility bills online
+Order birthday gift for Sarah
+Read one chapter of Rust book
+Clean out garage storage bins
+Refill prescription medication
+Backup photos to external drive
+Check in on project deadline with team
+Update LinkedIn profile summary
+Water the backyard garden


### PR DESCRIPTION
remove redundant config get, require all config (fail on invalid), add defaults, enforce valid values

# 📦 Pull Request

## Summary

This PR removes duplicate config creation functions, sets default values on the config using serde_default (if they don't exist - don't need to be created manually), and enforces values present in json (so it errors out if invalid values are present). 
It also removes the redundant `get()` config function, so everything is underneath the `get_or_create` which then calls `create` if the file doesn't exist.
It also adds `Regex` fields to the config:
```
   comment_exclude_regex: None,
            task_exclude_regex: None,
```
However, no additional code related to these is implemented yet and that will be added as a feature later.

Refactors config to remove duplicate get (now just a single get_or_create). 

Confirmed it no longer deletes config (goes straight into new config) if a file already exists - it only calls create if config does not exist.

Also corrects list_import test case which broke as some of this work and needed tob e updated to match code.

In addition, see comment on #1301 regarding function architecture going forward for errors :

## Type of Change

- [ ] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fixes)
- [ ] 📝 Docs (documentation only)
- [ ] 🎨 Style (formatting, missing semi colons, etc.)
- [x] ♻️ Refactor (non-breaking change, no new features)
- [ ] 🚨 Tests (adding or updating tests)
- [ ] 🔧 Chore (maintenance, tooling, or other misc items)

## Requirements

> Please confirm all items below before requesting a review:

- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format  
- [x] All CI checks pass  
- [x] Documentation was updated if necessary  
- [x] This PR is ready for **review**  

## Related Issues


See linked issues