### PR TITLE
feat: list sort

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,6 +43,19 @@ If the config does not exist, Tod will prompt for your initial Todoist API token
   "no_sections": null,
   "path": "See Location - Platform Specific",
   "projectsv1": [],
+    "sort_value": {
+    "deadline_days": 5,
+    "deadline_value": 30,
+    "no_due_date": 80,
+    "not_recurring": 50,
+    "now": 200,
+    "overdue": 150,
+    "priority_high": 4,
+    "priority_low": 1,
+    "priority_medium": 3,
+    "priority_none": 2,
+    "today": 100
+  },
   "sort_order": [
     "priority:desc",
     "due_date:asc",
@@ -177,6 +190,24 @@ If true will not prompt for a section whenever possible
 ```
 
 Projects are stored locally in config to help save on API requests and speed up actions taken. Manage this with the `project` subcommands.
+
+### sort_value
+
+Deprecated in latest version, replaced with sort_order. Will be removed in future release.
+
+  {
+    "deadline_days": 5,
+    "deadline_value": 30,
+    "no_due_date": 80,
+    "not_recurring": 50,
+    "now": 200,
+    "overdue": 150,
+    "priority_high": 4,
+    "priority_low": 1,
+    "priority_medium": 3,
+    "priority_none": 2,
+    "today": 100
+  },
 
 ### sort_order
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -195,21 +195,19 @@ Projects are stored locally in config to help save on API requests and speed up 
 
 Deprecated in latest version, replaced with sort_order. Will be removed in future release.
 
-```json
-  {
-    "deadline_days": 5,
-    "deadline_value": 30,
-    "no_due_date": 80,
-    "not_recurring": 50,
-    "now": 200,
-    "overdue": 150,
-    "priority_high": 4,
-    "priority_low": 1,
-    "priority_medium": 3,
-    "priority_none": 2,
-    "today": 100
-  },
-```
+    {
+      "deadline_days": 5,
+      "deadline_value": 30,
+      "no_due_date": 80,
+      "not_recurring": 50,
+      "now": 200,
+      "overdue": 150,
+      "priority_high": 4,
+      "priority_low": 1,
+      "priority_medium": 3,
+      "priority_none": 2,
+      "today": 100
+    }
 
 ### sort_order
 
@@ -225,7 +223,7 @@ The direction may be omitted to use the key's default. For example, `priority` i
 
 Available keys: `priority`, `due_date`, `overdue`, `today`, `now`, `no_due_date`, `not_recurring`, `deadline`, and `order`. Available directions are `asc` and `desc`. `order` uses Todoist's task order (`child_order` in the current API).
 
-Legacy configs that still contain `sort_value` will be accepted temporarily. Tod migrates the old numeric weights into a best-effort `sort_order` at load time and prints a warning that `sort_value` will be removed in a future version. To avoid the warning, replace `sort_value` with an explicit `sort_order` list.
+Legacy configs that still contain `sort_value` will be accepted temporarily. Tod migrates the old numeric weights into a best-effort `sort_order` at load time and will print a warning that `sort_value` will be removed in a future version. To avoid the warning, replace `sort_value` with an explicit `sort_order` list.
 
 ### spinners
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@
     - [natural_language_only](#natural_language_only)
     - [no_sections](#no_sections)
     - [projectsv1](#projectsv1)
-    - [sort_value](#sort_value)
+    - [sort_order](#sort_order)
     - [spinners](#spinners)
     - [timeout](#timeout)
     - [timezone](#timezone)
@@ -43,19 +43,17 @@ If the config does not exist, Tod will prompt for your initial Todoist API token
   "no_sections": null,
   "path": "See Location - Platform Specific",
   "projectsv1": [],
-  "sort_value": {
-    "deadline_days": 5,
-    "deadline_value": 30,
-    "no_due_date": 80,
-    "not_recurring": 50,
-    "now": 200,
-    "overdue": 150,
-    "priority_high": 4,
-    "priority_low": 1,
-    "priority_medium": 3,
-    "priority_none": 2,
-    "today": 100
-  },
+  "sort_order": [
+    "priority:desc",
+    "due_date:asc",
+    "overdue:desc",
+    "today:desc",
+    "now:desc",
+    "no_due_date:desc",
+    "not_recurring:desc",
+    "deadline:asc",
+    "order:asc"
+  ],
   "spinners": true,
   "timeout": null,
   "timezone": "",
@@ -180,50 +178,21 @@ If true will not prompt for a section whenever possible
 
 Projects are stored locally in config to help save on API requests and speed up actions taken. Manage this with the `project` subcommands.
 
-### sort_value
+### sort_order
 
-Tasks are ranked by points and the first is returned, the points are the sum of the following:
+List of sort rules used when sorting with the default `value` sort. Each rule uses `key:asc` or `key:desc`. Tod compares tasks only by the configured rules, in order. If tasks are equal after those comparisons, their order from the Todoist API is preserved.
 
-- Task is overdue: 150
-- The date is today with no time: 100
-- The date is today with time in next or last 15 min: 200
-- No date: 80
-- Not recurring: 50
-- Task has no priority: 2
-- Priority 1: 1
-- Priority 2: 3
-- Priority 3: 4
+New config files include this default order: `priority:desc`, `due_date:asc`, `overdue:desc`, `today:desc`, `now:desc`, `no_due_date:desc`, `not_recurring:desc`, `deadline:asc`, `order:asc`.
 
-The math for how much a deadline contributes in points is a little more involved. It is based on the number of days before the deadline (closer = more) and the value per day.
-
-The formula is `max(deadline_days - number of days until deadline, 0) * deadline_value`
-
-The default for deadline_days is 5, and deadline_value is 30. For example:
-
-- 6 days before the deadline it is 0
-- 4 days before deadline the value is 30
-- on the day of the deadline it is 150
-- 2 days after the deadline it is 210
-
-Defaults:
+The direction may be omitted to use the key's default. For example, `priority` is equivalent to `priority:desc`:
 
 ``` json
-  {
-    "deadline_days": 5,
-    "deadline_value": 30,
-    "no_due_date": 80,
-    "not_recurring": 50,
-    "now": 200,
-    "overdue": 150,
-    "priority_high": 4,
-    "priority_low": 1,
-    "priority_medium": 3,
-    "priority_none": 2,
-    "today": 100
-  },
+  "sort_order": ["priority", "due_date:desc"]
 ```
 
-These values are u8, so they can be 0-255 (must not exceed 255) - if they exceed 255, Tod will report a config parse error.
+Available keys: `priority`, `due_date`, `overdue`, `today`, `now`, `no_due_date`, `not_recurring`, `deadline`, and `order`. Available directions are `asc` and `desc`. `order` uses Todoist's task order (`child_order` in the current API).
+
+Legacy configs that still contain `sort_value` will be accepted temporarily. Tod migrates the old numeric weights into a best-effort `sort_order` at load time and prints a warning that `sort_value` will be removed in a future version. To avoid the warning, replace `sort_value` with an explicit `sort_order` list.
 
 ### spinners
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -195,6 +195,7 @@ Projects are stored locally in config to help save on API requests and speed up 
 
 Deprecated in latest version, replaced with sort_order. Will be removed in future release.
 
+```json
   {
     "deadline_days": 5,
     "deadline_value": 30,
@@ -208,6 +209,7 @@ Deprecated in latest version, replaced with sort_order. Will be removed in futur
     "priority_none": 2,
     "today": 100
   },
+```
 
 ### sort_order
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,6 +6,7 @@ For GitHub Copilot-specific rules, see [`.github/copilot-instructions.md`](.gith
 ---
 
 ## General Principles
+
 - Write **clear, maintainable, idiomatic Rust** code.
 - Avoid unnecessary complexity—favor simple, well-factored functions.
 - Use descriptive function and variable names; no cryptic abbreviations.
@@ -16,6 +17,7 @@ For GitHub Copilot-specific rules, see [`.github/copilot-instructions.md`](.gith
 ---
 
 ## Code Style
+
 - Use the `?` operator for error propagation.
 - Prefer `.expect("clear message")` over `.unwrap()` when a panic is acceptable.
 - Derive common traits (`Debug`, `Clone`, `PartialEq`) where appropriate.
@@ -27,6 +29,7 @@ For GitHub Copilot-specific rules, see [`.github/copilot-instructions.md`](.gith
 ---
 
 ## Error Handling
+
 - Always include context in error messages.
 - Use a **standardized error reporting function** for consistency.
 - Only auto-fix scenarios that are deterministic and safe. Otherwise, report a descriptive error.
@@ -34,6 +37,7 @@ For GitHub Copilot-specific rules, see [`.github/copilot-instructions.md`](.gith
 ---
 
 ## Testing
+
 - Every new function should include a unit test.
 - New features and bug fixes must include test coverage.
 - Use `assert_cmd` for CLI testing and `mockito` for HTTP mocking.
@@ -43,6 +47,7 @@ For GitHub Copilot-specific rules, see [`.github/copilot-instructions.md`](.gith
 ---
 
 ## GitHub Actions / CI
+
 - Favor **reusable workflows** over copy-paste jobs.
 - Avoid running duplicate jobs for `push` and `pull_request`.
 - Always set `concurrency` in workflows to prevent overlapping runs.
@@ -52,6 +57,7 @@ For GitHub Copilot-specific rules, see [`.github/copilot-instructions.md`](.gith
 ---
 
 ## Commit Messages
+
 We use the **[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)** standard.
 
 - Messages must be **all lowercase**.
@@ -62,14 +68,16 @@ We use the **[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.
 - Breaking changes and issue references belong in the footer.
 
 ### Good Examples
-```
+
+```text
 feat(config): support pathbuf for config path
 fix(parser): handle empty lines in csv import
 ci(workflow): add concurrency to prevent overlapping runs
 ```
 
 ### Bad Examples
-```
+
+```text
 Update files
 Fix stuff
 Refactor
@@ -78,6 +86,7 @@ Refactor
 ---
 
 ## Pull Requests
+
 - Include a summary and rationale for changes.
 - Keep PRs small and focused.
 - Link related issues.
@@ -87,6 +96,7 @@ Refactor
 ---
 
 ## Contributor Checklist
+
 - [ ] Code follows idiomatic Rust practices.
 - [ ] No `unwrap()` calls (use `expect` with clear messages).
 - [ ] Errors are consistent and descriptive.
@@ -96,4 +106,3 @@ Refactor
 - [ ] CI workflows pass cleanly and efficiently.
 
 ---
-

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -178,7 +178,9 @@ tod list label --filter "no label" --label physical --label digital
 
 ## How task priority is determined
 
-See [Sort_value](https://github.com/tod-org/tod/blob/main/docs/configuration.md#sort_value)
+See [sort_order](https://github.com/tod-org/tod/blob/main/docs/configuration.md#sort_order)
+
+Use `--sort` or `--sort value` to apply the configured sort order. Explicit alternatives remain available with `--sort datetime` and `--sort todoist`.
 
 ## Update Tod
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # rust-toolchain.toml
 
 [toolchain]
-channel = "1.96.0"
+channel = "1.97.0"
 components = ["clippy", "rustfmt"]

--- a/src/commands/list_commands.rs
+++ b/src/commands/list_commands.rs
@@ -60,7 +60,13 @@ pub struct View {
     /// The filter containing the tasks. Can add multiple filters separated by commas.
     filter: Option<String>,
 
-    #[arg(short = 't', long, default_value_t = SortOrder::Datetime)]
+    #[arg(
+        short = 't',
+        long,
+        default_value_t = SortOrder::Datetime,
+        default_missing_value = "value",
+        num_args = 0..=1
+    )]
     /// Choose how results should be sorted
     sort: SortOrder,
 }
@@ -75,7 +81,13 @@ pub struct Process {
     /// The filter containing the tasks. Can add multiple filters separated by commas.
     filter: Option<String>,
 
-    #[arg(short = 't', long, default_value_t = SortOrder::Value)]
+    #[arg(
+        short = 't',
+        long,
+        default_value_t = SortOrder::Value,
+        default_missing_value = "value",
+        num_args = 0..=1
+    )]
     /// Choose how results should be sorted
     sort: SortOrder,
 }
@@ -90,7 +102,13 @@ pub struct Timebox {
     /// The filter containing the tasks. It does not filter out tasks with durations unless specified in the filter. Can add multiple filters separated by commas.
     filter: Option<String>,
 
-    #[arg(short = 't', long, default_value_t = SortOrder::Value)]
+    #[arg(
+        short = 't',
+        long,
+        default_value_t = SortOrder::Value,
+        default_missing_value = "value",
+        num_args = 0..=1
+    )]
     /// Choose how results should be sorted
     sort: SortOrder,
 }
@@ -105,7 +123,13 @@ pub struct Prioritize {
     /// The filter containing the tasks. Can add multiple filters separated by commas.
     filter: Option<String>,
 
-    #[arg(short = 't', long, default_value_t = SortOrder::Value)]
+    #[arg(
+        short = 't',
+        long,
+        default_value_t = SortOrder::Value,
+        default_missing_value = "value",
+        num_args = 0..=1
+    )]
     /// Choose how results should be sorted
     sort: SortOrder,
 }
@@ -120,7 +144,13 @@ pub struct Remind {
     /// The filter containing the tasks. Can add multiple filters separated by commas.
     filter: Option<String>,
 
-    #[arg(short = 't', long, default_value_t = SortOrder::Value)]
+    #[arg(
+        short = 't',
+        long,
+        default_value_t = SortOrder::Value,
+        default_missing_value = "value",
+        num_args = 0..=1
+    )]
     /// Choose how results should be sorted
     sort: SortOrder,
 }
@@ -139,7 +169,13 @@ pub struct Label {
     /// Labels to select from, if left blank this will be fetched from API
     labels: Vec<String>,
 
-    #[arg(short = 't', long, default_value_t = SortOrder::Value)]
+    #[arg(
+        short = 't',
+        long,
+        default_value_t = SortOrder::Value,
+        default_missing_value = "value",
+        num_args = 0..=1
+    )]
     /// Choose how results should be sorted
     sort: SortOrder,
 }
@@ -162,7 +198,13 @@ pub struct Schedule {
     /// Only schedule overdue tasks
     overdue: bool,
 
-    #[arg(short = 't', long, default_value_t = SortOrder::Value)]
+    #[arg(
+        short = 't',
+        long,
+        default_value_t = SortOrder::Value,
+        default_missing_value = "value",
+        num_args = 0..=1
+    )]
     /// Choose how results should be sorted
     sort: SortOrder,
 }
@@ -177,7 +219,13 @@ pub struct Deadline {
     /// The filter containing the tasks. Can add multiple filters separated by commas.
     filter: Option<String>,
 
-    #[arg(short = 't', long, default_value_t = SortOrder::Value)]
+    #[arg(
+        short = 't',
+        long,
+        default_value_t = SortOrder::Value,
+        default_missing_value = "value",
+        num_args = 0..=1
+    )]
     /// Choose how results should be sorted
     sort: SortOrder,
 }
@@ -329,5 +377,22 @@ pub async fn deadline(config: Config, args: &Deadline) -> Result<String, Error> 
     match super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await? {
         Flag::Filter(filter) => filters::deadline(&config, &filter, sort).await,
         Flag::Project(project) => projects::deadline(&config, &project, sort).await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn view_sort_without_value_uses_configured_sort() {
+        let args = View::try_parse_from(["tod", "--sort"]).expect("--sort should be valid");
+        assert_eq!(args.sort.to_string(), "value");
+    }
+
+    #[test]
+    fn view_without_sort_keeps_datetime_default() {
+        let args = View::try_parse_from(["tod"]).expect("view arguments should be valid");
+        assert_eq!(args.sort.to_string(), "datetime");
     }
 }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -1,6 +1,8 @@
 //! For config functions that operate on the filesystem
 
-use crate::config::{Args, Internal, SortValue};
+use crate::config::{Args, Internal};
+#[cfg(test)]
+use crate::config::{SortDirection, SortKey, SortRule};
 use crate::{color, debug, input};
 use crate::{config::Config, errors::Error};
 use inquire::Confirm;
@@ -63,16 +65,7 @@ impl Config {
 
         let config: Config =
             serde_json::from_str(&json).map_err(|e| config_load_error(&e, path))?;
-        let config = if config.sort_value.is_none() {
-            Config {
-                sort_value: Some(SortValue::default()),
-                ..config
-            }
-        } else {
-            config
-        };
-
-        Ok(config)
+        Ok(config.with_default_sort_order())
     }
 
     pub async fn reload(&self) -> Result<Self, Error> {
@@ -442,14 +435,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn load_should_fail_on_invalid_u8_value() {
-        let (_temp_dir, bad_config_path) = temp_config_path("bad_config_invalid_u8.cfg");
+    async fn load_should_fail_on_invalid_sort_order_value() {
+        let (_temp_dir, bad_config_path) = temp_config_path("bad_config_invalid_sort_order.cfg");
         let contents = serde_json::json!({
             "token": "abc123",
             "path": bad_config_path,
-            "sort_value": {
-                "priority_none": 500
-            }
+            "sort_order": ["not_a_sort_key"]
         })
         .to_string();
 
@@ -458,7 +449,118 @@ mod tests {
             .expect("Could not write to file");
 
         let result = Config::load(&bad_config_path).await;
-        assert!(result.is_err(), "Expected error from invalid u8");
+        assert!(result.is_err(), "Expected error from invalid sort order");
+    }
+
+    #[tokio::test]
+    async fn load_should_accept_order_sort_key() {
+        let (_temp_dir, path) = temp_config_path("order_sort_key.cfg");
+        let contents = serde_json::json!({
+            "path": path,
+            "sort_order": ["order"]
+        })
+        .to_string();
+
+        tokio::fs::write(&path, contents)
+            .await
+            .expect("Could not write to file");
+
+        let config = Config::load(&path)
+            .await
+            .expect("order should be a valid sort key");
+
+        assert_eq!(
+            config.sort_order,
+            Some(vec![SortRule::new(SortKey::Order, SortDirection::Asc)])
+        );
+    }
+
+    #[tokio::test]
+    async fn load_should_accept_explicit_sort_direction() {
+        let (_temp_dir, path) = temp_config_path("explicit_sort_direction.cfg");
+        let contents = serde_json::json!({
+            "path": path,
+            "sort_order": ["priority:asc", "order:desc"]
+        })
+        .to_string();
+
+        tokio::fs::write(&path, contents)
+            .await
+            .expect("Could not write to file");
+
+        let config = Config::load(&path)
+            .await
+            .expect("explicit sort directions should load");
+
+        assert_eq!(
+            config.sort_order,
+            Some(vec![
+                SortRule::new(SortKey::Priority, SortDirection::Asc),
+                SortRule::new(SortKey::Order, SortDirection::Desc),
+            ])
+        );
+    }
+
+    #[tokio::test]
+    async fn load_should_reject_invalid_sort_direction() {
+        let (_temp_dir, path) = temp_config_path("invalid_sort_direction.cfg");
+        let contents = serde_json::json!({
+            "path": path,
+            "sort_order": ["priority:sideways"]
+        })
+        .to_string();
+
+        tokio::fs::write(&path, contents)
+            .await
+            .expect("Could not write to file");
+
+        assert!(Config::load(&path).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn load_should_migrate_legacy_sort_value_to_sort_order() {
+        let (_temp_dir, path) = temp_config_path("legacy_sort_value.cfg");
+        let contents = serde_json::json!({
+            "token": "abc123",
+            "path": path,
+            "sort_value": {
+                "priority_none": 2,
+                "priority_low": 1,
+                "priority_medium": 3,
+                "priority_high": 4,
+                "no_due_date": 80,
+                "not_recurring": 50,
+                "today": 100,
+                "overdue": 150,
+                "now": 200,
+                "deadline_value": 30,
+                "deadline_days": 5
+            }
+        })
+        .to_string();
+
+        tokio::fs::write(&path, contents)
+            .await
+            .expect("Could not write to file");
+
+        let config = Config::load(&path)
+            .await
+            .expect("legacy sort_value should migrate");
+
+        assert_eq!(
+            config.sort_order.expect("sort_order should be populated"),
+            vec![
+                SortRule::new(SortKey::Now, SortDirection::Desc),
+                SortRule::new(SortKey::Overdue, SortDirection::Desc),
+                SortRule::new(SortKey::Today, SortDirection::Desc),
+                SortRule::new(SortKey::NoDueDate, SortDirection::Desc),
+                SortRule::new(SortKey::NotRecurring, SortDirection::Desc),
+                SortRule::new(SortKey::Deadline, SortDirection::Asc),
+                SortRule::new(SortKey::Priority, SortDirection::Desc),
+                SortRule::new(SortKey::DueDate, SortDirection::Asc),
+                SortRule::new(SortKey::Order, SortDirection::Asc),
+            ]
+        );
     }
 
     #[tokio::test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -14,8 +14,6 @@ use regex::Regex;
 use serde::de::Error as DeError;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::path::PathBuf;
-#[cfg(test)]
-use tempfile;
 use terminal_size::{Height, Width, terminal_size};
 use tokio::sync::mpsc::UnboundedSender;
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,6 +4,7 @@ mod projects;
 mod timezone;
 use crate::errors::Error;
 use crate::input::page_size;
+use crate::legacy;
 use crate::projects::Project;
 use crate::tasks::Task;
 use crate::tasks::format::maybe_format_url;
@@ -11,7 +12,7 @@ use crate::time::{SystemTimeProvider, TimeProviderEnum};
 use crate::{VERSION, cargo, color, input, oauth, time};
 use regex::Regex;
 use serde::de::Error as DeError;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::path::PathBuf;
 #[cfg(test)]
 use tempfile;
@@ -20,19 +21,17 @@ use tokio::sync::mpsc::UnboundedSender;
 
 const MAX_COMMENT_LENGTH: u32 = 500;
 pub const DEFAULT_TIMEOUT_SECONDS: u64 = 30;
-pub const DEFAULT_DEADLINE_VALUE: u8 = 30;
-pub const DEFAULT_DEADLINE_DAYS: u8 = 5;
 pub const OAUTH: &str = "Login with OAuth (recommended)";
 pub const DEVELOPER: &str = "Login with developer API token";
 pub const TOKEN_METHOD: &str = "Choose your Todoist login method";
 const TODOIST_INTEGRATIONS_URL: &str = "https://todoist.com/prefs/integrations";
-
 pub use file::config_open;
 pub use file::config_reset;
 pub use file::generate_path;
 pub use file::get_config;
 pub use file::get_or_create;
 pub use file::resolve_config_path;
+pub use legacy::LegacySortValue;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
@@ -110,7 +109,11 @@ pub struct Config {
     pub no_sections: Option<bool>,
     /// Goes straight to natural language input in datetime selection
     pub natural_language_only: Option<bool>,
-    pub sort_value: Option<SortValue>,
+    /// Ordered list of fields used when sorting by value.
+    pub sort_order: Option<Vec<SortRule>>,
+    /// Legacy numeric sort configuration. Deserialized for migration only.
+    #[serde(skip_serializing)]
+    pub sort_value: Option<LegacySortValue>,
 
     /// For storing arguments from the commandline
     #[serde(skip)]
@@ -139,44 +142,173 @@ pub struct Internal {
     pub tx: Option<UnboundedSender<Error>>,
 }
 
-// Determining how
-#[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Debug)]
-#[serde(deny_unknown_fields)]
-pub struct SortValue {
-    /// Task has one of these priorities
-    pub priority_none: u8,
-    pub priority_low: u8,
-    pub priority_medium: u8,
-    pub priority_high: u8,
-    pub no_due_date: u8,
-    pub not_recurring: u8,
-    pub today: u8,
-    pub overdue: u8,
-    /// Happens now plus or minus 15min
-    pub now: u8,
-    pub deadline_value: Option<u8>,
-    pub deadline_days: Option<u8>,
+#[derive(Copy, Clone, Serialize, Deserialize, Eq, PartialEq, Debug)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub enum SortKey {
+    Priority,
+    DueDate,
+    Overdue,
+    Today,
+    Now,
+    NoDueDate,
+    NotRecurring,
+    Deadline,
+    Order,
 }
 
-impl Default for SortValue {
-    fn default() -> Self {
-        SortValue {
-            priority_none: 2,
-            priority_low: 1,
-            priority_medium: 3,
-            priority_high: 4,
-            no_due_date: 80,
-            overdue: 150,
-            not_recurring: 50,
-            today: 100,
-            now: 200,
-            deadline_value: Some(DEFAULT_DEADLINE_VALUE),
-            deadline_days: Some(DEFAULT_DEADLINE_DAYS),
+impl SortKey {
+    pub fn default_order() -> Vec<SortKey> {
+        vec![
+            SortKey::Priority,
+            SortKey::DueDate,
+            SortKey::Overdue,
+            SortKey::Today,
+            SortKey::Now,
+            SortKey::NoDueDate,
+            SortKey::NotRecurring,
+            SortKey::Deadline,
+            SortKey::Order,
+        ]
+    }
+
+    fn config_name(self) -> &'static str {
+        match self {
+            SortKey::Priority => "priority",
+            SortKey::DueDate => "due_date",
+            SortKey::Overdue => "overdue",
+            SortKey::Today => "today",
+            SortKey::Now => "now",
+            SortKey::NoDueDate => "no_due_date",
+            SortKey::NotRecurring => "not_recurring",
+            SortKey::Deadline => "deadline",
+            SortKey::Order => "order",
+        }
+    }
+
+    fn from_config_name(value: &str) -> Option<Self> {
+        match value {
+            "priority" => Some(SortKey::Priority),
+            "due_date" => Some(SortKey::DueDate),
+            "overdue" => Some(SortKey::Overdue),
+            "today" => Some(SortKey::Today),
+            "now" => Some(SortKey::Now),
+            "no_due_date" => Some(SortKey::NoDueDate),
+            "not_recurring" => Some(SortKey::NotRecurring),
+            "deadline" => Some(SortKey::Deadline),
+            "order" => Some(SortKey::Order),
+            _ => None,
+        }
+    }
+
+    fn default_direction(self) -> SortDirection {
+        match self {
+            SortKey::Priority
+            | SortKey::Overdue
+            | SortKey::Today
+            | SortKey::Now
+            | SortKey::NoDueDate
+            | SortKey::NotRecurring => SortDirection::Desc,
+            SortKey::DueDate | SortKey::Deadline | SortKey::Order => SortDirection::Asc,
         }
     }
 }
 
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum SortDirection {
+    Asc,
+    Desc,
+}
+
+impl SortDirection {
+    fn config_name(self) -> &'static str {
+        match self {
+            SortDirection::Asc => "asc",
+            SortDirection::Desc => "desc",
+        }
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub struct SortRule {
+    pub key: SortKey,
+    pub direction: SortDirection,
+}
+
+impl SortRule {
+    pub fn new(key: SortKey, direction: SortDirection) -> Self {
+        Self { key, direction }
+    }
+
+    pub(crate) fn with_default_direction(key: SortKey) -> Self {
+        Self::new(key, key.default_direction())
+    }
+
+    pub fn default_order() -> Vec<Self> {
+        SortKey::default_order()
+            .into_iter()
+            .map(Self::with_default_direction)
+            .collect()
+    }
+}
+
+impl Serialize for SortRule {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!(
+            "{}:{}",
+            self.key.config_name(),
+            self.direction.config_name()
+        ))
+    }
+}
+
+impl<'de> Deserialize<'de> for SortRule {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        let (key, direction) = match value.split_once(':') {
+            Some((key, "asc")) => (key, Some(SortDirection::Asc)),
+            Some((key, "desc")) => (key, Some(SortDirection::Desc)),
+            Some((_, direction)) => {
+                return Err(D::Error::custom(format!(
+                    "invalid sort direction '{direction}'; expected 'asc' or 'desc'"
+                )));
+            }
+            None => (value.as_str(), None),
+        };
+        let key = SortKey::from_config_name(key)
+            .ok_or_else(|| D::Error::custom(format!("invalid sort key '{key}'")))?;
+
+        Ok(match direction {
+            Some(direction) => SortRule::new(key, direction),
+            None => SortRule::with_default_direction(key),
+        })
+    }
+}
+
 impl Config {
+    fn with_default_sort_order(self) -> Config {
+        if self.sort_order.is_some() {
+            self
+        } else if let Some(sort_order) =
+            legacy::detect_and_migrate_sort_value(self.sort_value.as_ref())
+        {
+            Config {
+                sort_order: Some(sort_order),
+                ..self
+            }
+        } else {
+            Config {
+                sort_order: Some(SortRule::default_order()),
+                ..self
+            }
+        }
+    }
+
     /// Pretty printed message for how to get API token
     pub fn token_message(self: &Config) -> String {
         let url = maybe_format_url(TODOIST_INTEGRATIONS_URL, self);
@@ -296,7 +428,8 @@ impl Config {
             timeout: None,
             bell_on_success: false,
             bell_on_failure: true,
-            sort_value: Some(SortValue::default()),
+            sort_order: Some(SortRule::default_order()),
+            sort_value: None,
             timezone: None,
             completed: None,
             disable_links: false,
@@ -350,22 +483,6 @@ impl Config {
         self.next_task.clone()
     }
 
-    pub(crate) fn deadline_days(&self) -> u8 {
-        self.sort_value
-            .clone()
-            .unwrap_or_default()
-            .deadline_days
-            .unwrap_or(DEFAULT_DEADLINE_DAYS)
-    }
-
-    pub(crate) fn deadline_value(&self) -> u8 {
-        self.sort_value
-            .clone()
-            .unwrap_or_default()
-            .deadline_value
-            .unwrap_or(DEFAULT_DEADLINE_VALUE)
-    }
-
     pub async fn set_token(&mut self, access_token: String) -> Result<String, Error> {
         self.token = Some(access_token);
         self.save().await
@@ -415,6 +532,7 @@ impl Config {
 
             // this is not implemented as it will be deprecated
             sort_value: _,
+            sort_order: _,
 
             // We don't want user to set the ones below
             args: _,
@@ -596,7 +714,8 @@ impl Default for Config {
             task_comment_command: None,
             task_exclude_regex: None,
             comment_exclude_regex: None,
-            sort_value: Some(SortValue::default()),
+            sort_order: None,
+            sort_value: None,
             timezone: None,
             completed: None,
             disable_links: false,
@@ -639,7 +758,8 @@ mod tests {
                     timeout: None,
                 },
                 internal: Internal { tx: None },
-                sort_value: Some(SortValue::default()),
+                sort_order: Some(SortRule::default_order()),
+                sort_value: None,
                 projects: Some(vec![]),
                 next_id: None,
                 next_task: None,
@@ -796,11 +916,9 @@ mod tests {
         let internal_debug = format!("{internal:?}");
         assert!(internal_debug.contains("Internal"));
 
-        let sort_value = SortValue::default();
-        let sort_value_debug = format!("{sort_value:?}");
-        assert!(sort_value_debug.contains("SortValue"));
-        assert!(sort_value_debug.contains("priority_none"));
-        assert!(sort_value_debug.contains("deadline_value"));
+        let sort_key = SortKey::Priority;
+        let sort_key_debug = format!("{sort_key:?}");
+        assert!(sort_key_debug.contains("Priority"));
     }
 
     #[test]
@@ -816,9 +934,9 @@ mod tests {
         let internal_clone = internal.clone();
         assert_eq!(internal.tx.is_none(), internal_clone.tx.is_none());
 
-        let sort_value = SortValue::default();
-        let sort_value_clone = sort_value.clone();
-        assert_eq!(sort_value, sort_value_clone);
+        let sort_key = SortKey::Priority;
+        let sort_key_copy = sort_key;
+        assert_eq!(sort_key, sort_key_copy);
 
         assert_eq!(
             args,
@@ -842,9 +960,7 @@ mod tests {
         let default_internal = Internal::default();
         assert!(default_internal.tx.is_none());
 
-        let default_sort = SortValue::default();
-        assert_eq!(default_sort.priority_none, 2);
-        assert_eq!(default_sort.deadline_value, Some(DEFAULT_DEADLINE_VALUE));
+        assert_eq!(SortKey::default_order().first(), Some(&SortKey::Priority));
     }
 
     #[tokio::test]

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -1,0 +1,89 @@
+use crate::config::{SortKey, SortRule};
+use serde::{Deserialize, Serialize};
+use std::sync::Once;
+
+static SORT_VALUE_WARNING: Once = Once::new();
+
+#[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct LegacySortValue {
+    pub priority_none: Option<u8>,
+    pub priority_low: Option<u8>,
+    pub priority_medium: Option<u8>,
+    pub priority_high: Option<u8>,
+    pub no_due_date: Option<u8>,
+    pub not_recurring: Option<u8>,
+    pub today: Option<u8>,
+    pub overdue: Option<u8>,
+    pub now: Option<u8>,
+    pub deadline_value: Option<u8>,
+    pub deadline_days: Option<u8>,
+}
+
+pub(crate) fn detect_and_migrate_sort_value(
+    sort_value: Option<&LegacySortValue>,
+) -> Option<Vec<SortRule>> {
+    let sort_value = sort_value?;
+    SORT_VALUE_WARNING.call_once(|| {
+        eprintln!(
+            "Legacy sort_value config detected; migrating to sort_order. \
+             Please update your config because sort_value will be removed in a future version."
+        );
+    });
+
+    let priority = [
+        sort_value.priority_none,
+        sort_value.priority_low,
+        sort_value.priority_medium,
+        sort_value.priority_high,
+    ]
+    .into_iter()
+    .flatten()
+    .max()
+    .unwrap_or_default();
+
+    let mut weighted_keys = vec![
+        (SortKey::Priority, priority),
+        (SortKey::Overdue, sort_value.overdue.unwrap_or_default()),
+        (SortKey::Today, sort_value.today.unwrap_or_default()),
+        (SortKey::Now, sort_value.now.unwrap_or_default()),
+        (
+            SortKey::NoDueDate,
+            sort_value.no_due_date.unwrap_or_default(),
+        ),
+        (
+            SortKey::NotRecurring,
+            sort_value.not_recurring.unwrap_or_default(),
+        ),
+        (
+            SortKey::Deadline,
+            sort_value.deadline_value.unwrap_or_default(),
+        ),
+    ];
+
+    weighted_keys.sort_by(|(left_key, left_weight), (right_key, right_weight)| {
+        right_weight
+            .cmp(left_weight)
+            .then_with(|| sort_key_default_index(left_key).cmp(&sort_key_default_index(right_key)))
+    });
+
+    let mut keys: Vec<SortKey> = weighted_keys.into_iter().map(|(key, _)| key).collect();
+    for default_key in SortKey::default_order() {
+        if !keys.contains(&default_key) {
+            keys.push(default_key);
+        }
+    }
+
+    Some(
+        keys.into_iter()
+            .map(SortRule::with_default_direction)
+            .collect(),
+    )
+}
+
+fn sort_key_default_index(key: &SortKey) -> usize {
+    SortKey::default_order()
+        .iter()
+        .position(|default_key| default_key == key)
+        .unwrap_or(usize::MAX)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ mod errors;
 mod filters;
 mod input;
 mod labels;
+mod legacy;
 mod lists;
 mod oauth;
 mod projects;

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -271,12 +271,10 @@ impl Task {
             Ok(DateTimeInfo::Date { date, .. }) => {
                 let naive_datetime = date.and_hms_opt(23, 59, 00)?;
 
-                let now = time::datetime_now(config).ok()?;
+                let tz_string = config.get_timezone().ok()?;
+                let tz = time::timezone_from_str(&tz_string).ok()?;
 
-                Some(DateTime::from_naive_utc_and_offset(
-                    naive_datetime,
-                    *now.offset(),
-                ))
+                naive_datetime.and_local_timezone(tz).single()
             }
             Ok(DateTimeInfo::NoDateTime) | Err(_) => None,
         }
@@ -286,11 +284,11 @@ impl Task {
         let Deadline { date, .. } = self.deadline.as_ref()?;
         let date = time::date_string_to_naive_date(date).ok()?;
         let naive_datetime = date.and_hms_opt(23, 59, 00)?;
-        let now = time::datetime_now(config).ok()?;
-        Some(DateTime::from_naive_utc_and_offset(
-            naive_datetime,
-            *now.offset(),
-        ))
+
+        let tz_string = config.get_timezone().ok()?;
+        let tz = time::timezone_from_str(&tz_string).ok()?;
+
+        naive_datetime.and_local_timezone(tz).single()
     }
 
     /// Converts the JSON date representation into Date or Datetime

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -2,8 +2,7 @@ use chrono::DateTime;
 use chrono::NaiveDate;
 use chrono_tz::Tz;
 use serde::{Deserialize, Serialize};
-use std::cmp::Reverse;
-use std::cmp::max;
+use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::fmt::Display;
 use tokio::task::JoinHandle;
@@ -12,8 +11,9 @@ pub mod format;
 pub mod priority;
 use crate::comments::Comment;
 use crate::config::Config;
-use crate::config::SortValue;
-use crate::debug;
+#[cfg(test)]
+use crate::config::SortRule;
+use crate::config::{SortDirection, SortKey};
 use crate::errors::Error;
 use crate::input::CONTENT;
 use crate::input::DATE_AND_TIME;
@@ -191,7 +191,7 @@ enum DateTimeInfo {
 
 #[derive(clap::ValueEnum, Debug, Copy, Clone)]
 pub enum SortOrder {
-    /// Sort by Tod's configurable sort value
+    /// Sort by Tod's configured sort order
     Value,
     /// Sort by datetime only
     Datetime,
@@ -264,88 +264,7 @@ impl Task {
         ))
     }
 
-    /// Determines the numeric value of an task for sorting
-    fn value(&self, config: &Config) -> u32 {
-        let date_value: u8 = self.date_value(config);
-        let priority_value: u8 = self.priority_value(config);
-        let deadline_value: u32 = match self.deadline_value(config) {
-            Ok(value) => value,
-            Err(error) => {
-                config
-                    .clone()
-                    .tx()
-                    .send(error)
-                    .expect("Failed to send error message in task value calculation");
-                0
-            }
-        };
-
-        let value = u32::from(date_value) + u32::from(priority_value) + deadline_value;
-
-        let debug_text = format!("Value: {value}, Content: {}", self.content);
-        debug::maybe_print(config, &debug_text);
-        value
-    }
-
-    /// Return the value of the due field
-    fn date_value(&self, config: &Config) -> u8 {
-        let SortValue {
-            no_due_date,
-            today,
-            overdue,
-            now,
-            not_recurring,
-            ..
-        } = config.sort_value.clone().unwrap_or_default();
-
-        match &self.datetimeinfo(config) {
-            Ok(DateTimeInfo::NoDateTime) => no_due_date,
-            Ok(DateTimeInfo::Date {
-                date, is_recurring, ..
-            }) => {
-                let today_value = if *date == time::naive_date_today(config).unwrap_or_default() {
-                    today
-                } else {
-                    0
-                };
-                let overdue_value = if self.is_overdue(config).unwrap_or_default() {
-                    overdue
-                } else {
-                    0
-                };
-                let recurring_value = if is_recurring.to_owned() {
-                    0
-                } else {
-                    not_recurring
-                };
-                today_value + overdue_value + recurring_value
-            }
-            Ok(DateTimeInfo::DateTime {
-                datetime,
-                is_recurring,
-                ..
-            }) => {
-                let recurring_value = if is_recurring.to_owned() {
-                    0
-                } else {
-                    not_recurring
-                };
-
-                let duration = match time::datetime_now(config) {
-                    Ok(tz) => (*datetime - tz).num_minutes(),
-                    _ => 0,
-                };
-
-                match duration {
-                    -15..=15 => now + recurring_value,
-                    _ => recurring_value,
-                }
-            }
-            Err(_) => not_recurring,
-        }
-    }
-
-    /// Return the value of the due field
+    /// Return the task due date as a sortable datetime.
     fn datetime(&self, config: &Config) -> Option<DateTime<Tz>> {
         match self.datetimeinfo(config) {
             Ok(DateTimeInfo::DateTime { datetime, .. }) => Some(datetime),
@@ -363,35 +282,15 @@ impl Task {
         }
     }
 
-    fn priority_value(&self, config: &Config) -> u8 {
-        let SortValue {
-            priority_none,
-            priority_low,
-            priority_medium,
-            priority_high,
-            ..
-        } = config.sort_value.clone().unwrap_or_default();
-        match &self.priority {
-            Priority::None => priority_none,
-            Priority::Low => priority_low,
-            Priority::Medium => priority_medium,
-            Priority::High => priority_high,
-        }
-    }
-
-    fn deadline_value(&self, config: &Config) -> Result<u32, Error> {
-        match &self.deadline {
-            None => Ok(0),
-            Some(Deadline { date, .. }) => {
-                let naive_date = time::date_string_to_naive_date(date)?;
-                let days_from_today = time::naive_date_days_in_future(naive_date, config)?;
-                let deadline_days = config.deadline_days();
-                let day_multiplier =
-                    u32::try_from(max(i64::from(deadline_days) - days_from_today, 0))?;
-                let day_value = config.deadline_value();
-                Ok(day_multiplier * u32::from(day_value))
-            }
-        }
+    fn deadline_datetime(&self, config: &Config) -> Option<DateTime<Tz>> {
+        let Deadline { date, .. } = self.deadline.as_ref()?;
+        let date = time::date_string_to_naive_date(date).ok()?;
+        let naive_datetime = date.and_hms_opt(23, 59, 00)?;
+        let now = time::datetime_now(config).ok()?;
+        Some(DateTime::from_naive_utc_and_offset(
+            naive_datetime,
+            *now.offset(),
+        ))
     }
 
     /// Converts the JSON date representation into Date or Datetime
@@ -451,6 +350,17 @@ impl Task {
         };
 
         Ok(boolean)
+    }
+
+    fn is_now(&self, config: &Config) -> bool {
+        let Ok(DateTimeInfo::DateTime { datetime, .. }) = self.datetimeinfo(config) else {
+            return false;
+        };
+        let duration = match time::datetime_now(config) {
+            Ok(now) => (datetime - now).num_minutes(),
+            _ => return false,
+        };
+        matches!(duration, -15..=15)
     }
 
     pub fn is_overdue(&self, config: &Config) -> Result<bool, Error> {
@@ -941,8 +851,53 @@ pub fn spawn_update_task_priority(
 }
 
 pub fn sort_by_value(mut tasks: Vec<Task>, config: &Config) -> Vec<Task> {
-    tasks.sort_by_key(|b| Reverse(b.value(config)));
+    tasks.sort_by(|a, b| compare_by_sort_order(a, b, config));
     tasks
+}
+
+fn compare_by_sort_order(a: &Task, b: &Task, config: &Config) -> Ordering {
+    for rule in config.sort_order.as_deref().unwrap_or_default() {
+        let ordering = compare_by_sort_key(a, b, config, &rule.key);
+        if ordering != Ordering::Equal {
+            return match rule.direction {
+                SortDirection::Asc => ordering,
+                SortDirection::Desc => ordering.reverse(),
+            };
+        }
+    }
+
+    Ordering::Equal
+}
+
+fn compare_by_sort_key(a: &Task, b: &Task, config: &Config, key: &SortKey) -> Ordering {
+    match key {
+        SortKey::Priority => a.priority.to_integer().cmp(&b.priority.to_integer()),
+        SortKey::DueDate => compare_datetime(a.datetime(config), b.datetime(config)),
+        SortKey::Overdue => a
+            .is_overdue(config)
+            .unwrap_or_default()
+            .cmp(&b.is_overdue(config).unwrap_or_default()),
+        SortKey::Today => a
+            .is_today(config)
+            .unwrap_or_default()
+            .cmp(&b.is_today(config).unwrap_or_default()),
+        SortKey::Now => a.is_now(config).cmp(&b.is_now(config)),
+        SortKey::NoDueDate => a.has_no_date().cmp(&b.has_no_date()),
+        SortKey::NotRecurring => (!a.is_recurring()).cmp(&(!b.is_recurring())),
+        SortKey::Deadline => {
+            compare_datetime(a.deadline_datetime(config), b.deadline_datetime(config))
+        }
+        SortKey::Order => a.child_order.cmp(&b.child_order),
+    }
+}
+
+fn compare_datetime(a: Option<DateTime<Tz>>, b: Option<DateTime<Tz>>) -> Ordering {
+    match (a, b) {
+        (Some(a), Some(b)) => a.cmp(&b),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => Ordering::Equal,
+    }
 }
 
 pub fn sort_by_datetime(mut tasks: Vec<Task>, config: &Config) -> Vec<Task> {
@@ -1255,60 +1210,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn date_value_can_handle_date() {
-        let config = test::fixtures::config().await;
-        // On another day
-        assert_eq!(test::fixtures::today_task().await.date_value(&config), 50);
-
-        // Recurring
-        let task = Task {
-            due: Some(DateInfo {
-                is_recurring: true,
-                ..test::fixtures::today_task()
-                    .await
-                    .due
-                    .expect("Failed to unwrap due field in test fixtures for today_task")
-            }),
-            ..test::fixtures::today_task().await
-        };
-        assert_eq!(task.date_value(&config), 0);
-
-        // Overdue
-        let task = Task {
-            due: Some(DateInfo {
-                date: "2001-11-13".into(),
-                is_recurring: true,
-                lang: "en".into(),
-                timezone: Some("America/Los_Angeles".into()),
-                string: "Every 2 weeks".into(),
-            }),
-            ..test::fixtures::today_task().await
-        };
-        assert_eq!(task.date_value(&config), 150);
-
-        // No date
-        let task = Task { due: None, ..task };
-        assert_eq!(task.date_value(&config), 80);
-    }
-
-    #[tokio::test]
-    async fn date_value_can_handle_datetime() {
-        let config = test::fixtures::config().await;
-        let task = Task {
-            due: Some(DateInfo {
-                date: "2021-02-27T19:41:56Z".into(),
-                ..test::fixtures::today_task()
-                    .await
-                    .due
-                    .expect("Failed to unwrap due field in test fixtures for today_task")
-            }),
-            ..test::fixtures::today_task().await
-        };
-
-        assert_eq!(task.date_value(&config), 50);
-    }
-
-    #[tokio::test]
     async fn can_format_task_with_a_date() {
         let config = test::fixtures::config().await;
         let task = Task {
@@ -1359,23 +1260,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn value_can_get_the_value_of_an_task() {
-        let config = test::fixtures::config().await;
-        let task = Task {
-            due: Some(DateInfo {
-                date: "2021-09-06T16:00:00".into(),
-                ..test::fixtures::today_task()
-                    .await
-                    .due
-                    .expect("Failed to unwrap due field in test fixtures for today_task")
-            }),
-            ..test::fixtures::today_task().await
-        };
-
-        assert_matches!(task.datetime(&config), Some(DateTime { .. }));
-    }
-
-    #[tokio::test]
     async fn datetime_works_with_date() {
         let config = test::fixtures::config().await;
         let task = Task {
@@ -1391,6 +1275,28 @@ mod tests {
         };
 
         assert!(task.datetime(&config).is_some());
+    }
+
+    #[tokio::test]
+    async fn datetime_date_only_uses_config_timezone() {
+        let config = test::fixtures::config().await.with_timezone("Asia/Tokyo");
+        let task = Task {
+            due: Some(DateInfo {
+                date: "2025-05-10".into(),
+                is_recurring: false,
+                lang: "en".into(),
+                timezone: None,
+                string: "2025-05-10".into(),
+            }),
+            ..test::fixtures::today_task().await
+        };
+
+        assert_eq!(
+            task.datetime(&config)
+                .expect("date-only task should have a sortable datetime")
+                .to_rfc3339(),
+            "2025-05-10T23:59:00+09:00"
+        );
     }
 
     #[tokio::test]
@@ -1507,6 +1413,84 @@ mod tests {
         let result = vec![today, today_recurring, future];
 
         assert_eq!(sort_by_value(input, &config), result);
+    }
+
+    #[tokio::test]
+    async fn sort_by_value_preserves_api_order_after_configured_keys() {
+        let mut config = test::fixtures::config().await;
+        config.sort_order = Some(vec![SortRule::new(SortKey::Priority, SortDirection::Desc)]);
+
+        let low_early = Task {
+            id: "low-early".into(),
+            due: Some(DateInfo {
+                date: "2030-01-01".into(),
+                is_recurring: false,
+                lang: "en".into(),
+                string: "2030-01-01".into(),
+                timezone: None,
+            }),
+            priority: Priority::Low,
+            ..test::fixtures::today_task().await
+        };
+        let high_late = Task {
+            id: "high-late".into(),
+            due: Some(DateInfo {
+                date: "2030-12-31".into(),
+                is_recurring: false,
+                lang: "en".into(),
+                string: "2030-12-31".into(),
+                timezone: None,
+            }),
+            priority: Priority::High,
+            ..test::fixtures::today_task().await
+        };
+        let high_early = Task {
+            id: "high-early".into(),
+            due: Some(DateInfo {
+                date: "2030-01-01".into(),
+                is_recurring: false,
+                lang: "en".into(),
+                string: "2030-01-01".into(),
+                timezone: None,
+            }),
+            priority: Priority::High,
+            ..test::fixtures::today_task().await
+        };
+
+        let sorted = sort_by_value(
+            vec![low_early.clone(), high_late.clone(), high_early.clone()],
+            &config,
+        );
+
+        assert_eq!(sorted, vec![high_late, high_early, low_early]);
+    }
+
+    #[tokio::test]
+    async fn sort_by_value_uses_configured_direction() {
+        let mut config = test::fixtures::config().await;
+        config.sort_order = Some(vec![SortRule::new(SortKey::Order, SortDirection::Asc)]);
+
+        let second = Task {
+            id: "second".into(),
+            child_order: 2,
+            ..test::fixtures::today_task().await
+        };
+        let first = Task {
+            id: "first".into(),
+            child_order: 1,
+            ..test::fixtures::today_task().await
+        };
+
+        assert_eq!(
+            sort_by_value(vec![second.clone(), first.clone()], &config),
+            vec![first.clone(), second.clone()]
+        );
+
+        config.sort_order = Some(vec![SortRule::new(SortKey::Order, SortDirection::Desc)]);
+        assert_eq!(
+            sort_by_value(vec![first.clone(), second.clone()], &config),
+            vec![second, first]
+        );
     }
 
     #[tokio::test]
@@ -1804,46 +1788,5 @@ mod tests {
         let task = test::fixtures::today_task().await;
         let string = String::from("TEST");
         assert_eq!(string, task.to_string());
-    }
-    #[tokio::test]
-    async fn test_deadline_value_when_today() {
-        let config = test::fixtures::config().await;
-        let task = test::fixtures::today_task().await;
-        let value = task
-            .deadline_value(&config)
-            .expect("expected value or result, got None or Err");
-        assert_eq!(value, 150);
-    }
-
-    #[tokio::test]
-    async fn test_deadline_value_when_tomorrow() {
-        let config = test::fixtures::config().await;
-        let task = test::fixtures::task(1).await;
-
-        let value = task
-            .deadline_value(&config)
-            .expect("expected value or result, got None or Err");
-        assert_eq!(value, 120);
-    }
-
-    #[tokio::test]
-    async fn test_deadline_value_when_in_six_days() {
-        let config = test::fixtures::config().await;
-        let task = test::fixtures::task(6).await;
-
-        let value = task
-            .deadline_value(&config)
-            .expect("expected value or result, got None or Err");
-        assert_eq!(value, 0);
-    }
-    #[tokio::test]
-    async fn test_deadline_value_when_yesterday() {
-        let config = test::fixtures::config().await;
-        let task = test::fixtures::task(-1).await;
-
-        let value = task
-            .deadline_value(&config)
-            .expect("expected value or result, got None or Err");
-        assert_eq!(value, 180);
     }
 }

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -1372,6 +1372,87 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn is_now_handles_15_minute_boundaries() {
+        let config = test::fixtures::config().await;
+        let base_task = test::fixtures::today_task().await;
+
+        let minus_fifteen = Task {
+            due: Some(DateInfo {
+                date: "2025-05-10T02:45:00".into(),
+                is_recurring: false,
+                lang: "en".into(),
+                timezone: None,
+                string: "2025-05-10 02:45".into(),
+            }),
+            ..base_task.clone()
+        };
+        let plus_fifteen = Task {
+            due: Some(DateInfo {
+                date: "2025-05-10T03:15:00".into(),
+                is_recurring: false,
+                lang: "en".into(),
+                timezone: None,
+                string: "2025-05-10 03:15".into(),
+            }),
+            ..base_task.clone()
+        };
+        let outside_minus = Task {
+            due: Some(DateInfo {
+                date: "2025-05-10T02:44:00".into(),
+                is_recurring: false,
+                lang: "en".into(),
+                timezone: None,
+                string: "2025-05-10 02:44".into(),
+            }),
+            ..base_task.clone()
+        };
+        let outside_plus = Task {
+            due: Some(DateInfo {
+                date: "2025-05-10T03:16:00".into(),
+                is_recurring: false,
+                lang: "en".into(),
+                timezone: None,
+                string: "2025-05-10 03:16".into(),
+            }),
+            ..base_task
+        };
+
+        assert!(minus_fifteen.is_now(&config));
+        assert!(plus_fifteen.is_now(&config));
+        assert!(!outside_minus.is_now(&config));
+        assert!(!outside_plus.is_now(&config));
+    }
+
+    #[tokio::test]
+    async fn deadline_datetime_orders_correctly_in_positive_offset_timezone() {
+        let config = test::fixtures::config().await.with_timezone("Asia/Tokyo");
+        let base_task = test::fixtures::today_task().await;
+
+        let earlier_deadline = Task {
+            deadline: Some(Deadline {
+                date: "2025-05-10".into(),
+                lang: "en".into(),
+            }),
+            ..base_task.clone()
+        };
+        let later_deadline = Task {
+            deadline: Some(Deadline {
+                date: "2025-05-11".into(),
+                lang: "en".into(),
+            }),
+            ..base_task
+        };
+
+        assert_eq!(
+            compare_datetime(
+                earlier_deadline.deadline_datetime(&config),
+                later_deadline.deadline_datetime(&config),
+            ),
+            Ordering::Less
+        );
+    }
+
+    #[tokio::test]
     async fn sort_by_value_works() {
         let config = test::fixtures::config().await;
         let today = Task {

--- a/src/test/fixtures.rs
+++ b/src/test/fixtures.rs
@@ -74,48 +74,6 @@ pub async fn today_task() -> Task {
     }
 }
 
-pub async fn task(days_in_future: i64) -> Task {
-    let date = adjusted_date(days_in_future).await;
-    Task {
-        id: "6Xqhv4cwxgjwG9w8".into(),
-        section_id: None,
-        added_by_uid: Some("633166".into()),
-        added_at: Some(format!("{date}T22:29:34.404051Z")),
-        child_order: 1,
-        day_order: -1,
-        responsible_uid: None,
-        assigned_by_uid: None,
-        updated_at: Some(format!("{date}T22:32:46.415849Z")),
-        deadline: Some(Deadline {
-            lang: "en".into(),
-            date: date.clone(),
-        }),
-        completed_at: None,
-        is_collapsed: false,
-        user_id: "910".into(),
-        content: "TEST".into(),
-        checked: false,
-        duration: Some(Duration {
-            amount: 15,
-            unit: Unit::Minute,
-        }),
-        parent_id: None,
-        note_count: 0,
-        project_id: "6VRRxv8CM6GVmmgf".into(),
-        labels: vec!["computer".into()],
-        description: String::new(),
-        due: Some(DateInfo {
-            date: format!("{date}T12:00:00Z"),
-            lang: "en".into(),
-            is_recurring: false,
-            timezone: Some("America/Vancouver".into()),
-            string: format!("{date} 15:00"),
-        }),
-        priority: Priority::Medium,
-        is_deleted: false,
-    }
-}
-
 pub async fn config() -> Config {
     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel::<Error>();
 

--- a/tests/project_test_config
+++ b/tests/project_test_config
@@ -9,17 +9,5 @@
   "token": "123123",
   "update_check": true,
   "update_check_interval": 86400,
-  "sort_value": {
-    "deadline_days": 5,
-    "deadline_value": 30,
-    "no_due_date": 80,
-    "not_recurring": 50,
-    "now": 200,
-    "overdue": 150,
-    "priority_high": 4,
-    "priority_low": 1,
-    "priority_medium": 3,
-    "priority_none": 2,
-    "today": 100
-  }
+  "sort_order": ["priority:desc", "due_date:asc", "overdue:desc", "today:desc", "now:desc", "no_due_date:desc", "not_recurring:desc", "deadline:asc", "order:asc"]
 }


### PR DESCRIPTION
# 📦 Pull Request

## Summary

> Adds "sort_order" to config and sorts based on defined order instead of numeric value.

For now, remaps legacy sort_value to sort_order; future version will print deprecation message; then sort_value can be removed.

## PR Checklist

> Please confirm all items below before requesting a review (required for approval)

- [X] This PR/commit messages follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [X] All CI checks pass
- [X] Documentation is updated if necessary
- [X] This PR is tagged with any appropriate tags
- [X] This PR is ready for **review**  

Important note:

- All CI Checks must pass before PR is committed.
- All PRs must be reviewed before PR is committed.
- Only rebasing is allowed. Any merge commits in the chain will block PR from being commited.

## Related Issues

resolves #975 
