### PR TITLE
feat: add installation method detection & auto-update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "tod"
-version = "0.9.1"
+version = "0.9.0"
 dependencies = [
  "assert_cmd",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,23 +282,12 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efdce149c370f133a071ca8ef6ea340b7b88748ab0810097a9e2976eaa34b4f3"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
- "chrono-tz-build",
  "phf",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f10f8c9340e31fc120ff885fcdb54a0b48e474bbd77cab557f0c30a3e569402"
-dependencies = [
- "parse-zoneinfo",
- "phf_codegen",
 ]
 
 [[package]]
@@ -1228,7 +1217,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand 0.9.1",
+ "rand",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -1404,15 +1393,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-zoneinfo"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
-dependencies = [
- "regex",
-]
-
-[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1426,38 +1406,18 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
  "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand 0.8.5",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
@@ -1564,21 +1524,12 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha",
- "rand_core 0.9.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -1588,14 +1539,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -2217,7 +2162,7 @@ dependencies = [
  "pad",
  "predicates",
  "pretty_assertions",
- "rand 0.9.1",
+ "rand",
  "rayon",
  "regex",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "tod"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "assert_cmd",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ dirs = "6.0.0"
 matches = "0.1.10"
 regex = "1.11.1"
 chrono = "0.4.41"
-chrono-tz = "0.10.3"
+chrono-tz = "0.10.4"
 colored = "3.0.0"
 clap = { version = "4.5.41", features = ["derive"] }
 spinners = "4.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tod"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Alan Vardy <alan@vardy.cc>"]
 edition = "2024"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tod"
-version = "0.9.1"
+version = "0.9.0"
 authors = ["Alan Vardy <alan@vardy.cc>"]
 edition = "2024"
 license = "MIT"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,7 +6,7 @@
   - [Usage Examples](#usage-examples)
   - [Shell script examples](#shell-script-examples)
     - [Sort, schedule, prioritize, and process tasks](#sort-schedule-prioritize-and-process-tasks)
-  - [Update Tod only if it is out of date](#update-tod-only-if-it-is-out-of-date)
+  - [Update Tod](#update-tod)
   - [How task priority is determined](#how-task-priority-is-determined)
 <!--toc:end-->
 
@@ -148,8 +148,16 @@ tod list label --filter "no label" --label physical --label digital
 
 See [Sort_value](https://github.com/alanvardy/tod/blob/main/docs/configuration.md#sort_value)
 
-## Update Tod only if it is out of date
+## Update Tod
 
 ```bash
-tod config check-version || cargo install tod --force
+tod config check-version
 ```
+
+## Update Tod (no prompt)
+
+```bash
+tod config check-version --force 
+```
+
+Tod will attempt to detect the installed method (homebrew, cargo, scoop, etc) and auto-update if possible.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1307,6 +1307,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_config_reset_delete_y_input() {
+        // Setup temp config file
+        let dir = temp_dir();
+        let temp_path: PathBuf = dir.join("temp_test_config_prompt_yes.cfg");
+
+        File::create(&temp_path).expect("Failed to create temp config file");
+        assert!(temp_path.exists(), "Temp config should exist before reset");
+
+        // Simulate user saying "yes" to prompt
+        let result = config_reset_with_prompt(Some(temp_path.clone()), false, || true).await;
+
+        assert!(result.is_ok(), "Expected Ok, got {result:?}");
+        assert!(
+            result.unwrap().contains("deleted successfully"),
+            "Expected deletion message"
+        );
+        assert!(
+            !Path::new(&temp_path).exists(),
+            "File should be deleted after reset"
+        );
+    }
+
+    #[tokio::test]
     async fn test_config_reset_aborts_on_n_input() {
         // Setup temp config file
         let dir = temp_dir();

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,4 +1,4 @@
-//File for shell functions used local to the system, such as command exeution, shell completions.
+//File for shell functions used local to the system, such as command execution, shell completions.
 use crate::{Cli, LOWERCASE_NAME};
 use clap::CommandFactory;
 use std::{io, process::Stdio};

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,4 +1,4 @@
-//File for shell functions used local to the system, such as command exeution and shell completions
+//File for shell functions used local to the system, such as command exeution, shell completions.
 use crate::{Cli, LOWERCASE_NAME};
 use clap::CommandFactory;
 use std::{io, process::Stdio};

--- a/src/test/responses.rs
+++ b/src/test/responses.rs
@@ -45,8 +45,20 @@ impl ResponseFromFile {
         self.replace_values(json).await
     }
 
-    /// Allows us to replace static values in JSON with dynamic data i.e. today's date. Specify a vector with the from and to values.
-    /// Use an empty vector to make no changes
+    /// Loads JSON and replaces INSERTVERSION with a custom version string
+    pub async fn read_with_version(&self, version: &str) -> String {
+        let path = format!("tests/responses/{self}.json");
+
+        let json = std::fs::read_to_string(&path)
+            .unwrap_or_else(|_| panic!("Could not find json file at {path}"));
+
+        match self {
+            Self::Versions => json.replace("INSERTVERSION", version),
+            _ => self.replace_values(json).await,
+        }
+    }
+
+    /// Allows us to replace static values in JSON with dynamic data
     async fn replace_values(&self, json_string: String) -> String {
         let replace_with: Vec<(&str, String)> = match self {
             Self::AccessToken => Vec::new(),

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,8 +1,8 @@
 // Thils file contains the functions used for checking for updates and automatically updating the tod CLI tool.
 // Functions that attempt to detect the installation method of the current executable, used for autoupdate and debug
-use std::env;
+use std::{env, process::Command};
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum InstallMethod {
     Homebrew,
     Scoop,
@@ -13,12 +13,16 @@ pub enum InstallMethod {
 
 // Public API: returns the detected or overridden install method if manually specified
 pub fn get_install_method(override_arg: &Option<String>) -> InstallMethod {
-    match override_arg.as_deref() {
-        Some("cargo") => InstallMethod::Cargo,
-        Some("scoop") => InstallMethod::Scoop,
-        Some("homebrew") => InstallMethod::Homebrew,
-        Some("source") => InstallMethod::FromSource,
-        _ => detect_install_method(),
+    if let Some(value) = override_arg {
+        match value.trim().to_lowercase().as_str() {
+            "cargo" => InstallMethod::Cargo,
+            "scoop" => InstallMethod::Scoop,
+            "homebrew" => InstallMethod::Homebrew,
+            "source" | "fromsource" => InstallMethod::FromSource,
+            _ => InstallMethod::Unknown,
+        }
+    } else {
+        detect_install_method()
     }
 }
 
@@ -57,17 +61,245 @@ pub fn get_install_method_string(override_arg: &Option<String>) -> &'static str 
     }
 }
 // Public API: returns the upgrade instruction
-pub fn get_upgrade_command(override_arg: &Option<String>) -> &'static str {
+pub fn get_update_command_args(
+    override_arg: &Option<String>,
+) -> Result<(&'static str, Vec<&'static str>), String> {
     match get_install_method(override_arg) {
-        InstallMethod::Homebrew => "brew upgrade tod",
-        InstallMethod::Scoop => "scoop update tod",
-        InstallMethod::Cargo => "cargo install tod --force",
-        InstallMethod::FromSource | InstallMethod::Unknown => "https://tod.cx",
+        InstallMethod::Homebrew => Ok(("brew", vec!["upgrade", "tod"])),
+        InstallMethod::Scoop => Ok(("scoop", vec!["update", "tod"])),
+        InstallMethod::Cargo => Ok(("cargo", vec!["install", "tod", "--force"])),
+        InstallMethod::FromSource | InstallMethod::Unknown => {
+            let url = "https://github.com/alanvardy/tod#installation";
+            Err(format!(
+                "Automatic update is not supported for this installation method.\nPlease visit: {url}"
+            ))
+        }
+    }
+}
+pub fn perform_auto_update(override_arg: &Option<String>) -> Result<(), String> {
+    let cmd = get_update_command_args(override_arg)?;
+    let command_str = format!("{} {}", cmd.0, cmd.1.join(" "));
+    println!("Executing command.... {command_str}");
+
+    let status = Command::new(cmd.0)
+        .args(&cmd.1)
+        .status()
+        .map_err(|e| format!("Failed to execute '{}': {}", cmd.0, e))?;
+
+    if status.success() {
+        println!("Upgraded successfully!");
+        Ok(())
+    } else {
+        let upgrade_cmd = get_upgrade_command(override_arg);
+        Err(format!(
+            "Automatic update failed. Please run '{upgrade_cmd}' manually."
+        ))
     }
 }
 
-pub fn perform_auto_update() -> Result<(), String> {
-    // This is where actual update logic will go later
-    println!("Auto-updating (placeholder)...");
-    Ok(())
+// Returns the upgrade command as a string for manual use
+pub fn get_upgrade_command(override_arg: &Option<String>) -> String {
+    match get_install_method(override_arg) {
+        InstallMethod::Homebrew => "brew upgrade tod".to_string(),
+        InstallMethod::Scoop => "scoop update tod".to_string(),
+        InstallMethod::Cargo => "cargo install tod --force".to_string(),
+        InstallMethod::FromSource | InstallMethod::Unknown => {
+            "https://github.com/alanvardy/tod#installation".to_string()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{ConfigCheckVersion, config_check_version, test::responses::ResponseFromFile};
+
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_get_install_method_override() {
+        assert_eq!(
+            get_install_method(&Some("cargo".into())),
+            InstallMethod::Cargo
+        );
+        assert_eq!(
+            get_install_method(&Some("scoop".into())),
+            InstallMethod::Scoop
+        );
+        assert_eq!(
+            get_install_method(&Some("homebrew".into())),
+            InstallMethod::Homebrew
+        );
+        assert_eq!(
+            get_install_method(&Some("source".into())),
+            InstallMethod::FromSource
+        );
+        assert_eq!(
+            get_install_method(&Some("unknown".into())),
+            InstallMethod::Unknown
+        );
+        assert_eq!(get_install_method(&None), detect_install_method());
+    }
+
+    #[test]
+    fn test_get_install_method_string() {
+        assert_eq!(get_install_method_string(&Some("cargo".into())), "cargo");
+        assert_eq!(get_install_method_string(&Some("scoop".into())), "scoop");
+        assert_eq!(
+            get_install_method_string(&Some("homebrew".into())),
+            "homebrew"
+        );
+        assert_eq!(
+            get_install_method_string(&Some("source".into())),
+            "from source"
+        );
+        assert_eq!(
+            get_install_method_string(&Some("unknown".into())),
+            "unknown"
+        );
+    }
+
+    #[test]
+    fn test_get_upgrade_command() {
+        assert_eq!(
+            get_upgrade_command(&Some("cargo".into())),
+            "cargo install tod --force"
+        );
+        assert_eq!(
+            get_upgrade_command(&Some("scoop".into())),
+            "scoop update tod"
+        );
+        assert_eq!(
+            get_upgrade_command(&Some("homebrew".into())),
+            "brew upgrade tod"
+        );
+        assert_eq!(
+            get_upgrade_command(&Some("source".into())),
+            "https://github.com/alanvardy/tod#installation"
+        );
+        assert_eq!(
+            get_upgrade_command(&Some("unknown".into())),
+            "https://github.com/alanvardy/tod#installation"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_config_check_version_outdated() {
+        use mockito::Server;
+
+        // Start mock server
+        let mut server = Server::new_async().await;
+
+        // Mock the crates.io versions endpoint
+        let mock = server
+            .mock("GET", "/v1/crates/tod/versions")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                ResponseFromFile::Versions
+                    .read_with_version("999.99.999")
+                    .await,
+            )
+            .create_async()
+            .await;
+
+        let args = ConfigCheckVersion {
+            force: true,
+            repo: None,
+        };
+
+        // Run the version check
+        let response = config_check_version(&args, Some(server.url()))
+            .await
+            .expect("Expected version check to succeed");
+
+        // Print full output for debugging if test fails
+        println!("DEBUG: Version check output:\n{response}");
+
+        // Assertions — robust against changing installed version
+        assert!(
+            response.contains("Tod is out of date"),
+            "Missing 'Tod is out of date' message"
+        );
+        assert!(
+            response.contains("Installed version:"),
+            "Missing installed version line"
+        );
+        assert!(
+            response.contains("Latest version: 999.99.999"),
+            "Missing latest version string"
+        );
+        assert!(
+            response.contains("Detected installation method:"),
+            "Missing installation method detection"
+        );
+        assert!(
+            response.contains("Auto-update failed:"),
+            "Missing auto-update failure notice"
+        );
+        assert!(
+            response.contains("https://github.com/alanvardy/tod#installation"),
+            "Missing manual update link"
+        );
+
+        // Ensure the mock was actually called
+        mock.assert();
+    }
+
+    #[test]
+    fn test_get_update_command_args_homebrew() {
+        let cmd = get_update_command_args(&Some("homebrew".into())).unwrap();
+        assert_eq!(cmd.0, "brew");
+        assert_eq!(cmd.1, vec!["upgrade", "tod"]);
+    }
+
+    #[test]
+    fn test_get_update_command_args_scoop() {
+        let cmd = get_update_command_args(&Some("scoop".into())).unwrap();
+        assert_eq!(cmd.0, "scoop");
+        assert_eq!(cmd.1, vec!["update", "tod"]);
+    }
+
+    #[test]
+    fn test_get_update_command_args_cargo() {
+        let cmd = get_update_command_args(&Some("cargo".into())).unwrap();
+        assert_eq!(cmd.0, "cargo");
+        assert_eq!(cmd.1, vec!["install", "tod", "--force"]);
+    }
+
+    #[test]
+    fn test_get_update_command_args_from_source() {
+        let err = get_update_command_args(&Some("source".into())).unwrap_err();
+        assert!(err.contains("Automatic update is not supported"));
+    }
+
+    #[test]
+    fn test_get_update_command_args_unknown() {
+        let err = get_update_command_args(&Some("unknown".into())).unwrap_err();
+        assert!(err.contains("Automatic update is not supported"));
+    }
+    #[test]
+    fn test_get_install_method_override_whitespace_case() {
+        assert_eq!(
+            get_install_method(&Some("  CaRgO  ".into())),
+            InstallMethod::Cargo
+        );
+    }
+    #[test]
+    fn test_get_install_method_override_random() {
+        assert_eq!(
+            get_install_method(&Some("foobar".into())),
+            InstallMethod::Unknown
+        );
+    }
+    #[test]
+    fn test_get_update_command_args_none() {
+        let result = get_update_command_args(&None);
+        assert!(
+            result.is_ok()
+                || result
+                    .unwrap_err()
+                    .contains("Automatic update is not supported")
+        );
+    }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,73 @@
+// Thils file contains the functions used for checking for updates and automatically updating the tod CLI tool.
+// Functions that attempt to detect the installation method of the current executable, used for autoupdate and debug
+use std::env;
+
+#[derive(Debug)]
+pub enum InstallMethod {
+    Homebrew,
+    Scoop,
+    Cargo,
+    FromSource,
+    Unknown,
+}
+
+// Public API: returns the detected or overridden install method if manually specified
+pub fn get_install_method(override_arg: &Option<String>) -> InstallMethod {
+    match override_arg.as_deref() {
+        Some("cargo") => InstallMethod::Cargo,
+        Some("scoop") => InstallMethod::Scoop,
+        Some("homebrew") => InstallMethod::Homebrew,
+        Some("source") => InstallMethod::FromSource,
+        _ => detect_install_method(),
+    }
+}
+
+fn detect_install_method() -> InstallMethod {
+    let path = match env::current_exe() {
+        Ok(p) => p,
+        Err(_) => return InstallMethod::Unknown,
+    };
+
+    let components: Vec<_> = path
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy().to_lowercase())
+        .collect();
+
+    if cfg!(debug_assertions) || components.iter().any(|c| c == "target") {
+        InstallMethod::FromSource
+    } else if components.iter().any(|c| c.contains(".cargo")) {
+        InstallMethod::Cargo
+    } else if components.iter().any(|c| c.contains("scoop")) {
+        InstallMethod::Scoop
+    } else if components.iter().any(|c| c.contains("homebrew")) {
+        InstallMethod::Homebrew
+    } else {
+        InstallMethod::Unknown
+    }
+}
+
+// Public API: returns the string name of how it was installed
+pub fn get_install_method_string(override_arg: &Option<String>) -> &'static str {
+    match get_install_method(override_arg) {
+        InstallMethod::Homebrew => "homebrew",
+        InstallMethod::Scoop => "scoop",
+        InstallMethod::Cargo => "cargo",
+        InstallMethod::FromSource => "from source",
+        InstallMethod::Unknown => "unknown",
+    }
+}
+// Public API: returns the upgrade instruction
+pub fn get_upgrade_command(override_arg: &Option<String>) -> &'static str {
+    match get_install_method(override_arg) {
+        InstallMethod::Homebrew => "brew upgrade tod",
+        InstallMethod::Scoop => "scoop update tod",
+        InstallMethod::Cargo => "cargo install tod --force",
+        InstallMethod::FromSource | InstallMethod::Unknown => "https://tod.cx",
+    }
+}
+
+pub fn perform_auto_update() -> Result<(), String> {
+    // This is where actual update logic will go later
+    println!("Auto-updating (placeholder)...");
+    Ok(())
+}

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,4 +1,4 @@
-// Thils file contains the functions used for checking for updates and automatically updating the tod CLI tool.
+// This file contains the functions used for checking for updates and automatically updating the tod CLI tool.
 // Functions that attempt to detect the installation method of the current executable, used for autoupdate and debug
 use std::{env, process::Command};
 


### PR DESCRIPTION
# 📦 Pull Request

## Summary

Adds auto-update including installation method detection (best effort, based on executable location) and prints installation version method.

Also updates y/n in Config Reset to use inquire::Confirm (crate already present) for consistency in methods.

fix auto-update to include installation method detection and print version update.

chore: updates y/n to use inquire::Confirm (crate already present) instead of readBuf for consistency

docs: updates docs to detail usage of self-update

tests: adds test cases using -f (force) for selfupdate with mocked future version.

## PR Checklist

> Please confirm all items below before requesting a review (required for approval)

- [x] This PR/commit messages follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] All CI checks pass
- [x] Documentation is updated if necessary
- [x] This PR is tagged with any appropriate tags
- [x] This PR is ready for **review**  

Important note:

- All CI Checks must pass before PR is committed.
- All PRs must be reviewed before PR is committed.
- Only rebasing is allowed. Any merge commits in the chain will block PR from being commited.

## Related Issues

Closes #1385 and #1381 
