### PR TITLE
chore: add commitlint config file

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -14,4 +14,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wagoid/commitlint-github-action@v6
-      
+        with:
+          configFile: config/commitlint.config.mjs

--- a/.github/workflows/config/commitlint.config.mjs
+++ b/.github/workflows/config/commitlint.config.mjs
@@ -1,0 +1,7 @@
+// commitlint.config.mjs
+export default {
+    extends: ['@commitlint/config-conventional'],
+    rules: {
+        'body-max-line-length': [2, 'always', 200], //Override the default body line length to 200 characters
+    },
+};


### PR DESCRIPTION
Expands commitlint line length limit from the default (100) to 200

(The dependabot PR was failing due to too long of a commit; I could just bypass commitlint from dependabot if needed but I think this is a good step to try first)