### PR TITLE
Potential fix for code scanning alert no. 40: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/scripts/update_formula.rb
+++ b/scripts/update_formula.rb
@@ -1,5 +1,6 @@
 require "digest"
 require "open-uri"
+require "net/http"
 
 version = ARGV[0] or abort("Usage: ruby update_formula.rb <version> (e.g. 0.8.0)")
 tag = "v#{version}"
@@ -19,7 +20,7 @@ platforms.each do |key, filename|
   url = "#{base_url}/#{filename}"
   begin
     puts "🔽 Downloading #{url}..."
-    file = URI.open(url).read
+    file = Net::HTTP.get(URI(url))
     sha256s[key] = Digest::SHA256.hexdigest(file)
     puts "✅ SHA256 for #{key}: #{sha256s[key]}"
   rescue => e


### PR DESCRIPTION
Potential fix for [https://github.com/tod-org/tod/security/code-scanning/40](https://github.com/tod-org/tod/security/code-scanning/40)

To fix the problem, replace the use of `URI.open(url)` with a safer alternative that does not invoke `Kernel.open`. The recommended approach is to use `Net::HTTP` to fetch the file contents from the URL. This avoids the risk associated with `Kernel.open` and is the standard way to perform HTTP requests in Ruby. Specifically, in `scripts/update_formula.rb`, replace the line `file = URI.open(url).read` with code that uses `Net::HTTP.get(URI(url))`. You will need to require the `net/http` library at the top of the file. No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
