### PR TITLE
feat: config open

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ dependencies = [
  "document-features",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -551,6 +551,16 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "edit"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f364860e764787163c8c8f58231003839be31276e821e2ad2092ddf496b1aa09"
+dependencies = [
+ "tempfile",
+ "which",
+]
 
 [[package]]
 name = "either"
@@ -814,6 +824,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "homedir"
@@ -1234,6 +1253,12 @@ dependencies = [
  "bitflags",
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1818,6 +1843,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1825,7 +1863,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2276,7 +2314,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2286,7 +2324,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2382,6 +2420,7 @@ dependencies = [
  "clap_complete",
  "colored",
  "dirs",
+ "edit",
  "futures",
  "homedir",
  "inquire",
@@ -2784,6 +2823,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ strum_macros = "0.28.0"
 axum = "0.8.9"
 serde_regex = "1.1.0"
 open = "5.3.4"
+edit = "0.1.5"
 
 
 [dev-dependencies]

--- a/src/commands/config_commands.rs
+++ b/src/commands/config_commands.rs
@@ -29,6 +29,10 @@ pub enum ConfigCommands {
     #[clap(alias = "r")]
     Reset(ConfigReset),
 
+    #[clap(alias = "o")]
+    /// (o) Open the configuration file in the default editor
+    Open(ConfigOpen),
+
     #[clap(alias = "tz")]
     /// (tz) Change the timezone in the configuration file
     SetTimezone(SetTimezone),
@@ -49,6 +53,9 @@ pub struct ConfigReset {
     #[arg(long)]
     pub force: bool,
 }
+
+#[derive(Parser, Debug, Clone)]
+pub struct ConfigOpen {}
 
 #[derive(Parser, Debug, Clone)]
 pub struct About {}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -391,6 +391,12 @@ pub async fn select_command(
             crate::config::config_reset(cli.config.clone(), args.force).await,
         ),
 
+        Commands::Config(ConfigCommands::Open(_args)) => (
+            false,
+            false,
+            crate::config::config_open(cli.config.clone()).await,
+        ),
+
         Commands::Config(ConfigCommands::SetTimezone(args)) => {
             let config = match fetch_config(&cli, &tx).await {
                 Ok(config) => config,

--- a/src/config.rs
+++ b/src/config.rs
@@ -767,6 +767,54 @@ where
     }
 }
 
+/// Opens the config file in the user's editor, creating a default config first if requested.
+pub async fn config_open(cli_config_path: Option<PathBuf>) -> Result<String, Error> {
+    config_open_with_prompt_and_editor(
+        cli_config_path,
+        |path| {
+            Confirm::new(&format!(
+                "No config file found at {}. Create it?",
+                path.display()
+            ))
+            .with_default(true)
+            .prompt()
+            .unwrap_or(false)
+        },
+        |path| edit::edit_file(path).map_err(Error::from),
+    )
+    .await
+}
+
+async fn config_open_with_prompt_and_editor<P, E>(
+    cli_config_path: Option<PathBuf>,
+    prompt_fn: P,
+    editor_fn: E,
+) -> Result<String, Error>
+where
+    P: FnOnce(&Path) -> bool,
+    E: FnOnce(&Path) -> Result<(), Error>,
+{
+    let path = resolve_config_path(cli_config_path).await?;
+
+    if !path.exists() {
+        if !prompt_fn(&path) {
+            return Ok("Aborted: Config not created.".to_string());
+        }
+
+        let mut config = Config::new(None, path.clone()).await?;
+        config.touch_file().await?;
+        config.save().await?;
+    }
+
+    editor_fn(&path)?;
+    Config::load(&path).await?;
+
+    Ok(format!(
+        "Config file at {} opened and validated successfully.",
+        path.display()
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1479,5 +1527,65 @@ mod tests {
         let msg = result.expect("Could not get reset config response");
         assert_eq!(msg, "Aborted: Config not deleted.");
         assert!(temp_path.exists(), "File should not be deleted after abort");
+    }
+
+    #[tokio::test]
+    async fn test_config_open_missing_prompt_no_aborts() {
+        let (_temp_dir, temp_path) = temp_config_path("missing_open_no.cfg");
+
+        let result = config_open_with_prompt_and_editor(
+            Some(temp_path.clone()),
+            |_| false,
+            |_| -> Result<(), Error> { panic!("editor should not be called") },
+        )
+        .await;
+
+        assert_eq!(result, Ok("Aborted: Config not created.".to_string()));
+        assert!(
+            !temp_path.exists(),
+            "Config file should not be created after abort"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_config_open_missing_prompt_yes_creates_and_validates() {
+        let (_temp_dir, temp_path) = temp_config_path("missing_open_yes.cfg");
+
+        let result =
+            config_open_with_prompt_and_editor(Some(temp_path.clone()), |_| true, |_| Ok(())).await;
+
+        assert!(result.is_ok(), "Expected Ok, got {result:?}");
+        assert!(temp_path.exists(), "Config file should be created");
+
+        let loaded = Config::load(&temp_path)
+            .await
+            .expect("Created config should load");
+        assert_eq!(loaded.path, temp_path);
+    }
+
+    #[tokio::test]
+    async fn test_config_open_invalid_after_editor_errors() {
+        let (_temp_dir, temp_path) = temp_config_path("invalid_after_open.cfg");
+        Config::default_test()
+            .with_path(temp_path.clone())
+            .create()
+            .await
+            .expect("Failed to create temp config");
+
+        let result = config_open_with_prompt_and_editor(
+            Some(temp_path.clone()),
+            |_| -> bool { panic!("prompt should not be called") },
+            |path| {
+                std::fs::write(path, "{ invalid").expect("Failed to write invalid config");
+                Ok(())
+            },
+        )
+        .await;
+
+        let err = result.expect_err("Invalid config should fail validation");
+        assert!(
+            err.message.contains("Error loading configuration file"),
+            "Expected config load error, got: {err}"
+        );
     }
 }

--- a/tests/config_open.rs
+++ b/tests/config_open.rs
@@ -1,0 +1,68 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::tempdir;
+
+fn noop_editor() -> &'static str {
+    if cfg!(windows) {
+        "cmd.exe /C rem"
+    } else {
+        "true"
+    }
+}
+
+fn tod_command() -> Command {
+    let mut command = Command::cargo_bin("tod").expect("tod binary should build");
+    command.env("VISUAL", noop_editor());
+    command.env("EDITOR", noop_editor());
+    command
+}
+
+#[test]
+fn config_open_opens_existing_config_and_validates() {
+    let dir = tempdir().expect("temp dir should be created");
+    let path = dir.path().join("tod.cfg");
+    fs::write(&path, "{}").expect("config should be written");
+
+    tod_command()
+        .arg("--config")
+        .arg(&path)
+        .args(["config", "open"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "opened and validated successfully",
+        ));
+}
+
+#[test]
+fn config_open_alias_opens_existing_config_and_validates() {
+    let dir = tempdir().expect("temp dir should be created");
+    let path = dir.path().join("tod.cfg");
+    fs::write(&path, "{}").expect("config should be written");
+
+    tod_command()
+        .arg("--config")
+        .arg(&path)
+        .args(["config", "o"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "opened and validated successfully",
+        ));
+}
+
+#[test]
+fn config_open_fails_when_config_is_invalid_after_editor_exits() {
+    let dir = tempdir().expect("temp dir should be created");
+    let path = dir.path().join("tod.cfg");
+    fs::write(&path, "{ invalid").expect("config should be written");
+
+    tod_command()
+        .arg("--config")
+        .arg(&path)
+        .args(["config", "open"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Error loading configuration file"));
+}


### PR DESCRIPTION
## Summary
- add the `edit` crate for opening files in the user's editor
- add `tod config open` / `tod config o`
- create a default config on request when the config file is missing, then validate the config after the editor exits
- add CLI integration coverage for the open command, alias, and invalid config validation

Closes #1355

## Validation
- `cargo test --test config_open`
- `cargo test test_config_open`
- `cargo test verify_cmd`
- `cargo test`

## Manual test
- `EDITOR=true cargo run -- --config /tmp/tod.cfg config open`