### PR TITLE
fix: restore windows test compatibility

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -97,6 +97,7 @@ pub(crate) fn generate_completions(shell: Shell) {
 mod tests {
     use super::*;
     use assert_cmd::Command;
+    #[cfg(unix)]
     use predicates::prelude::*;
     // Contains is used to make CMD test cases cross-platform compatible
     use predicates::str::contains;

--- a/tests/config_create.rs
+++ b/tests/config_create.rs
@@ -1,5 +1,6 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
+use serde_json::json;
 use std::fs;
 use tempfile::tempdir;
 
@@ -8,15 +9,16 @@ fn tod_command() -> Command {
 }
 
 fn write_config_with_timezone(path: &std::path::Path, token: Option<&str>) {
-    let token = token
-        .map(|token| format!(r#","token":"{token}""#))
-        .unwrap_or_default();
-    let path_value = path.to_string_lossy();
-    fs::write(
-        path,
-        format!(r#"{{"path":"{path_value}","timezone":"UTC"{token}}}"#),
-    )
-    .expect("config should be written");
+    let mut config = json!({
+        "path": path.to_string_lossy(),
+        "timezone": "UTC",
+    });
+
+    if let Some(token) = token {
+        config["token"] = json!(token);
+    }
+
+    fs::write(path, config.to_string()).expect("config should be written");
 }
 
 // --- Config creation via `auth token` (the non-interactive creation path) ---


### PR DESCRIPTION
# 📦 Pull Request

## Summary

> Briefly describe what this PR does and what it changes.

## PR Checklist

Fixes #1671 by using serde_json instead of writing the config directly with the changes instead of fs::write.