### PR TITLE
chore: update String to PathBuf

### DIFF
--- a/src/filters.rs
+++ b/src/filters.rs
@@ -181,11 +181,11 @@ mod tests {
 
         let config = test::fixtures::config().await.with_mock_url(server.url());
 
-        let config_dir = dirs::config_dir().unwrap().to_str().unwrap().to_owned();
+        let config_dir = dirs::config_dir().expect("Could not find config directory");
 
         let config_with_timezone = config
             .with_timezone("US/Pacific")
-            .with_path(format!("{config_dir}/test3"));
+            .with_path(config_dir.join("test3"));
 
         config_with_timezone.clone().create().await.unwrap();
 

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -556,11 +556,11 @@ mod tests {
 
         let config = test::fixtures::config().await.with_mock_url(server.url());
 
-        let config_dir = dirs::config_dir().unwrap().to_str().unwrap().to_owned();
+        let config_dir = dirs::config_dir().expect("Could not find config directory");
 
         let config_with_timezone = config
             .with_timezone("US/Pacific")
-            .with_path(format!("{config_dir}/test3"))
+            .with_path(config_dir.join("test3"))
             .with_mock_url(server.url())
             .mock_select(0);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use lists::Flag;
 use shell::Shell;
 use std::fmt::Display;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tasks::priority::Priority;
 use tasks::{SortOrder, TaskAttribute, priority};
 use tokio::sync::mpsc::UnboundedSender;
@@ -77,7 +77,7 @@ struct Cli {
 
     #[arg(short, long)]
     /// Absolute path of configuration. Defaults to $XDG_CONFIG_HOME/tod.cfg
-    config: Option<String>,
+    config: Option<PathBuf>,
 
     #[arg(short, long)]
     /// Time to wait for a response from API in seconds. Defaults to 30.

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -607,11 +607,11 @@ mod tests {
 
         let config = test::fixtures::config().await.with_mock_url(server.url());
 
-        let config_dir = dirs::config_dir().unwrap().to_str().unwrap().to_owned();
+        let config_dir = dirs::config_dir().expect("Could not find config directory");
 
         let config_with_timezone = config
             .with_timezone("America/Vancouver")
-            .with_path(format!("{config_dir}/test2"))
+            .with_path(config_dir.join("test3"))
             .with_mock_url(server.url());
         let binding = config_with_timezone.projects().await.unwrap();
         let project = binding.first().unwrap();


### PR DESCRIPTION
Updates path to use PathBuf instead of String for all config path-related functions (including generate config and test config.

# 📦 Pull Request

## Summary

> Updates path to use PathBuf instead of String for all config path-related functions (including generate config and test config.

## PR Checklist

> Please confirm all items below before requesting a review (required for approval)

- [ ] This PR/commit messages follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] All CI checks pass
- [ ] Documentation is updated if necessary
- [ ] This PR is tagged with any appropriate tags
- [ ] This PR is ready for **review**  

Important note:

- All CI Checks must pass before PR is committed.
- All PRs must be reviewed before PR is committed.
- Only rebasing is allowed. Any merge commits in the chain will block PR from being commited.

## Related Issues

> Closees #1316

