### PR TITLE
[codex] add recursive response blob tests

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -47,19 +47,25 @@ pub async fn get_latest_version(mock_url: Option<String>) -> Result<String, Erro
         .await?;
 
     if response.status().is_success() {
-        let cr: CargoResponse = serde_json::from_str(&response.text().await?)?;
-        Ok(cr
-            .versions
-            .first()
-            .expect("crates.io response contained no versions")
-            .num
-            .clone())
+        let json = response.text().await?;
+        json_to_latest_version(&json)
     } else {
         let message = format!("Error: {:#?}", response.text().await);
         let source = "get_latest_version response failure".to_string();
         Err(Error { message, source })
     }
 }
+
+pub fn json_to_latest_version(json: &str) -> Result<String, Error> {
+    let cr: CargoResponse = serde_json::from_str(json)?;
+    Ok(cr
+        .versions
+        .first()
+        .expect("crates.io response contained no versions")
+        .num
+        .clone())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -29,6 +29,11 @@ pub async fn get_labels(config: &Config, spinner: bool) -> Result<Vec<Label>, Er
     todoist::all_labels(config, spinner, None).await
 }
 
+pub fn json_to_label(json: &str) -> Result<Label, Error> {
+    let label: Label = serde_json::from_str(json)?;
+    Ok(label)
+}
+
 pub fn json_to_labels_response(json: &str) -> Result<LabelResponse, Error> {
     let response: LabelResponse = serde_json::from_str(json)?;
     Ok(response)
@@ -73,6 +78,19 @@ mod tests {
     #[test]
     fn test_json_to_labels_response_invalid() {
         let result = json_to_labels_response("not json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_json_to_label_valid() {
+        let json = r#"{"id":"1","name":"work","color":"red","order":1,"is_favorite":false}"#;
+        let label = json_to_label(json).expect("should parse label");
+        assert_eq!(label.name, "work");
+    }
+
+    #[test]
+    fn test_json_to_label_invalid() {
+        let result = json_to_label("not json");
         assert!(result.is_err());
     }
 }

--- a/src/test/responses.rs
+++ b/src/test/responses.rs
@@ -1,6 +1,10 @@
 //! Responses are for generating JSON and mocking API calls
 
-use crate::VERSION;
+use crate::{VERSION, cargo, comments, id, labels, oauth, projects, sections, tasks, users};
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+
+const RESPONSE_ROOT: &str = "tests/responses";
 
 /// File name is the same as the enum name
 /// So you can find the `Task` variant in tests/responses/Task.json
@@ -36,7 +40,7 @@ pub enum ResponseFromFile {
 impl ResponseFromFile {
     /// Loads JSON responses from file for testing
     pub async fn read(&self) -> String {
-        let path = format!("tests/responses/{self}.json");
+        let path = format!("{RESPONSE_ROOT}/{self}.json");
 
         let json = std::fs::read_to_string(&path)
             .unwrap_or_else(|_| panic!("Could not find json file at {path}"));
@@ -46,7 +50,7 @@ impl ResponseFromFile {
 
     /// Loads JSON and replaces INSERTVERSION with a custom version string
     pub async fn read_with_version(&self, version: &str) -> String {
-        let path = format!("tests/responses/{self}.json");
+        let path = format!("{RESPONSE_ROOT}/{self}.json");
 
         let json = std::fs::read_to_string(&path)
             .unwrap_or_else(|_| panic!("Could not find json file at {path}"));
@@ -86,4 +90,261 @@ impl ResponseFromFile {
         }
         result
     }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ResponseKind {
+    AccessToken,
+    Comment,
+    Ids,
+    Label,
+    Project,
+    Section,
+    Task,
+    User,
+    Version,
+}
+
+#[tokio::test]
+async fn every_response_blob_deserializes_with_expected_parser() {
+    let mut paths = response_blob_paths(Path::new(RESPONSE_ROOT)).unwrap_or_else(|error| {
+        panic!("failed to discover response blobs under {RESPONSE_ROOT}: {error}")
+    });
+
+    paths.sort();
+
+    assert!(
+        !paths.is_empty(),
+        "expected at least one JSON response blob under {RESPONSE_ROOT}"
+    );
+
+    let mut failures = Vec::new();
+    for path in paths {
+        match test_response_blob(&path).await {
+            Ok(()) => {}
+            Err(error) => failures.push(error),
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "response blob parser failures:\n\n{}",
+        failures.join("\n\n")
+    );
+}
+
+async fn test_response_blob(path: &Path) -> Result<(), String> {
+    let kind = classify_response_blob(path).ok_or_else(|| {
+        format!(
+            "{}: no response parser matched this blob. Put it under a typed directory like \
+             comments/, tasks/, projects/, sections/, or labels/, or name it after its response type.",
+            path.display()
+        )
+    })?;
+    let json = read_response_blob(path).await?;
+
+    parse_response_blob(path, kind, &json)
+}
+
+async fn read_response_blob(path: &Path) -> Result<String, String> {
+    let mut json = std::fs::read_to_string(path)
+        .map_err(|error| format!("{}: failed to read blob: {error}", path.display()))?;
+
+    if json.contains("INSERTDATE") {
+        json = json.replace("INSERTDATE", &super::today_date().await);
+    }
+
+    if json.contains("INSERTVERSION") {
+        json = json.replace("INSERTVERSION", VERSION);
+    }
+
+    Ok(json)
+}
+
+fn response_blob_paths(root: &Path) -> Result<Vec<PathBuf>, String> {
+    let mut paths = Vec::new();
+    collect_response_blob_paths(root, &mut paths)?;
+    Ok(paths)
+}
+
+fn collect_response_blob_paths(dir: &Path, paths: &mut Vec<PathBuf>) -> Result<(), String> {
+    let entries = std::fs::read_dir(dir)
+        .map_err(|error| format!("{}: failed to read directory: {error}", dir.display()))?;
+
+    for entry in entries {
+        let entry =
+            entry.map_err(|error| format!("{}: failed to read entry: {error}", dir.display()))?;
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .map_err(|error| format!("{}: failed to read file type: {error}", path.display()))?;
+
+        if file_type.is_dir() {
+            collect_response_blob_paths(&path, paths)?;
+        } else if is_json_file(&path) {
+            paths.push(path);
+        }
+    }
+
+    Ok(())
+}
+
+fn is_json_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("json"))
+}
+
+fn classify_response_blob(path: &Path) -> Option<ResponseKind> {
+    classify_by_parent_directory(path).or_else(|| classify_by_file_stem(path))
+}
+
+fn classify_by_parent_directory(path: &Path) -> Option<ResponseKind> {
+    let mut directory = path.parent();
+
+    while let Some(path) = directory {
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            break;
+        };
+        let name = normalize(name);
+
+        if name == "responses" {
+            break;
+        }
+
+        if let Some(kind) = classify_directory_name(&name) {
+            return Some(kind);
+        }
+
+        directory = path.parent();
+    }
+
+    None
+}
+
+fn classify_by_file_stem(path: &Path) -> Option<ResponseKind> {
+    let stem = path.file_stem()?.to_str()?;
+    let stem = normalize(stem);
+
+    match stem.as_str() {
+        "accesstoken" => Some(ResponseKind::AccessToken),
+        "ids" => Some(ResponseKind::Ids),
+        "user" => Some(ResponseKind::User),
+        "versions" => Some(ResponseKind::Version),
+        _ if stem.contains("comment") => Some(ResponseKind::Comment),
+        _ if stem.contains("label") => Some(ResponseKind::Label),
+        _ if stem.contains("project") => Some(ResponseKind::Project),
+        _ if stem.contains("section") => Some(ResponseKind::Section),
+        _ if stem.contains("task") => Some(ResponseKind::Task),
+        _ => None,
+    }
+}
+
+fn classify_directory_name(name: &str) -> Option<ResponseKind> {
+    match name {
+        "comments" | "comment" => Some(ResponseKind::Comment),
+        "labels" | "label" => Some(ResponseKind::Label),
+        "projects" | "project" => Some(ResponseKind::Project),
+        "sections" | "section" => Some(ResponseKind::Section),
+        "tasks" | "task" => Some(ResponseKind::Task),
+        "users" | "user" => Some(ResponseKind::User),
+        "versions" | "version" => Some(ResponseKind::Version),
+        "ids" => Some(ResponseKind::Ids),
+        "accesstokens" | "accesstoken" => Some(ResponseKind::AccessToken),
+        _ => None,
+    }
+}
+
+fn normalize(value: &str) -> String {
+    value
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn parse_response_blob(path: &Path, kind: ResponseKind, json: &str) -> Result<(), String> {
+    match kind {
+        ResponseKind::AccessToken => oauth::json_to_access_token(json.to_string())
+            .map(|_| ())
+            .map_err(|error| parse_error(path, "access token", error)),
+        ResponseKind::Comment => parse_single_or_response(
+            path,
+            json,
+            "comment",
+            |json| comments::json_to_comment(json.to_string()).map(|_| ()),
+            |json| comments::json_to_comment_response(json.to_string()).map(|_| ()),
+        ),
+        ResponseKind::Ids => id::json_to_ids(json.to_string())
+            .map(|_| ())
+            .map_err(|error| parse_error(path, "id list", error)),
+        ResponseKind::Label => parse_single_or_response(
+            path,
+            json,
+            "label",
+            |json| labels::json_to_label(json).map(|_| ()),
+            |json| labels::json_to_labels_response(json).map(|_| ()),
+        ),
+        ResponseKind::Project => parse_single_or_response(
+            path,
+            json,
+            "project",
+            |json| projects::json_to_project(json.to_string()).map(|_| ()),
+            |json| projects::json_to_projects_response(json.to_string()).map(|_| ()),
+        ),
+        ResponseKind::Section => parse_single_or_response(
+            path,
+            json,
+            "section",
+            |json| sections::json_to_section(json).map(|_| ()),
+            |json| sections::json_to_sections_response(json).map(|_| ()),
+        ),
+        ResponseKind::Task => parse_single_or_response(
+            path,
+            json,
+            "task",
+            |json| tasks::json_to_task(json.to_string()).map(|_| ()),
+            |json| tasks::json_to_tasks_response(json.to_string()).map(|_| ()),
+        ),
+        ResponseKind::User => users::json_to_user(json)
+            .map(|_| ())
+            .map_err(|error| parse_error(path, "user", error)),
+        ResponseKind::Version => cargo::json_to_latest_version(json)
+            .map(|_| ())
+            .map_err(|error| parse_error(path, "version response", error)),
+    }
+}
+
+fn parse_single_or_response<Single, Response>(
+    path: &Path,
+    json: &str,
+    type_name: &str,
+    parse_single: Single,
+    parse_response: Response,
+) -> Result<(), String>
+where
+    Single: FnOnce(&str) -> Result<(), crate::errors::Error>,
+    Response: FnOnce(&str) -> Result<(), crate::errors::Error>,
+{
+    if has_results(json).map_err(|error| parse_error(path, "JSON object", error))? {
+        parse_response(json)
+            .map_err(|error| parse_error(path, &format!("{type_name} response"), error))
+    } else {
+        parse_single(json).map_err(|error| parse_error(path, type_name, error))
+    }
+}
+
+fn has_results(json: &str) -> Result<bool, serde_json::Error> {
+    let value: Value = serde_json::from_str(json)?;
+    Ok(value.get("results").is_some())
+}
+
+fn parse_error<E>(path: &Path, type_name: &str, error: E) -> String
+where
+    E: std::fmt::Display,
+{
+    format!(
+        "{}: failed to parse as {type_name}: {error}",
+        path.display()
+    )
 }


### PR DESCRIPTION
## Summary

Adds recursive coverage for JSON response blobs under `tests/responses` so future fixture examples are automatically deserialized by the parser that matches their response type.

## Changes

- Walk every `.json` file under `tests/responses`, including nested directories.
- Classify blobs by typed parent directory first, then by filename for current flat fixtures.
- Route each blob through the relevant parser for comments, tasks, projects, sections, labels, ids, users, access tokens, and crate versions.
- Add direct parser helpers for single label JSON and crate version JSON so those fixtures are covered like the other response types.

## Validation

- `cargo test`
- Result: `230 passed; 0 failed`