### PR TITLE
feat: add `tod auth token` command and E2E Todoist CI workflow

### DIFF
--- a/.github/workflows/e2e_todoist.yml
+++ b/.github/workflows/e2e_todoist.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         run: rustup toolchain install stable
@@ -66,12 +66,18 @@ jobs:
       # start with an empty project.
       - name: Pre-test cleanup — empty Tod_DEV_CI of any leftover tasks
         run: |
+          set -euo pipefail
           echo "Checking for leftover tasks..."
           for i in $(seq 1 20); do
             output=$($TOD_BIN --config "$TOD_CONFIG" task next --project "$TOD_PROJECT" 2>&1)
             echo "$output"
             if echo "$output" | grep -q "No tasks on list"; then
               echo "✓ Project is already clean"
+              break
+            fi
+            # Only complete tasks we created; bail if we find a non-E2E task
+            if ! echo "$output" | grep -q "\[E2E\]"; then
+              echo "WARNING: Unexpected non-E2E task found — stopping pre-cleanup to avoid data loss"
               break
             fi
             echo "Completing leftover task $i..."

--- a/.github/workflows/e2e_todoist.yml
+++ b/.github/workflows/e2e_todoist.yml
@@ -77,8 +77,8 @@ jobs:
             fi
             # Only complete tasks we created; bail if we find a non-E2E task
             if ! echo "$output" | grep -q "\[E2E\]"; then
-              echo "WARNING: Unexpected non-E2E task found — stopping pre-cleanup to avoid data loss"
-              break
+              echo "FAIL: Unexpected non-E2E task found in $TOD_PROJECT; refusing to continue"
+              exit 1
             fi
             echo "Completing leftover task $i..."
             $TOD_BIN --config "$TOD_CONFIG" task complete

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -36,6 +36,7 @@ Commands:
   task     (t) Commands for individual tasks
   list     (l) Commands for multiple tasks
   config   (c) Commands around configuration and the app
+  auth     (a) Commands for logging in with OAuth or setting an API token
   help     Print this message or the help of the given subcommand(s)
 
 Options:
@@ -48,27 +49,28 @@ Options:
 And also use it to dig into subcommands
 
 ```bash
-> tod task -h
+> tod auth -h
 
-Commands for individual tasks
+Commands for logging in with OAuth or setting an API token
 
-Usage: tod task <COMMAND>
+Usage: tod auth <COMMAND>
 
 Commands:
-  quick-add  (q) Create a new task using NLP
-  create     (c) Create a new task (without NLP)
-  edit       (e) Edit an existing task's content
-  next       (n) Get the next task by priority
-  complete   (o) Complete the last task fetched with the next command
-  help       Print this message or the help of the given subcommand(s)
-
-Options:
-  -h, --help  Print help
+  login  (l) Log into Todoist using OAuth
+  api    (a) Save a Todoist developer API token directly to the config (non-interactive)
+  help   Print this message or the help of the given subcommand(s)
 ```
 
 ## Usage Examples
 
 ```bash
+# Set your Todoist API token directly (non-interactive, great for CI/scripting)
+tod auth api --token YOUR_API_TOKEN
+
+# Log in with OAuth (interactive, opens a browser)
+tod auth login
+
+
 # Quickly create a task
 tod task quick-add --content Buy more milk today
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -49,6 +49,25 @@ Options:
 And also use it to dig into subcommands
 
 ```bash
+> tod task -h
+
+Commands for individual tasks
+
+Usage: tod task <COMMAND>
+
+Commands:
+  quick-add  (q) Create a new task using NLP
+  create     (c) Create a new task (without NLP)
+  edit       (e) Edit an existing task's content
+  next       (n) Get the next task by priority
+  complete   (o) Complete the last task fetched with the next command
+  help       Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+```
+
+```bash
 > tod auth -h
 
 Commands for logging in with OAuth or setting an API token
@@ -69,7 +88,6 @@ tod auth token YOUR_API_TOKEN
 
 # Log in with OAuth (interactive, opens a browser)
 tod auth login
-
 
 # Quickly create a task
 tod task quick-add --content Buy more milk today

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -57,7 +57,7 @@ Usage: tod auth <COMMAND>
 
 Commands:
   login  (l) Log into Todoist using OAuth
-  api    (a) Save a Todoist developer API token directly to the config (non-interactive)
+  token  (t) Save a Todoist developer API token directly to the config (non-interactive)
   help   Print this message or the help of the given subcommand(s)
 ```
 
@@ -65,7 +65,7 @@ Commands:
 
 ```bash
 # Set your Todoist API token directly (non-interactive, great for CI/scripting)
-tod auth api --token YOUR_API_TOKEN
+tod auth token YOUR_API_TOKEN
 
 # Log in with OAuth (interactive, opens a browser)
 tod auth login

--- a/src/commands/auth_commands.rs
+++ b/src/commands/auth_commands.rs
@@ -1,16 +1,115 @@
-use crate::{config::Config, errors::Error, oauth};
+use crate::{color, config::{self, Config}, errors::Error, oauth};
 use clap::{Parser, Subcommand};
+use std::path::PathBuf;
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum AuthCommands {
     #[clap(alias = "l")]
     /// (l) Log into Todoist using OAuth
     Login(Login),
+
+    #[clap(alias = "a")]
+    /// (a) Save a Todoist developer API token directly to the config (non-interactive)
+    Api(Api),
 }
 
 #[derive(Parser, Debug, Clone)]
 pub struct Login {}
 
+#[derive(Parser, Debug, Clone)]
+pub struct Api {
+    #[arg(short, long)]
+    /// Todoist developer API token from https://todoist.com/prefs/integrations
+    token: String,
+}
+
 pub async fn login(config: &mut Config, _args: &Login) -> Result<String, Error> {
     oauth::login(config, None).await
+}
+
+/// Saves the given Todoist API token to the config without any interactive prompts.
+///
+/// Creates the config file at `config_path` (or the platform default) if it does not yet exist.
+/// Timezone and other settings are left at their defaults and will be filled in automatically
+/// on the next command that contacts the Todoist API.
+pub async fn api(config_path: Option<PathBuf>, args: &Api) -> Result<String, Error> {
+    let Api { token } = args;
+    let path = config::resolve_path_or_default(config_path).await?;
+
+    let mut config = match Config::load(&path).await {
+        Ok(existing) => existing,
+        Err(_) => {
+            // Config doesn't exist yet — create a blank file with default settings.
+            // No interactive prompts are triggered here.
+            Config::new(None, path.clone()).await?.create().await?
+        }
+    };
+
+    config.set_token(token.clone()).await?;
+    Ok(color::green_string(&format!(
+        "✓ API token saved to {}",
+        path.display()
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn test_api_creates_config_and_saves_token() {
+        let dir = tempdir().expect("temp dir should be created");
+        let path = dir.path().join("tod.cfg");
+
+        let args = Api {
+            token: "test-api-token-123".to_string(),
+        };
+
+        let result = api(Some(path.clone()), &args)
+            .await
+            .expect("api command should succeed");
+
+        assert!(result.contains("✓"), "should return success checkmark");
+
+        let config = Config::load(&path)
+            .await
+            .expect("config should be readable after api command");
+        assert_eq!(
+            config.token,
+            Some("test-api-token-123".to_string()),
+            "token should be saved in config"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_api_updates_existing_config_token() {
+        let dir = tempdir().expect("temp dir should be created");
+        let path = dir.path().join("tod.cfg");
+
+        // Create a config with an initial token
+        let initial = Api {
+            token: "old-token".to_string(),
+        };
+        api(Some(path.clone()), &initial)
+            .await
+            .expect("first api call should succeed");
+
+        // Update with a new token
+        let updated = Api {
+            token: "new-token".to_string(),
+        };
+        api(Some(path.clone()), &updated)
+            .await
+            .expect("second api call should succeed");
+
+        let config = Config::load(&path)
+            .await
+            .expect("config should be readable");
+        assert_eq!(
+            config.token,
+            Some("new-token".to_string()),
+            "token should be updated in config"
+        );
+    }
 }

--- a/src/commands/auth_commands.rs
+++ b/src/commands/auth_commands.rs
@@ -5,7 +5,7 @@ use crate::{
     oauth,
 };
 use clap::{Parser, Subcommand};
-use std::path::PathBuf;
+use std::{io::ErrorKind, path::PathBuf};
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum AuthCommands {
@@ -40,13 +40,14 @@ pub async fn token(config_path: Option<PathBuf>, args: &Token) -> Result<String,
     let Token { key } = args;
     let path = config::resolve_path_or_default(config_path).await?;
 
-    let mut config = match Config::load(&path).await {
-        Ok(existing) => existing,
-        Err(_) => {
+    let mut config = match tokio::fs::metadata(&path).await {
+        Err(e) if e.kind() == ErrorKind::NotFound => {
             // Config doesn't exist yet — create a blank file with default settings.
             // No interactive prompts are triggered here.
             Config::new(None, path.clone()).await?.create().await?
         }
+        Err(e) => return Err(e.into()),
+        Ok(_) => Config::load(&path).await?,
     };
 
     config.set_token(key.clone()).await?;
@@ -62,7 +63,7 @@ mod tests {
     use tempfile::tempdir;
 
     #[tokio::test]
-    async fn test_api_creates_config_and_saves_token() {
+    async fn test_token_creates_config_and_saves_token() {
         let dir = tempdir().expect("temp dir should be created");
         let path = dir.path().join("tod.cfg");
 
@@ -72,13 +73,13 @@ mod tests {
 
         let result = token(Some(path.clone()), &args)
             .await
-            .expect("api command should succeed");
+            .expect("token command should succeed");
 
         assert!(result.contains("✓"), "should return success checkmark");
 
         let config = Config::load(&path)
             .await
-            .expect("config should be readable after api command");
+            .expect("config should be readable after token command");
         assert_eq!(
             config.token,
             Some("test-api-token-123".to_string()),
@@ -87,7 +88,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_api_updates_existing_config_token() {
+    async fn test_token_updates_existing_config_token() {
         let dir = tempdir().expect("temp dir should be created");
         let path = dir.path().join("tod.cfg");
 

--- a/src/commands/auth_commands.rs
+++ b/src/commands/auth_commands.rs
@@ -1,4 +1,9 @@
-use crate::{color, config::{self, Config}, errors::Error, oauth};
+use crate::{
+    color,
+    config::{self, Config},
+    errors::Error,
+    oauth,
+};
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 

--- a/src/commands/auth_commands.rs
+++ b/src/commands/auth_commands.rs
@@ -49,9 +49,10 @@ pub async fn token(config_path: Option<PathBuf>, args: &Token) -> Result<String,
 
     let mut config = match tokio::fs::metadata(&path).await {
         Err(e) if e.kind() == ErrorKind::NotFound => {
-            // Config doesn't exist yet — create a blank file with default settings.
-            // No interactive prompts are triggered here.
-            Config::new(None, path.clone()).await?.create().await?
+            // Config doesn't exist yet — touch the file and let set_token() perform first save.
+            let config = Config::new(None, path.clone()).await?;
+            config.touch_file().await?;
+            config
         }
         Err(e) => return Err(e.into()),
         Ok(_) => Config::load(&path).await?,

--- a/src/commands/auth_commands.rs
+++ b/src/commands/auth_commands.rs
@@ -38,6 +38,13 @@ pub async fn login(config: &mut Config, _args: &Login) -> Result<String, Error> 
 /// on the next command that contacts the Todoist API.
 pub async fn token(config_path: Option<PathBuf>, args: &Token) -> Result<String, Error> {
     let Token { key } = args;
+    let trimmed_key = key.trim();
+    if trimmed_key.is_empty() {
+        return Err(Error::new(
+            "auth token",
+            "Todoist API token cannot be empty or whitespace",
+        ));
+    }
     let path = config::resolve_path_or_default(config_path).await?;
 
     let mut config = match tokio::fs::metadata(&path).await {
@@ -50,7 +57,7 @@ pub async fn token(config_path: Option<PathBuf>, args: &Token) -> Result<String,
         Ok(_) => Config::load(&path).await?,
     };
 
-    config.set_token(key.clone()).await?;
+    config.set_token(trimmed_key.to_string()).await?;
     Ok(color::green_string(&format!(
         "✓ API token saved to {}",
         path.display()
@@ -115,6 +122,25 @@ mod tests {
             config.token,
             Some("new-token".to_string()),
             "token should be updated in config"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_token_rejects_empty_or_whitespace_key() {
+        let dir = tempdir().expect("temp dir should be created");
+        let path = dir.path().join("tod.cfg");
+
+        let empty = Token {
+            key: "   ".to_string(),
+        };
+
+        let error = token(Some(path), &empty)
+            .await
+            .expect_err("empty token should be rejected");
+        assert_eq!(error.source, "auth token");
+        assert!(
+            error.message.contains("cannot be empty or whitespace"),
+            "error message should explain empty/whitespace rejection"
         );
     }
 }

--- a/src/commands/auth_commands.rs
+++ b/src/commands/auth_commands.rs
@@ -8,19 +8,18 @@ pub enum AuthCommands {
     /// (l) Log into Todoist using OAuth
     Login(Login),
 
-    #[clap(alias = "a")]
-    /// (a) Save a Todoist developer API token directly to the config (non-interactive)
-    Api(Api),
+    #[clap(alias = "t")]
+    /// (t) Save a Todoist developer API token directly to the config (non-interactive)
+    Token(Token),
 }
 
 #[derive(Parser, Debug, Clone)]
 pub struct Login {}
 
 #[derive(Parser, Debug, Clone)]
-pub struct Api {
-    #[arg(short, long)]
+pub struct Token {
     /// Todoist developer API token from https://todoist.com/prefs/integrations
-    token: String,
+    key: String,
 }
 
 pub async fn login(config: &mut Config, _args: &Login) -> Result<String, Error> {
@@ -32,8 +31,8 @@ pub async fn login(config: &mut Config, _args: &Login) -> Result<String, Error> 
 /// Creates the config file at `config_path` (or the platform default) if it does not yet exist.
 /// Timezone and other settings are left at their defaults and will be filled in automatically
 /// on the next command that contacts the Todoist API.
-pub async fn api(config_path: Option<PathBuf>, args: &Api) -> Result<String, Error> {
-    let Api { token } = args;
+pub async fn token(config_path: Option<PathBuf>, args: &Token) -> Result<String, Error> {
+    let Token { key } = args;
     let path = config::resolve_path_or_default(config_path).await?;
 
     let mut config = match Config::load(&path).await {
@@ -45,7 +44,7 @@ pub async fn api(config_path: Option<PathBuf>, args: &Api) -> Result<String, Err
         }
     };
 
-    config.set_token(token.clone()).await?;
+    config.set_token(key.clone()).await?;
     Ok(color::green_string(&format!(
         "✓ API token saved to {}",
         path.display()
@@ -62,11 +61,11 @@ mod tests {
         let dir = tempdir().expect("temp dir should be created");
         let path = dir.path().join("tod.cfg");
 
-        let args = Api {
-            token: "test-api-token-123".to_string(),
+        let args = Token {
+            key: "test-api-token-123".to_string(),
         };
 
-        let result = api(Some(path.clone()), &args)
+        let result = token(Some(path.clone()), &args)
             .await
             .expect("api command should succeed");
 
@@ -88,20 +87,20 @@ mod tests {
         let path = dir.path().join("tod.cfg");
 
         // Create a config with an initial token
-        let initial = Api {
-            token: "old-token".to_string(),
+        let initial = Token {
+            key: "old-token".to_string(),
         };
-        api(Some(path.clone()), &initial)
+        token(Some(path.clone()), &initial)
             .await
-            .expect("first api call should succeed");
+            .expect("first token call should succeed");
 
         // Update with a new token
-        let updated = Api {
-            token: "new-token".to_string(),
+        let updated = Token {
+            key: "new-token".to_string(),
         };
-        api(Some(path.clone()), &updated)
+        token(Some(path.clone()), &updated)
             .await
-            .expect("second api call should succeed");
+            .expect("second token call should succeed");
 
         let config = Config::load(&path)
             .await

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -431,10 +431,10 @@ pub async fn select_command(
             )
         }
 
-        Commands::Auth(AuthCommands::Api(args)) => (
+        Commands::Auth(AuthCommands::Token(args)) => (
             false,
             false,
-            auth_commands::api(cli.config.clone(), args).await,
+            auth_commands::token(cli.config.clone(), args).await,
         ),
 
         // Shell

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -431,6 +431,12 @@ pub async fn select_command(
             )
         }
 
+        Commands::Auth(AuthCommands::Api(args)) => (
+            false,
+            false,
+            auth_commands::api(cli.config.clone(), args).await,
+        ),
+
         // Shell
         Commands::Shell(ShellCommands::Completions(args)) => {
             (true, true, shell_commands::completions(args).await)

--- a/src/config.rs
+++ b/src/config.rs
@@ -615,6 +615,11 @@ async fn resolve_config_path(config_path: Option<PathBuf>) -> Result<PathBuf, Er
         Some(path) => maybe_expand_home_dir(path),
     }
 }
+
+/// Public version of `resolve_config_path` for use outside this module (e.g. auth commands).
+pub async fn resolve_path_or_default(config_path: Option<PathBuf>) -> Result<PathBuf, Error> {
+    resolve_config_path(config_path).await
+}
 /// Fetches config from from disk and creates it if it doesn't exist
 /// Prompts for Todoist API token
 pub async fn get_or_create(

--- a/src/config.rs
+++ b/src/config.rs
@@ -616,8 +616,10 @@ async fn resolve_config_path(config_path: Option<PathBuf>) -> Result<PathBuf, Er
     }
 }
 
-/// Public version of `resolve_config_path` for use outside this module (e.g. auth commands).
-pub async fn resolve_path_or_default(config_path: Option<PathBuf>) -> Result<PathBuf, Error> {
+/// Crate-visible version of `resolve_config_path` for use across internal modules.
+pub(crate) async fn resolve_path_or_default(
+    config_path: Option<PathBuf>,
+) -> Result<PathBuf, Error> {
     resolve_config_path(config_path).await
 }
 /// Fetches config from from disk and creates it if it doesn't exist


### PR DESCRIPTION
# 📦 Pull Request

## Summary

Two related additions: a new `tod auth token <key>` command for non-interactive API token setup, and a manual E2E integration test workflow that exercises Tod end-to-end against the real Todoist API.

### `tod auth token <key>` (alias: `t`)

Currently the only way to authenticate is `tod auth login`, which opens a browser for OAuth -- making it unusable in CI or scripting contexts. This PR adds a second auth subcommand:

```bash
tod auth token YOUR_API_TOKEN
# or with aliases
tod a t YOUR_API_TOKEN
```

The command creates the config file from scratch (using `Config::new` + `Config::create`) if none exists yet, then sets the token and saves -- no prompts, no browser, no jq required. Timezone and other fields are populated automatically on the first API call. Two unit tests cover the create-from-scratch and update-existing paths.

A small public helper `config::resolve_path_or_default` is also exposed so the new command can do the same `~`-expansion as the rest of tod when a `--config` path is provided.

### E2E Todoist integration test (`.github/workflows/e2e_todoist.yml`)

A `workflow_dispatch`-only workflow that runs Tod as a real user would against the `Tod_DEV_CI` project in the dev Todoist account (secret: `TODOIST_DEV_API_TEST`):

1. Builds tod from source
2. Initialises config via `tod auth token "$TODOIST_API_TOKEN"`
3. Pre-cleans any stale tasks from prior failed runs
4. Creates four tasks covering every priority level (High/p4, Medium/p3, None/p1, Low/p2)
5. Asserts all four tasks appear in `list view`
6. Asserts the sort order via four `task next` / `task complete` cycles -- verifying the expected scores: High (134) > Medium (133) > None (132) > Low (131), where pts = `no_due_date(80) + not_recurring(50) + priority_value`
7. Asserts the project is empty after all completions
8. Always-runs cleanup loop completes any remaining `[E2E]` tasks and removes the temp config, leaving the Todoist account clean

The workflow uses `concurrency: cancel-in-progress: false` so parallel manual triggers can't corrupt shared Todoist state.

## PR Checklist

- [x] This PR/commit messages follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] All CI checks pass
- [x] Documentation is updated if necessary
- [x] This PR is tagged with any appropriate tags
- [x] This PR is ready for **review**

## Related Issues

N/A