### PR TITLE
feat: automatically open web browser when performing Oauth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,6 +1060,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,6 +1311,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "open"
+version = "5.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2483562e62ea94312f3576a7aca397306df7990b8d89033e18766744377ef95"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,6 +1411,12 @@ checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
 dependencies = [
  "regex",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -2177,6 +2213,7 @@ dependencies = [
  "matches",
  "mockito",
  "once_cell",
+ "open",
  "pad",
  "predicates",
  "pretty_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1803,6 +1803,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22b2d775fb28f245817589471dd49c5edf64237f4a19d10ce9a92ff4651a27f4"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1816,6 +1825,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 
 [[package]]
 name = "security-framework"
@@ -1913,6 +1928,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2225,6 +2265,7 @@ dependencies = [
  "serde_json",
  "serde_regex",
  "serde_repr",
+ "serial_test",
  "spinners",
  "strum 0.27.1",
  "strum_macros 0.27.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1803,15 +1803,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b2d775fb28f245817589471dd49c5edf64237f4a19d10ce9a92ff4651a27f4"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,12 +1816,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "3.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 
 [[package]]
 name = "security-framework"
@@ -1928,31 +1913,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serial_test"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
-dependencies = [
- "futures",
- "log",
- "once_cell",
- "parking_lot",
- "scc",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.103",
 ]
 
 [[package]]
@@ -2265,7 +2225,6 @@ dependencies = [
  "serde_json",
  "serde_regex",
  "serde_repr",
- "serial_test",
  "spinners",
  "strum 0.27.1",
  "strum_macros 0.27.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ assert_cmd = "2.0.17"
 mockito = "1.7.0"
 predicates = "3.1.3"
 pretty_assertions = "1.4.1"
-serial_test = "3.2.0"
 
 [build-dependencies]
 chrono = "0.4.41"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ assert_cmd = "2.0.17"
 mockito = "1.7.0"
 predicates = "3.1.3"
 pretty_assertions = "1.4.1"
+serial_test = "3.2.0"
 
 [build-dependencies]
 chrono = "0.4.41"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ strum = { version = "0.27.1", features = ["strum_macros"] }
 strum_macros = "0.27.1"
 axum = "0.8.4"
 serde_regex = "1.1.0"
+open = "5.3.2"
 
 
 [dev-dependencies]

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use crate::id::Resource;
 use crate::input::page_size;
 use crate::projects::{LegacyProject, Project};
 use crate::tasks::Task;
-use crate::tasks::format::format_url;
+use crate::tasks::format::maybe_format_url;
 use crate::time::{SystemTimeProvider, TimeProviderEnum};
 use crate::{VERSION, cargo, color, debug, input, oauth, time, todoist};
 use rand::distr::{Alphanumeric, SampleString};
@@ -524,7 +524,7 @@ impl Config {
                     config
                 }
                 DEVELOPER => {
-                    let url = format_url("https://todoist.com/prefs/integrations", &self);
+                    let url = maybe_format_url("https://todoist.com/prefs/integrations", &self);
                     let desc = format!("Please enter your Todoist API token from {url} ");
 
                     // We can't use mock_string from config here because it can't be set in test.

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use crate::id::Resource;
 use crate::input::page_size;
 use crate::projects::{LegacyProject, Project};
 use crate::tasks::Task;
+use crate::tasks::format::format_url;
 use crate::time::{SystemTimeProvider, TimeProviderEnum};
 use crate::{VERSION, cargo, color, debug, input, oauth, time, todoist};
 use rand::distr::{Alphanumeric, SampleString};
@@ -523,11 +524,12 @@ impl Config {
                     config
                 }
                 DEVELOPER => {
-                    let desc = "Please enter your Todoist API token from https://todoist.com/prefs/integrations ";
+                    let url = format_url("https://todoist.com/prefs/integrations", &self);
+                    let desc = format!("Please enter your Todoist API token from {url} ");
 
                     // We can't use mock_string from config here because it can't be set in test.
                     let fake_token = Some("faketoken".into());
-                    let token = input::string(desc, fake_token)?;
+                    let token = input::string(&desc, fake_token)?;
                     self.with_token(&token)
                 }
                 _ => unreachable!(),

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -36,7 +36,8 @@ pub struct AccessToken {
 }
 
 pub async fn login(config: &mut Config, test_tx: Option<Sender<()>>) -> Result<String, Error> {
-    let csrf_token = print_oauth_url();
+    // Use the provided config, not a new default every time
+    let csrf_token = print_oauth_url(config);
     let listener = tokio::net::TcpListener::bind(PROD_LOCALHOST).await?;
     let code = receive_callback(&csrf_token, test_tx, listener)
         .await?

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -36,8 +36,7 @@ pub struct AccessToken {
 }
 
 pub async fn login(config: &mut Config, test_tx: Option<Sender<()>>) -> Result<String, Error> {
-    // Use the provided config, not a new default every time
-    let csrf_token = print_oauth_url(config);
+    let csrf_token = print_oauth_url();
     let listener = tokio::net::TcpListener::bind(PROD_LOCALHOST).await?;
     let code = receive_callback(&csrf_token, test_tx, listener)
         .await?
@@ -154,11 +153,8 @@ mod tests {
     use super::*;
     use crate::test::{self, responses::ResponseFromFile};
     use pretty_assertions::assert_eq;
-    use serial_test::serial;
 
-    // Oauth tests must be run serially to avoid conflicts/failures with the mock server
     #[tokio::test]
-    #[serial]
     async fn login_test() {
         let mut server = mockito::Server::new_async().await;
 
@@ -198,7 +194,6 @@ mod tests {
         assert_eq!(result, String::from("✓"));
         mock.assert()
     }
-    #[serial]
     #[tokio::test]
     async fn receive_callback_with_error_param() {
         let (test_tx, test_rx) = oneshot::channel::<()>();

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -194,6 +194,7 @@ mod tests {
         assert_eq!(result, String::from("✓"));
         mock.assert()
     }
+
     #[tokio::test]
     async fn receive_callback_with_error_param() {
         let (test_tx, test_rx) = oneshot::channel::<()>();

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -16,7 +16,7 @@ pub const CLIENT_ID: &str = "2696d64dc4f745679e21181c56b489fe";
 pub const CLIENT_SECRET: &str = "bfde0d10e3d740beb47f95879881634e";
 const FAKE_UUID: &str = "42963283-2bab-4b1f-bad2-278ef2b6ba2c";
 const TRANSMIT_ERROR: &str = "Could not transmit";
-// Host to bind the OAuth server to in production.
+/// Host to bind the OAuth server to in production.
 const PROD_LOCALHOST: &str = "127.0.0.1:8080";
 const SCOPE: &str = "data:read_write,data:delete,project:delete";
 

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 
 use crate::color::green_string;
 use crate::errors::Error;
-use crate::tasks::format::format_url;
+use crate::tasks::format::maybe_format_url;
 use crate::todoist::OAUTH_URL;
 use crate::{config::Config, todoist};
 
@@ -58,7 +58,7 @@ fn print_oauth_url() -> String {
     let url = format!(
         "https://todoist.com{OAUTH_URL}?client_id={CLIENT_ID}&scope={SCOPE}&state={csrf_token}"
     );
-    let formatted_url = format_url(&url, &Config::default());
+    let formatted_url = maybe_format_url(&url, &Config::default());
     // Don't open the browser in test mode, just print the URL
     if cfg!(test) {
         println!("Please visit the following url to authenticate with Todoist:");
@@ -193,6 +193,7 @@ mod tests {
         assert_eq!(result, String::from("✓"));
         mock.assert()
     }
+
     #[tokio::test]
     async fn receive_callback_with_error_param() {
         let (test_tx, test_rx) = oneshot::channel::<()>();
@@ -276,7 +277,7 @@ mod tests {
         let url = format!(
             "https://todoist.com{OAUTH_URL}?client_id={CLIENT_ID}&scope={SCOPE}&state={FAKE_UUID}"
         );
-        let formatted_url = format_url(&url, &Config::default());
+        let formatted_url = maybe_format_url(&url, &Config::default());
         assert!(formatted_url.contains(&expected_url_part));
     }
 }

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -154,8 +154,11 @@ mod tests {
     use super::*;
     use crate::test::{self, responses::ResponseFromFile};
     use pretty_assertions::assert_eq;
+    use serial_test::serial;
 
+    // Oauth tests must be run serially to avoid conflicts/failures with the mock server
     #[tokio::test]
+    #[serial]
     async fn login_test() {
         let mut server = mockito::Server::new_async().await;
 
@@ -195,7 +198,7 @@ mod tests {
         assert_eq!(result, String::from("✓"));
         mock.assert()
     }
-
+    #[serial]
     #[tokio::test]
     async fn receive_callback_with_error_param() {
         let (test_tx, test_rx) = oneshot::channel::<()>();

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -211,12 +211,8 @@ impl Task {
         } else {
             String::new()
         };
-
-        let url = if format::hyperlinks_disabled(config) {
-            String::new()
-        } else {
-            format::task_url(&self.id)
-        };
+        // Format_task_id returns the same format if urls are disabled
+        let url = format::maybe_format_task_id(&self.id, config);
 
         let due = format::due(self, config, &buffer);
         let prefix = match format {

--- a/src/tasks/format.rs
+++ b/src/tasks/format.rs
@@ -123,7 +123,7 @@ pub fn format_url(url: &str, config: &Config) -> String {
     if hyperlinks_disabled(config) {
         return url.to_string();
     }
-    format!("\x1B]8;;{url}\x1B\\{url}\x1B]8;;\x1B\\")
+    format!("\x1B]8;;{url}\x1B\\[{url}]\x1B]8;;\x1B\\")
 }
 pub fn number_comments(quantity: usize) -> String {
     let comment_icon = color::purple_string("★");
@@ -236,12 +236,17 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_format_url_hyperlinks_enabled() {
+    #[tokio::test]
+    async fn test_format_url_hyperlinks_enabled() {
         let url = "https://www.rust-lang.org/";
         let expected =
             "\x1B]8;;https://www.rust-lang.org/\x1B\\[https://www.rust-lang.org/]\x1B]8;;\x1B\\";
         let config = Config::default();
+        // Skip the test if hyperlinks are not supported in the current environment (otherwise test fails)
+        if !supports_hyperlinks::on(Stream::Stdout) {
+            eprintln!("Skipping test: hyperlinks not supported in this environment");
+            return;
+        }
         assert_eq!(format_url(url, &config), expected);
     }
     #[test]

--- a/src/tasks/format.rs
+++ b/src/tasks/format.rs
@@ -103,7 +103,7 @@ pub fn due(task: &Task, config: &Config, buffer: &str) -> String {
     }
 }
 
-/// Formats a string for all style/formatted links (including markdown) and formats them as a hyperlink
+// Formats a string for all style/formatted links (including markdown) and formats them as a hyperlink
 fn create_links(content: &str) -> String {
     // Define the regex pattern for Markdown links
     let link_regex = Regex::new(r"\[([^\]]+)\]\(([^)]+)\)").unwrap();

--- a/src/tasks/format.rs
+++ b/src/tasks/format.rs
@@ -103,7 +103,7 @@ pub fn due(task: &Task, config: &Config, buffer: &str) -> String {
     }
 }
 
-/// Formats a string for all style/formatted links (including markdown) and formats them as a hyperlink
+//Formats a string for all style/formatted links (including markdown) and formats them as a hyperlink
 fn create_links(content: &str) -> String {
     // Define the regex pattern for Markdown links
     let link_regex = Regex::new(r"\[([^\]]+)\]\(([^)]+)\)").unwrap();

--- a/src/tasks/format.rs
+++ b/src/tasks/format.rs
@@ -139,7 +139,7 @@ pub fn maybe_format_task_id(task_id: &str, config: &Config) -> String {
     if hyperlinks_disabled(config) {
         url
     } else {
-        format!("\x1B]8;;{url}\x1B\\[link]\x1B]8;;\x1B\\")
+        format!("\x1B]8;;{url}\x07[link]\x1B]8;;\x07")
     }
 }
 

--- a/src/tasks/format.rs
+++ b/src/tasks/format.rs
@@ -103,7 +103,7 @@ pub fn due(task: &Task, config: &Config, buffer: &str) -> String {
     }
 }
 
-//Formats a string for all style/formatted links (including markdown) and formats them as a hyperlink
+/// Formats a string for all style/formatted links (including markdown) and formats them as a hyperlink
 fn create_links(content: &str) -> String {
     // Define the regex pattern for Markdown links
     let link_regex = Regex::new(r"\[([^\]]+)\]\(([^)]+)\)").unwrap();
@@ -118,7 +118,7 @@ fn create_links(content: &str) -> String {
     result.into_owned()
 }
 
-/// Formats a single URL as a hyperlinked URL (with the URL as the Hyperlink), if hyperlinks are enabled in the config - If hyperlinks are disabled, it returns the same URL as a plain string.
+// Formats a single URL as a hyperlinked URL (with the URL as the Hyperlink), if hyperlinks are enabled in the config - If hyperlinks are disabled, it returns the same URL as a plain string.
 pub fn maybe_format_url(url: &str, config: &Config) -> String {
     if hyperlinks_disabled(config) {
         return url.to_string();

--- a/src/tasks/format.rs
+++ b/src/tasks/format.rs
@@ -103,7 +103,7 @@ pub fn due(task: &Task, config: &Config, buffer: &str) -> String {
     }
 }
 
-//Formats a string for all style/formatted links (including markdown) and formats them as a hyperlink
+/// Formats a string for all style/formatted links (including markdown) and formats them as a hyperlink
 fn create_links(content: &str) -> String {
     // Define the regex pattern for Markdown links
     let link_regex = Regex::new(r"\[([^\]]+)\]\(([^)]+)\)").unwrap();
@@ -118,7 +118,7 @@ fn create_links(content: &str) -> String {
     result.into_owned()
 }
 
-// Formats a single URL as a hyperlinked URL (with the URL as the Hyperlink), if hyperlinks are enabled in the config - If hyperlinks are disabled, it returns the same URL as a plain string.
+/// Formats a single URL as a hyperlinked URL (with the URL as the Hyperlink), if hyperlinks are enabled in the config - If hyperlinks are disabled, it returns the same URL as a plain string.
 pub fn format_url(url: &str, config: &Config) -> String {
     if hyperlinks_disabled(config) {
         return url.to_string();

--- a/src/tasks/format.rs
+++ b/src/tasks/format.rs
@@ -123,7 +123,7 @@ pub fn maybe_format_url(url: &str, config: &Config) -> String {
     if hyperlinks_disabled(config) {
         return url.to_string();
     }
-    format!("\x1B]8;;{url}\x1B\\[{url}]\x1B]8;;\x1B\\")
+    format!("\x1B]8;;{url}\x07[{url}]\x1B]8;;\x07")
 }
 pub fn number_comments(quantity: usize) -> String {
     let comment_icon = color::purple_string("★");


### PR DESCRIPTION
# 📦 Pull Request

## Summary

> Adds code and test cases to automatically open the default web browser for Oauth when performing OAuth for Todoist

> adds and updates OSC8 formatting functions for using any instance in which URLs are returned to the CLI

> Also updates test cases to use random local port so they don't conflict and additional test cases can be used or happen simultaneously (production is still bound to 8080)

## PR Checklist

> Please confirm all items below before requesting a review (required for approval)

- [x] This PR/commit messages follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] All CI checks pass
- [x] Documentation is updated if necessary
- [x] This PR is tagged with any appropriate tags
- [x] This PR is ready for **review**  

Important note:

- All CI Checks must pass before PR is committed.
- All PRs must be reviewed before PR is committed.
- Only rebasing is allowed. Any merge commits in the chain will block PR from being commited.

## Related Issues

> Adds feature/fixes #1379 
