### PR TITLE
ci: dependabot fix

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -75,7 +75,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh pr merge ${{ github.event.pull_request.number }} \
-            --repo "${{ github.repository }}" \  
+            --repo "${{ github.repository }}" \
             --rebase --auto --delete-branch
 
       - name: Skip major updates


### PR DESCRIPTION
## Summary

Fixes the Dependabot auto-merge workflow, which was failing silently due to a trailing space after a backslash in the `gh pr merge` command.

## Why

A `\ ` (backslash + space) is not a valid shell line continuation — only `\` followed immediately by a newline works. This caused `--rebase --auto --delete-branch` to be interpreted as a separate invalid command, so `gh pr merge` never received those flags and auto-merge was never enabled.

The auto-approval step (tod-deploy) was working correctly; only the merge step was broken.

## Changes

- `.github/workflows/dependabot_auto_merge.yml`: remove trailing space after `\` on the `--repo` line of the `gh pr merge` command