### PR TITLE
chore: readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,7 @@
 
 An unofficial Todoist CLI program. Takes simple input and dumps it in your inbox or another project. Takes advantage of natural language processing to assign due dates, tags, etc. Designed for single-tasking in a world filled with distraction.
 
-Get started with [Cargo](https://crates.io/crates/tod) (All Platforms)
-
-```bash
-cargo install tod
-```
-
-or [Homebrew](https://brew.sh) (macOS, Linux, WSL)
+Get started with [Homebrew](https://brew.sh) (macOS, Linux, WSL)
 
 ```bash
 brew tap alanvardy/tod
@@ -27,6 +21,12 @@ or [Scoop](https://scoop.sh/) (Windows)
 ```powershell
 scoop bucket add tod https://github.com/alanvardy/tod
 scoop install tod
+```
+
+or [Cargo](https://crates.io/crates/tod) (Rust Package Manager / All Platforms)
+
+```bash
+cargo install tod
 ```
 
 - [Installation](/docs/installation.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -57,4 +57,4 @@ cargo build --release
 
 You can then find the binary in `/target/release/`
 
-Will ask for your [Todoist API token](https://todoist.com/prefs/integrations) on the first run
+It will ask you to OAuth or provide your [Todoist API token](https://todoist.com/prefs/integrations) on the first run


### PR DESCRIPTION
prioritize homebrew/scoop for new users (doesn't require cargo/crates dependencies)

Simply updates the order in readme.