### PR TITLE
Add nextest JUnit upload to Codecov

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,4 @@
+[profile.ci.junit]
+path = "junit.xml"
+store-success-output = false
+store-failure-output = true

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -34,7 +34,17 @@ jobs:
         with:
           cache-all-crates: true
       - name: Cargo Test
-        run: cargo nextest run --all-features
+        run: cargo nextest run --profile ci --all-features
+      - name: Upload nextest JUnit test results to Codecov
+        if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/nextest/ci/junit.xml
+          disable_search: true
+          report_type: test_results
+          flags: nextest
+          name: nextest-junit
 
   check:
     name: Cargo Check

--- a/.github/workflows/ci_push.yml
+++ b/.github/workflows/ci_push.yml
@@ -34,7 +34,17 @@ jobs:
         with:
           cache-all-crates: true
       - name: Cargo Test
-        run: cargo nextest run --all-features
+        run: cargo nextest run --profile ci --all-features
+      - name: Upload nextest JUnit test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/nextest/ci/junit.xml
+          disable_search: true
+          report_type: test_results
+          flags: nextest
+          name: nextest-junit
 
   check:
     name: Cargo Check


### PR DESCRIPTION
## Summary
- add a nextest CI profile that emits JUnit XML
- run CI nextest jobs with the `ci` profile
- upload nextest JUnit test results to Codecov as `test_results`
- restrict PR uploads to same-repo PRs or manual workflow runs so fork PRs do not access `CODECOV_TOKEN`

Closes #1416

## Validation
- reviewed generated workflow changes and Codecov action inputs
- not run locally; workflow behavior is validated by GitHub Actions
