### PR TITLE
fix: duplicate oAuth login

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,7 +26,7 @@
 
 If the config does not exist, Tod will prompt for your initial Todoist API token and create a default config with the following values:
 
-``` json
+```json
 {
   "bell_on_failure": true,
   "bell_on_success": false,
@@ -91,44 +91,53 @@ Run `tod config check` to validate the configuration file and optionally remove 
 
 ### bell_on_success
 
-``` json
+```yaml
+{
   type: boolean
   default: false
+}
 ```
 
 Triggers the terminal bell on successful completion of a command
 
 ### bell_on_failure
 
-``` json
+```yaml
+{
   type: boolean
   default: true
+}
 ```
 
 Triggers the terminal bell on an error
 
 ### disable_links
 
-``` json
+``` yaml
+{
   type: boolean
   default: false
+}
 ```
 
 If true, disables OSC8 linking and just displays plain text
 
 ### last_version_check
 
-``` json
-  type: nullable string
+``` yaml
+ {
+ type: nullable string
   default: null
   possible_values: any string in format YYYY-MM-DD
+ }
 ```
 
 Holds a string date, i.e. `"2023-08-30"` representing the last time crates.io was checked for the latest `tod` version. Tod will check crates.io a maximum of once per day.
 
 ### max_comment_length
 
-``` json
+```yaml
+  
   type: nullable positive integer
   default: null
   possible_values: Any positive integer or null
@@ -143,7 +152,7 @@ If not set, this is dynamically calculated at runtime based on terminal window s
 
 ### next_id
 
-``` json
+```yaml
   type: nullable string
   default: null
   possible values: null or any positive integer in string form
@@ -153,7 +162,7 @@ When `task next` is executed the ID is stored in this field. When `task complete
 
 ### path
 
-``` json
+```yaml
   type: string
   default: $XDG_CONFIG_HOME/tod.cfg
   possible values: Any path
@@ -173,7 +182,7 @@ If true, the datetime selection in `project schedule` will go straight to natura
 
 ### no_sections
 
-``` json
+``` yaml
   type: nullable boolean
   default: null
   possible values: null, true, or false
@@ -183,7 +192,7 @@ If true will not prompt for a section whenever possible
 
 ### projectsv1
 
-```json
+```yaml
   type: Nullable array of objects
   default: []
   possible values: List of project objects from the Todoist API
@@ -195,6 +204,7 @@ Projects are stored locally in config to help save on API requests and speed up 
 
 Deprecated in latest version, replaced with sort_order. Will be removed in future release.
 
+```json
     {
       "deadline_days": 5,
       "deadline_value": 30,
@@ -203,11 +213,12 @@ Deprecated in latest version, replaced with sort_order. Will be removed in futur
       "now": 200,
       "overdue": 150,
       "priority_high": 4,
-      "priority_low": 1,
       "priority_medium": 3,
-      "priority_none": 2,
+      "priority_low": 2,
+      "priority_none": 1,
       "today": 100
     }
+```
 
 ### sort_order
 
@@ -217,7 +228,7 @@ New config files include this default order: `priority:desc`, `due_date:asc`, `o
 
 The direction may be omitted to use the key's default. For example, `priority` is equivalent to `priority:desc`:
 
-``` json
+```yaml
   "sort_order": ["priority", "due_date:desc"]
 ```
 
@@ -227,7 +238,7 @@ Legacy configs that still contain `sort_value` will be accepted temporarily. Tod
 
 ### spinners
 
-``` json
+```yaml
   type: nullable boolean
   default: null
   possible values: null, true, or false
@@ -243,7 +254,7 @@ You can also use the environment variable `DISABLE_SPINNER` to turn them off.
 
 ### timeout
 
-```json
+```yaml
   type: integer
   default: 30 (seconds)
   possible values: Any positive number in seconds
@@ -251,7 +262,7 @@ You can also use the environment variable `DISABLE_SPINNER` to turn them off.
 
 ### timezone
 
-```json
+```yaml
   type: string
   default: No default
   possible values: Any timezone string i.e. "Canada/Pacific"
@@ -261,7 +272,7 @@ You will be prompted for timezone on first run
 
 ### token
 
-```json
+```yaml
   type: string
   default: No default
   possible values: Any valid token
@@ -271,7 +282,7 @@ You will be prompted for your [Todoist API token](https://todoist.com/prefs/inte
 
 ### timeprovider
 
-```json
+```yaml
   type: string
   default: No default
   possible values: Enum of SystemTimeProvider or FixedTimeProvider
@@ -281,7 +292,7 @@ Used for dev/testing only to return fixed time (fixture) for use in test cases. 
 
 ### task_comment_command
 
-``` json
+```yaml
 type: string
 default: null
 possible values: Any valid executable shell command (such as 'echo task commented')
@@ -293,7 +304,7 @@ Command output is suppressed while the hook runs so it cannot interfere with ter
 
 ### task_create_command
 
-``` json
+```yaml
 type: string
 default: null
 possible values: Any valid executable shell command (such as 'echo task created')
@@ -305,7 +316,7 @@ Command output is suppressed while the hook runs so it cannot interfere with ter
 
 ### task_complete_command
 
-``` json
+```yaml
 type: string
 default: null
 possible values: Any valid executable shell command (such as 'echo task completed')
@@ -317,7 +328,7 @@ Command output is suppressed while the hook runs so it cannot interfere with ter
 
 ### task_exclude_regex
 
-``` json
+```yaml
 type: Regex in String form (JSON escaped)  
 default: null
 possible values: Any valid Regex expression
@@ -329,7 +340,7 @@ For example, this could be used to exclude uncompletable tasks ("^* ").
 
 ### comment_exclude_regex
 
-``` json
+```yaml
 type: Regex in String form (JSON escaped)  
 default: null
 possible values: Any valid Regex expression
@@ -339,7 +350,7 @@ Defaults to `null` (no comments excluded). This field must be a valid JSON-escap
 
 ### verbose
 
-```json
+```yaml
   type: nullable boolean
   default: null
   possible values: null, true, or false

--- a/src/commands/auth_commands.rs
+++ b/src/commands/auth_commands.rs
@@ -31,22 +31,32 @@ pub async fn login(config: &mut Config, _args: &Login) -> Result<String, Error> 
     oauth::login(config, None).await
 }
 
+/// Loads the config for an explicit auth command, creating a valid empty config if needed.
+///
+/// Explicit auth commands choose their own authentication method, so config creation here must
+/// not run the interactive first-use authentication flow.
+pub(super) async fn load_or_create_config(config_path: Option<PathBuf>) -> Result<Config, Error> {
+    let path = config::resolve_config_path(config_path).await?;
+
+    match tokio::fs::metadata(&path).await {
+        Err(e) if e.kind() == ErrorKind::NotFound => {
+            let mut config = Config::new(None, path).await?;
+            config.touch_file().await?;
+            config.save().await?;
+            Ok(config)
+        }
+        Err(e) => Err(e.into()),
+        Ok(_) => config::get_config(Some(path)).await,
+    }
+}
+
 /// Saves the given Todoist API token to the config without any interactive prompts.
 ///
 /// Creates the config file at `config_path` (or the platform default) if it does not yet exist,
 /// then fetches and saves the account timezone with the provided token.
 pub async fn token(config_path: Option<PathBuf>, args: &Token) -> Result<String, Error> {
-    let path = config::resolve_config_path(config_path).await?;
-
-    let config = match tokio::fs::metadata(&path).await {
-        Err(e) if e.kind() == ErrorKind::NotFound => {
-            let config = Config::new(None, path.clone()).await?;
-            config.touch_file().await?;
-            config
-        }
-        Err(e) => return Err(e.into()),
-        Ok(_) => Config::load(&path).await?,
-    };
+    let config = load_or_create_config(config_path).await?;
+    let path = config.path.clone();
 
     config.set_developer_token(&args.key).await?;
     Ok(color::green_string(&format!(
@@ -57,8 +67,47 @@ pub async fn token(config_path: Option<PathBuf>, args: &Token) -> Result<String,
 
 #[cfg(test)]
 mod tests {
+    use super::load_or_create_config;
     use crate::config::Config;
     use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn load_or_create_config_creates_empty_config_without_authentication() {
+        let dir = tempdir().expect("temp dir should be created");
+        let path = dir.path().join("tod.cfg");
+
+        let config = load_or_create_config(Some(path.clone()))
+            .await
+            .expect("config should be created");
+
+        assert!(path.exists());
+        assert_eq!(config.path, path);
+        assert_eq!(config.token, None);
+        assert!(config.get_timezone().is_err());
+    }
+
+    #[tokio::test]
+    async fn load_or_create_config_preserves_existing_authentication() {
+        let dir = tempdir().expect("temp dir should be created");
+        let path = dir.path().join("tod.cfg");
+        let mut existing = Config::new(None, path.clone())
+            .await
+            .expect("config should be created")
+            .with_token("existing-token")
+            .with_timezone("UTC");
+        existing
+            .touch_file()
+            .await
+            .expect("config file should be created");
+        existing.save().await.expect("config should save");
+
+        let loaded = load_or_create_config(Some(path))
+            .await
+            .expect("config should load");
+
+        assert_eq!(loaded.token, Some("existing-token".to_string()));
+        assert_eq!(loaded.get_timezone().expect("timezone should load"), "UTC");
+    }
 
     #[tokio::test]
     async fn test_save_developer_token_updates_existing_config_token() {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -131,7 +131,7 @@ pub async fn select_command(cli: Cli, tx: UnboundedSender<Error>) -> Result<Comm
     }
 
     match &cli.command {
-        Commands::Auth(command) => auth_command(command, &cli, &tx).await,
+        Commands::Auth(command) => auth_command(command, &cli).await,
         Commands::Config(command) => config_command(command, &cli, &tx).await,
         Commands::List(command) => list_command(command, &cli, &tx).await,
         Commands::Project(command) => project_command(command, &cli, &tx).await,
@@ -358,17 +358,10 @@ async fn config_command(
     }
 }
 
-async fn auth_command(
-    command: &AuthCommands,
-    cli: &Cli,
-    tx: &UnboundedSender<Error>,
-) -> Result<CommandResult, Error> {
+async fn auth_command(command: &AuthCommands, cli: &Cli) -> Result<CommandResult, Error> {
     match command {
         AuthCommands::Login(args) => {
-            let mut config = match get_existing_config_exists(cli.config.clone()).await {
-                Ok(config) => config,
-                Err(_) => fetch_config(cli, tx).await?,
-            };
+            let mut config = auth_commands::load_or_create_config(cli.config.clone()).await?;
             let result = auth_commands::login(&mut config, args).await;
             build_command_result(result, config)
         }
@@ -432,14 +425,6 @@ async fn fetch_config(cli: &Cli, tx: &UnboundedSender<Error>) -> Result<Config, 
 
     let config = config.check_for_latest_version().await?;
     config.maybe_set_timezone().await
-}
-
-/// Only fetches the config if it exists, otherwise errors.
-async fn get_existing_config_exists(config_path: Option<PathBuf>) -> Result<Config, Error> {
-    match crate::config::get_config(config_path).await {
-        Ok(config) => Ok(config),
-        Err(e) => Err(e),
-    }
 }
 
 fn fetch_string(

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -186,11 +186,11 @@ fn maybe_expand_home_dir(path: PathBuf) -> Result<PathBuf, Error> {
 /// Deletes the config file after resolving its path and confirming with the user.
 pub async fn config_reset(cli_config_path: Option<PathBuf>, force: bool) -> Result<String, Error> {
     // Defer to the testable version, but use `inquire::Confirm` for interactive input to pass true/false.
-    config_reset_with_prompt(cli_config_path.clone(), force, || {
-        let path_display = cli_config_path
-            .as_ref()
-            .map_or_else(|| "<default path>".into(), |p| p.display().to_string());
-        let desc = &format!("Are you sure you want to delete the config at {path_display}?");
+    config_reset_with_prompt(cli_config_path, force, |path| {
+        let desc = &format!(
+            "Are you sure you want to delete the config at {}?",
+            path.display()
+        );
         input::confirm(desc).unwrap_or_default()
     })
     .await
@@ -203,7 +203,7 @@ pub async fn config_reset_with_prompt<F>(
     prompt_fn: F,
 ) -> Result<String, Error>
 where
-    F: FnOnce() -> bool,
+    F: FnOnce(&Path) -> bool,
 {
     let path = match cli_config_path {
         Some(p) => maybe_expand_home_dir(p)?,
@@ -214,7 +214,7 @@ where
         return Ok(format!("No config file found at {}.", path.display()));
     }
 
-    if !force && !prompt_fn() {
+    if !force && !prompt_fn(&path) {
         return Ok("Aborted: Config not deleted.".to_string());
     }
 
@@ -655,7 +655,7 @@ mod tests {
         assert!(temp_path.exists(), "Temp config should exist before reset");
 
         // Simulate user saying "yes"
-        let result = config_reset_with_prompt(Some(temp_path.clone()), false, || true).await;
+        let result = config_reset_with_prompt(Some(temp_path.clone()), false, |_| true).await;
 
         assert!(result.is_ok(), "Expected Ok, got {result:?}");
         let msg = result.expect("Could not get msg");
@@ -676,12 +676,30 @@ mod tests {
         assert!(temp_path.exists(), "Temp config should exist before reset");
 
         // Simulate user saying "no"
-        let result = config_reset_with_prompt(Some(temp_path.clone()), false, || false).await;
+        let result = config_reset_with_prompt(Some(temp_path.clone()), false, |_| false).await;
 
         assert!(result.is_ok(), "Expected Ok, got {result:?}");
         let msg = result.expect("Could not get reset config response");
         assert_eq!(msg, "Aborted: Config not deleted.");
         assert!(temp_path.exists(), "File should not be deleted after abort");
+    }
+
+    #[tokio::test]
+    async fn test_config_reset_prompt_receives_resolved_path() {
+        let (_temp_dir, temp_path) = temp_config_path("temp_test_config_prompt_path.cfg");
+        tokio::fs::File::create(&temp_path)
+            .await
+            .expect("Failed to create temp config file");
+        let mut prompted_path = None;
+
+        let result = config_reset_with_prompt(Some(temp_path.clone()), false, |path| {
+            prompted_path = Some(path.to_path_buf());
+            false
+        })
+        .await;
+
+        assert_eq!(result, Ok("Aborted: Config not deleted.".to_string()));
+        assert_eq!(prompted_path, Some(temp_path));
     }
 
     #[tokio::test]

--- a/tests/config_create.rs
+++ b/tests/config_create.rs
@@ -196,3 +196,38 @@ fn config_reset_force_when_config_absent_reports_not_found() {
         .success()
         .stdout(predicate::str::contains("No config file found at"));
 }
+
+/// `-c` passes an explicit config path through reset and reports that exact path on deletion.
+#[test]
+fn config_reset_force_with_short_config_flag_deletes_manual_path() {
+    let dir = tempdir().expect("temp dir should be created");
+    let path = dir.path().join("manual-tod.cfg");
+    fs::write(&path, "{}").expect("config should be written");
+    let expected = format!("Config file at {} deleted successfully.", path.display());
+
+    tod_command()
+        .arg("-c")
+        .arg(&path)
+        .args(["config", "reset", "--force"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(expected));
+
+    assert!(!path.exists(), "manual config path should be deleted");
+}
+
+/// `-c` reports the explicit path when reset is requested for a missing config.
+#[test]
+fn config_reset_force_with_short_config_flag_reports_missing_manual_path() {
+    let dir = tempdir().expect("temp dir should be created");
+    let path = dir.path().join("missing-manual-tod.cfg");
+    let expected = format!("No config file found at {}.", path.display());
+
+    tod_command()
+        .arg("-c")
+        .arg(&path)
+        .args(["config", "reset", "--force"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(expected));
+}


### PR DESCRIPTION
Moves timezone to auth step to fix duplicate Oauth reqeust. 

fixes #1672 

Note: This separates token to "auth token" - "auth login" is now oAuth only.

# 📦 Pull Request

## Summary

> Moves timezone to auth step to fix duplicat eoAuth

## PR Checklist

> Please confirm all items below before requesting a review (required for approval)

- [X] This PR/commit messages follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [X] All CI checks pass
- [X] Documentation is updated if necessary
- [X] This PR is tagged with any appropriate tags
- [X] This PR is ready for **review**  

Important note:

- All CI Checks must pass before PR is committed.
- All PRs must be reviewed before PR is committed.
- Only rebasing is allowed. Any merge commits in the chain will block PR from being commited.
