### PR TITLE
docs: add features section

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@
 
 An unofficial Todoist command-line client. Takes simple input and dumps it in your inbox or another project. Takes advantage of natural language processing to assign due dates, tags, etc. Designed for single-tasking in a world filled with distraction.
 
+## Features
+
+- Todoist integration through the Todoist API.
+- Quick task capture with Todoist quick-add and natural language syntax.
+- Project import and project-aware task creation, listing, scheduling, prioritizing, and processing.
+- Filter-based task views and batch actions for reviewing, labeling, scheduling, and prioritizing tasks.
+- Interactive terminal flows for creating, editing, commenting on, completing, and processing tasks.
+- Task and comment output that adapts to the current CLI window size.
+
 Get started with [Homebrew](https://brew.sh) (macOS, Linux, WSL)
 
 ```bash

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,6 +2,7 @@
 
 <!--toc:start-->
 - [Usage](#usage)
+  - [Features](#features)
   - [Discovering the commands](#discovering-the-commands)
   - [Usage Examples](#usage-examples)
   - [Shell script examples](#shell-script-examples)
@@ -9,6 +10,17 @@
   - [Update Tod](#update-tod)
   - [How task priority is determined](#how-task-priority-is-determined)
 <!--toc:end-->
+
+## Features
+
+Tod supports common Todoist workflows from the command line:
+
+- Create tasks with Todoist quick-add and natural language syntax.
+- Import projects and create, list, schedule, prioritize, and process tasks by project.
+- View and update groups of tasks with Todoist filters.
+- Add task comments, edit tasks, complete tasks, and move through one task at a time.
+- Label, schedule, prioritize, and process tasks in interactive or scripted flows.
+- Automatically adapt task and comment output to the current CLI window size.
 
 ## Discovering the commands
 


### PR DESCRIPTION
## Summary

- Add a Features section to the README.
- Add a matching Features overview to the usage docs and table of contents.
- Cover Todoist support, project/filter/scheduling workflows, and CLI-size-aware task/comment output.

## Testing

- Not run; documentation-only change.

Closes #1407