### PR TITLE
chore: add build.rs and build profile and target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ terminal_size = "0.4.2"
 clap_complete = "4.5.54"
 walkdir = "2.5.0"
 once_cell = "1.21.3"
-strum = {version = "0.27.1", features = ["strum_macros"]}
+strum = { version = "0.27.1", features = ["strum_macros"] }
 strum_macros = "0.27.1"
 axum = "0.8.4"
 
@@ -48,3 +48,6 @@ axum = "0.8.4"
 [dev-dependencies]
 mockito = "1.7.0"
 pretty_assertions = "1.4.1"
+
+[build-dependencies]
+chrono = "0.4.41"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,18 @@
+//This file runs before the build process to set environment variables and perform other build-time tasks.
+// This file is part of the project and is executed by Cargo during the build process.
+// It sets environment variables that can be used in the Rust code, such as the build target, profile, and timestamp.
+
+use std::env;
+
+fn main() {
+    // Set TARGET and PROFILE as build-time env vars
+    let target = env::var("TARGET").unwrap_or_else(|_| "unknown".into());
+    let profile = env::var("PROFILE").unwrap_or_else(|_| "unknown".into());
+
+    println!("cargo:rustc-env=BUILD_TARGET={}", target);
+    println!("cargo:rustc-env=BUILD_PROFILE={}", profile);
+
+    // Add build timestamp
+    let timestamp = chrono::Utc::now().to_rfc3339();
+    println!("cargo:rustc-env=BUILD_TIMESTAMP={}", timestamp);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,6 @@ use errors::Error;
 use input::DateTimeInput;
 use lists::Flag;
 use shell::Shell;
-use std::env;
 use std::fmt::Display;
 use std::io::Write;
 use std::path::Path;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use errors::Error;
 use input::DateTimeInput;
 use lists::Flag;
 use shell::Shell;
+use std::env;
 use std::fmt::Display;
 use std::io::Write;
 use std::path::Path;
@@ -42,20 +43,31 @@ mod test_time;
 mod time;
 mod todoist;
 mod users;
-
-pub const NAME: &str = "Tod";
+// Values pulled from Cargo.toml
+const NAME: &str = env!("CARGO_PKG_NAME");
 const LOWERCASE_NAME: &str = "tod";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
-const AUTHOR: &str = "Alan Vardy <alan@vardy.cc>";
-const ABOUT: &str = "A tiny unofficial Todoist client";
-
+const LONG_VERSION: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    " (",
+    env!("BUILD_TARGET"),
+    "-",
+    env!("BUILD_PROFILE"),
+    ")"
+);
+const AUTHOR: &str = env!("CARGO_PKG_AUTHORS");
+const ABOUT: &str = env!("CARGO_PKG_DESCRIPTION");
+// Verbose values set at build time
+const BUILD_TARGET: &str = env!("BUILD_TARGET");
+const BUILD_PROFILE: &str = env!("BUILD_PROFILE");
+const BUILD_TIMESTAMP: &str = env!("BUILD_TIMESTAMP");
 const NO_PROJECTS_ERR: &str = "No projects in config. Add projects with `tod project import`";
 
 #[derive(Parser, Clone)]
 #[command(name = NAME)]
-#[command(version = VERSION)]
+#[command(author = AUTHOR)]
+#[command(version = LONG_VERSION)]
 #[command(about = ABOUT, long_about = None)]
-#[command(author = AUTHOR, version)]
 #[command(arg_required_else_help(true))]
 struct Cli {
     #[arg(short, long, default_value_t = false)]
@@ -1557,6 +1569,13 @@ async fn maybe_fetch_labels(config: &Config, labels: &[String]) -> Result<Vec<St
     } else {
         Ok(labels.to_vec())
     }
+}
+
+pub fn long_version() -> String {
+    format!(
+        "{} ({}, {}, {}, {})",
+        NAME, VERSION, BUILD_PROFILE, BUILD_TARGET, BUILD_TIMESTAMP
+    )
 }
 
 #[test]


### PR DESCRIPTION
adds build profile and target, and build.rs file that sets them upon compilation

also updates variables to pull automatically on build

# 📦 Pull Request

## Summary

>Adds target platform to -v output

## Type of Change

- [ ] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fixes)
- [ ] 📝 Docs (documentation only)
- [ ] 🎨 Style (formatting, missing semi colons, etc.)
- [ ] ♻️ Refactor (non-breaking change, no new features)
- [ ] 🚨 Tests (adding or updating tests)
- [x] 🔧 Chore (maintenance, tooling, or other misc items)

## Requirements

- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format  
- [x] All CI checks pass  
- [x] Documentation was updated if necessary  
- [x] This PR is ready for **review**  

## Related Issues

Fixes #1310  .  Didn't add timestamp because version/target is adequate for needs - could modify further down the road if we want to print more elsewhere or override clap -v
