### PR TITLE
ci: fix for code scanning alert no. 128: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     uses: ./.github/workflows/_reusable-lint.yml

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -12,6 +12,10 @@ on:
     types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Updated CI workflows alerted on scan permissions. Simplel fix for [https://github.com/tod-org/tod/security/code-scanning/128](https://github.com/tod-org/tod/security/code-scanning/128)

Add an explicit top-level `permissions` block in `.github/workflows/ci-release.yml` so all jobs in this workflow get least-privilege defaults unless overridden.  
Best minimal fix without changing functionality is:

- `contents: read` (standard for checkout/read access)
- `packages: read` (safe/read-only for package pulls if needed by called workflows)

Place it at workflow root (after `on:` is a common location), so it applies to:
- `is-release-pr`
- reusable workflow calls `full-matrix-test` and `e2e` (unless those workflows override permissions internally)

No imports/dependencies/methods are needed; this is pure YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
