### PR TITLE
fix: Cleanup and refactor config and auth workflows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,9 +109,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.1"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
@@ -190,15 +190,15 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bstr"
-version = "1.12.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -213,15 +213,15 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -237,9 +237,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -315,7 +315,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -404,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -414,18 +414,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -473,7 +473,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -517,7 +517,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -680,7 +680,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -741,11 +741,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -755,9 +753,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -830,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -840,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1141,7 +1141,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1160,16 +1160,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -1279,9 +1279,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mime"
@@ -1291,9 +1291,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
@@ -1318,7 +1318,7 @@ dependencies = [
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand 0.9.4",
+ "rand 0.9.5",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -1544,15 +1544,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1566,16 +1567,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1601,9 +1602,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -1644,6 +1645,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rayon"
@@ -1812,9 +1822,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -1887,9 +1897,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -1977,7 +1987,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2022,7 +2032,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2085,9 +2095,9 @@ dependencies = [
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -2125,9 +2135,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2196,7 +2206,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2224,9 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2250,7 +2260,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2320,14 +2330,14 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -2344,9 +2354,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2403,9 +2413,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.4"
+version = "1.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317fafbbe3f02fc663dad00ea6186197de963cd4190e86a26d8d0fae095539af"
+checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
 dependencies = [
  "bytes",
  "libc",
@@ -2420,13 +2430,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2681,7 +2691,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -2839,7 +2849,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2850,7 +2860,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2928,7 +2938,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2937,16 +2947,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2964,31 +2965,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3007,22 +2991,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3031,22 +3003,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3055,22 +3015,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3079,22 +3027,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -3133,28 +3069,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3174,7 +3110,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -3214,11 +3150,11 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # rust-toolchain.toml
 
 [toolchain]
-channel = "1.97.0"
+channel = "1.97.1"
 components = ["clippy", "rustfmt"]

--- a/src/commands/auth_commands.rs
+++ b/src/commands/auth_commands.rs
@@ -22,7 +22,7 @@ pub struct Login {}
 
 #[derive(Parser, Debug, Clone)]
 pub struct Token {
-    /// Todoist developer API token from https://todoist.com/prefs/integrations
+    /// Todoist developer API token from <https://todoist.com/prefs/integrations>
     key: String,
 }
 

--- a/src/commands/config_commands.rs
+++ b/src/commands/config_commands.rs
@@ -169,7 +169,7 @@ where
 {
     let path = resolve_config_path(cli_config_path).await?;
 
-    if !path.exists() {
+    if !tokio::fs::try_exists(&path).await? {
         return Err(Error::new(
             "config_check",
             &format!(

--- a/src/commands/config_commands.rs
+++ b/src/commands/config_commands.rs
@@ -308,13 +308,25 @@ fn confirm(message: &str, default: bool) -> Result<bool, Error> {
 }
 
 pub async fn set_timezone(config: Config, _args: &SetTimezone) -> Result<String, Error> {
+    if config
+        .token
+        .as_ref()
+        .map(|token| token.trim().is_empty())
+        .unwrap_or(true)
+    {
+        return Err(Error::new(
+            "config set-timezone",
+            "No auth present - run \"tod auth login\"",
+        ));
+    }
+
     match config.set_timezone().await {
         Ok(updated_config) => {
             let tz = updated_config.get_timezone()?;
             Ok(format!("Timezone set successfully to: {tz}"))
         }
         Err(e) => Err(Error::new(
-            "tz_reset",
+            "config set-timezone",
             &format!("Could not reset timezone in config. {e}"),
         )),
     }
@@ -451,5 +463,22 @@ mod tests {
 
         // Ensure the mock was actually called
         mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_set_timezone_requires_auth() {
+        let config = Config::default();
+
+        let error = set_timezone(config, &SetTimezone { timezone: None })
+            .await
+            .expect_err("set-timezone should fail when no auth token is present");
+
+        assert_eq!(error.source, "config set-timezone");
+        assert!(
+            error
+                .message
+                .contains("No auth present - run \"tod auth login\""),
+            "error should guide user to auth login"
+        );
     }
 }

--- a/src/commands/config_commands.rs
+++ b/src/commands/config_commands.rs
@@ -169,6 +169,16 @@ where
 {
     let path = resolve_config_path(cli_config_path).await?;
 
+    if !path.exists() {
+        return Err(Error::new(
+            "config_check",
+            &format!(
+                "No config file found at {}. Run 'tod auth login' to initialize tod.",
+                path.display()
+            ),
+        ));
+    }
+
     if Config::load(&path).await.is_ok() {
         return Ok(format!("Config file at {} is valid.", path.display()));
     }
@@ -402,6 +412,24 @@ mod tests {
             .await
             .expect("config should be readable");
         assert_eq!(unchanged, contents);
+    }
+
+    #[tokio::test]
+    async fn test_config_check_missing_file_returns_init_guidance() {
+        let dir = tempdir().expect("temp dir should be created");
+        let path = dir.path().join("missing.cfg");
+
+        let error = check_with_prompts(Some(path.clone()), |_| Ok(true), |_| Ok(true))
+            .await
+            .expect_err("missing config should fail");
+
+        assert_eq!(error.source, "config_check");
+        assert!(
+            error
+                .message
+                .contains("Run 'tod auth login' to initialize tod."),
+            "missing config should guide user to auth login"
+        );
     }
 
     #[tokio::test]

--- a/src/commands/config_commands.rs
+++ b/src/commands/config_commands.rs
@@ -321,8 +321,7 @@ pub async fn set_timezone(config: Config, _args: &SetTimezone) -> Result<String,
     if config
         .token
         .as_ref()
-        .map(|token| token.trim().is_empty())
-        .unwrap_or(true)
+        .is_none_or(|token| token.trim().is_empty())
     {
         return Err(Error::new(
             "config set-timezone",

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -148,7 +148,7 @@ async fn shell_command(command: &ShellCommands) -> Result<CommandResult, Error> 
     match command {
         ShellCommands::Completions(args) => {
             let result = shell_commands::completions(args).await;
-            build_command_result_without_config(result)
+            Ok(build_command_result_without_config(result))
         }
     }
 }
@@ -162,7 +162,7 @@ async fn reminder_command(
         ReminderCommands::List(args) => {
             let mut config = fetch_config(cli, tx).await?;
             let result = reminder_commands::list(&mut config, args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
     }
 }
@@ -176,7 +176,7 @@ async fn section_command(
         SectionCommands::Create(args) => {
             let config = fetch_config(cli, tx).await?;
             let result = section_commands::create(&config, args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
     }
 }
@@ -190,37 +190,37 @@ async fn project_command(
         ProjectCommands::Create(args) => {
             let mut config = fetch_config(cli, tx).await?;
             let result = project_commands::create(&mut config, args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
         ProjectCommands::List(args) => {
             let mut config = fetch_config(cli, tx).await?;
             let result = project_commands::list(&mut config, args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
         ProjectCommands::Remove(args) => {
             let mut config = fetch_config(cli, tx).await?;
             let result = project_commands::remove(&mut config, args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
         ProjectCommands::Rename(args) => {
             let mut config = fetch_config(cli, tx).await?;
             let result = project_commands::rename(&mut config, args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
         ProjectCommands::Import(args) => {
             let mut config = fetch_config(cli, tx).await?;
             let result = project_commands::import(&mut config, args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
         ProjectCommands::Empty(args) => {
             let mut config = fetch_config(cli, tx).await?;
             let result = project_commands::empty(&mut config, args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
         ProjectCommands::Delete(args) => {
             let mut config = fetch_config(cli, tx).await?;
             let result = project_commands::delete(&mut config, args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
     }
 }
@@ -234,32 +234,32 @@ async fn task_command(
         TaskCommands::QuickAdd(args) => {
             let config = fetch_config(cli, tx).await?;
             let result = task_commands::quick_add(&config, args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
         TaskCommands::Create(args) => {
             let config = fetch_config(cli, tx).await?;
             let result = task_commands::create(config.clone(), args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
         TaskCommands::Edit(args) => {
             let config = fetch_config(cli, tx).await?;
             let result = task_commands::edit(config.clone(), args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
         TaskCommands::Next(args) => {
             let config = fetch_config(cli, tx).await?;
             let result = task_commands::next(config.clone(), args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
         TaskCommands::Complete(args) => {
             let config = fetch_config(cli, tx).await?;
             let result = task_commands::complete(config.clone(), args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
         TaskCommands::Comment(args) => {
             let config = fetch_config(cli, tx).await?;
             let result = task_commands::comment(config.clone(), args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
     }
 }
@@ -273,47 +273,47 @@ async fn list_command(
         ListCommands::View(args) => {
             let mut config = fetch_config(cli, tx).await?;
             let result = list_commands::view(&mut config, args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
         ListCommands::Process(args) => {
             let config = fetch_config(cli, tx).await?;
             let result = list_commands::process(config.clone(), args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
         ListCommands::Prioritize(args) => {
             let config = fetch_config(cli, tx).await?;
             let result = list_commands::prioritize(config.clone(), args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
         ListCommands::Remind(args) => {
             let config = fetch_config(cli, tx).await?;
             let result = list_commands::remind(config.clone(), args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
         ListCommands::Label(args) => {
             let config = fetch_config(cli, tx).await?;
             let result = list_commands::label(config.clone(), args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
         ListCommands::Schedule(args) => {
             let config = fetch_config(cli, tx).await?;
             let result = list_commands::schedule(config.clone(), args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
         ListCommands::Deadline(args) => {
             let config = fetch_config(cli, tx).await?;
             let result = list_commands::deadline(config.clone(), args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
         ListCommands::Timebox(args) => {
             let config = fetch_config(cli, tx).await?;
             let result = list_commands::timebox(config.clone(), args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
         ListCommands::Import(args) => {
             let config = fetch_config(cli, tx).await?;
             let result = list_commands::import(config.clone(), args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
     }
 }
@@ -327,33 +327,33 @@ async fn config_command(
         ConfigCommands::SetTimezone(args) => {
             let config = fetch_config(cli, tx).await?;
             let result = config_commands::set_timezone(config.clone(), args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
         ConfigCommands::Edit(args) => {
             let config = fetch_config(cli, tx).await?;
             let result = config_commands::edit(config.clone(), args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
 
         ConfigCommands::CheckVersion(args) => {
             let result = config_commands::check_version(args, None).await;
-            build_command_result_without_config(result)
+            Ok(build_command_result_without_config(result))
         }
         ConfigCommands::Check(_args) => {
             let result = config_commands::check(cli.config.clone()).await;
-            build_command_result_without_config(result)
+            Ok(build_command_result_without_config(result))
         }
         ConfigCommands::About(args) => {
             let result = config_commands::about(args).await;
-            build_command_result_without_config(result)
+            Ok(build_command_result_without_config(result))
         }
         ConfigCommands::Reset(args) => {
             let result = crate::config::config_reset(cli.config.clone(), args.force).await;
-            build_command_result_without_config(result)
+            Ok(build_command_result_without_config(result))
         }
         ConfigCommands::Open(_args) => {
             let result = crate::config::config_open(cli.config.clone()).await;
-            build_command_result_without_config(result)
+            Ok(build_command_result_without_config(result))
         }
     }
 }
@@ -363,12 +363,12 @@ async fn auth_command(command: &AuthCommands, cli: &Cli) -> Result<CommandResult
         AuthCommands::Login(args) => {
             let mut config = auth_commands::load_or_create_config(cli.config.clone()).await?;
             let result = auth_commands::login(&mut config, args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
 
         AuthCommands::Token(args) => {
             let result = auth_commands::token(cli.config.clone(), args).await;
-            build_command_result_without_config(result)
+            Ok(build_command_result_without_config(result))
         }
     }
 }
@@ -382,36 +382,32 @@ async fn test_command(
         TestCommands::All(args) => {
             let config = fetch_config(cli, tx).await?;
             let result = test_commands::all(&config, args).await;
-            build_command_result(result, config)
+            Ok(build_command_result(result, &config))
         }
     }
 }
 
-fn build_command_result(
-    result: Result<String, Error>,
-    config: Config,
-) -> Result<CommandResult, Error> {
-    Ok(CommandResult {
+fn build_command_result(result: Result<String, Error>, config: &Config) -> CommandResult {
+    CommandResult {
         bell_success: config.bell_on_success,
         bell_failure: config.bell_on_failure,
         result,
-    })
+    }
 }
 
-fn build_command_result_without_config(
-    result: Result<String, Error>,
-) -> Result<CommandResult, Error> {
-    Ok(CommandResult {
+fn build_command_result_without_config(result: Result<String, Error>) -> CommandResult {
+    CommandResult {
         bell_success: false,
         bell_failure: true,
         result,
-    })
+    }
 }
 
 /// Load existing config and ensure auth is present.
 async fn fetch_config(cli: &Cli, tx: &UnboundedSender<Error>) -> Result<Config, Error> {
     let config = get_existing_config_exists(cli.config.clone()).await?;
     let config = with_cli_context(config, cli, tx);
+    crate::debug::maybe_print_redacted_config(&config);
     ensure_auth_present(&config, "fetch_config")?;
     let config = config.check_for_latest_version().await?;
     config.maybe_set_timezone().await
@@ -436,8 +432,7 @@ fn ensure_auth_present(config: &Config, source: &str) -> Result<(), Error> {
     if config
         .token
         .as_ref()
-        .map(|token| token.trim().is_empty())
-        .unwrap_or(true)
+        .is_none_or(|token| token.trim().is_empty())
     {
         Err(Error::new(
             source,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -533,3 +533,57 @@ async fn maybe_fetch_labels(config: &Config, labels: &[String]) -> Result<Vec<St
         Ok(labels.to_vec())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_command_result_uses_config_bell_settings() {
+        let mut config = Config::default();
+        config.bell_on_success = true;
+        config.bell_on_failure = false;
+
+        let result = build_command_result(Ok("ok".to_string()), &config);
+        assert!(result.bell_success);
+        assert!(!result.bell_failure);
+        assert!(matches!(result.result, Ok(text) if text == "ok"));
+    }
+
+    #[test]
+    fn build_command_result_without_config_uses_defaults() {
+        let result = build_command_result_without_config(Ok("ok".to_string()));
+        assert!(!result.bell_success);
+        assert!(result.bell_failure);
+        assert!(matches!(result.result, Ok(text) if text == "ok"));
+    }
+
+    #[test]
+    fn ensure_auth_present_errors_when_token_missing() {
+        let mut config = Config::default();
+        config.token = None;
+
+        let result = ensure_auth_present(&config, "test-source");
+        let error = result.expect_err("missing token should fail auth check");
+        assert!(error.message.contains("tod auth login"));
+    }
+
+    #[test]
+    fn ensure_auth_present_errors_when_token_whitespace() {
+        let mut config = Config::default();
+        config.token = Some("   ".to_string());
+
+        let result = ensure_auth_present(&config, "test-source");
+        let error = result.expect_err("whitespace token should fail auth check");
+        assert!(error.message.contains("tod auth login"));
+    }
+
+    #[test]
+    fn ensure_auth_present_succeeds_with_token() {
+        let mut config = Config::default();
+        config.token = Some("token".to_string());
+
+        let result = ensure_auth_present(&config, "test-source");
+        assert!(result.is_ok());
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -408,23 +408,44 @@ fn build_command_result_without_config(
     })
 }
 
-/// Get or create config
+/// Load existing config and ensure auth is present.
 async fn fetch_config(cli: &Cli, tx: &UnboundedSender<Error>) -> Result<Config, Error> {
-    let Cli {
-        verbose,
-        config: config_path,
-        timeout,
-        command: _,
-    } = cli;
-
-    let config_path = config_path.to_owned();
-    let verbose = verbose.to_owned();
-    let timeout = timeout.to_owned();
-
-    let config = crate::config::get_or_create(config_path, verbose, timeout, tx).await?;
-
+    let config = get_existing_config_exists(cli.config.clone()).await?;
+    let config = with_cli_context(config, cli, tx);
+    ensure_auth_present(&config, "fetch_config")?;
     let config = config.check_for_latest_version().await?;
     config.maybe_set_timezone().await
+}
+
+/// Only fetches the config if it exists, otherwise errors.
+async fn get_existing_config_exists(config_path: Option<PathBuf>) -> Result<Config, Error> {
+    match crate::config::get_config(config_path).await {
+        Ok(config) => Ok(config),
+        Err(e) => Err(e),
+    }
+}
+
+fn with_cli_context(mut config: Config, cli: &Cli, tx: &UnboundedSender<Error>) -> Config {
+    config.args.verbose = cli.verbose;
+    config.args.timeout = cli.timeout;
+    config.internal.tx = Some(tx.clone());
+    config
+}
+
+fn ensure_auth_present(config: &Config, source: &str) -> Result<(), Error> {
+    if config
+        .token
+        .as_ref()
+        .map(|token| token.trim().is_empty())
+        .unwrap_or(true)
+    {
+        Err(Error::new(
+            source,
+            "No auth present - run \"tod auth login\"",
+        ))
+    } else {
+        Ok(())
+    }
 }
 
 fn fetch_string(

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -173,7 +173,10 @@ where
 
 /// Opens the existing config file in the user's editor.
 pub async fn config_open(cli_config_path: Option<PathBuf>) -> Result<String, Error> {
-    config_open_with_editor(cli_config_path, |path| edit::edit_file(path).map_err(Error::from)).await
+    config_open_with_editor(cli_config_path, |path| {
+        edit::edit_file(path).map_err(Error::from)
+    })
+    .await
 }
 
 async fn config_open_with_editor<E>(
@@ -617,10 +620,7 @@ mod tests {
         .await;
 
         let err = result.expect_err("missing config should fail");
-        assert!(
-            !temp_path.exists(),
-            "Config file should not be created"
-        );
+        assert!(!temp_path.exists(), "Config file should not be created");
         assert!(
             err.to_string()
                 .contains("Run 'tod auth login' to initialize tod."),
@@ -637,16 +637,13 @@ mod tests {
             .await
             .expect("Failed to create temp config");
 
-        let result = config_open_with_editor(
-            Some(temp_path.clone()),
-            |path| {
-                let mut file = std::fs::File::create(path).expect("Failed to open invalid config");
-                file.write_all(b"{ invalid")
-                    .expect("Failed to write invalid config");
-                file.sync_all().expect("Failed to sync invalid config");
-                Ok(())
-            },
-        )
+        let result = config_open_with_editor(Some(temp_path.clone()), |path| {
+            let mut file = std::fs::File::create(path).expect("Failed to open invalid config");
+            file.write_all(b"{ invalid")
+                .expect("Failed to write invalid config");
+            file.sync_all().expect("Failed to sync invalid config");
+            Ok(())
+        })
         .await;
 
         let err = result.expect_err("Invalid config should fail validation");

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -187,7 +187,15 @@ where
     E: FnOnce(&Path) -> Result<(), Error>,
 {
     let path = resolve_config_path(cli_config_path).await?;
-    get_config(Some(path.clone())).await?;
+    if !path.exists() {
+        return Err(Error::new(
+            "config_open",
+            &format!(
+                "No config file found at {}. Run 'tod auth login' to initialize tod.",
+                path.display()
+            ),
+        ));
+    }
 
     editor_fn(&path)?;
     Config::load(&path).await?;
@@ -650,6 +658,22 @@ mod tests {
         assert!(
             err.message.contains("Error loading configuration file"),
             "Expected config load error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_config_open_invalid_before_editor_can_be_fixed() {
+        let (_temp_dir, temp_path) = temp_config_path("invalid_before_open.cfg");
+        std::fs::write(&temp_path, "{ invalid").expect("Failed to seed invalid config");
+
+        let result = config_open_with_editor(Some(temp_path.clone()), |path| {
+            std::fs::write(path, "{}").map_err(Error::from)
+        })
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "Editing invalid existing config should be allowed and validated after edit"
         );
     }
     #[tokio::test]

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -5,7 +5,6 @@ use crate::config::{Args, Internal};
 use crate::config::{SortDirection, SortKey, SortRule};
 use crate::{config::Config, errors::Error};
 use crate::{debug, format, input};
-use inquire::Confirm;
 use serde_json::json;
 use std::path::{Path, PathBuf};
 use tokio::fs;
@@ -230,44 +229,20 @@ where
     }
 }
 
-/// Opens the config file in the user's editor, creating a default config first if requested.
+/// Opens the existing config file in the user's editor.
 pub async fn config_open(cli_config_path: Option<PathBuf>) -> Result<String, Error> {
-    config_open_with_prompt_and_editor(
-        cli_config_path,
-        |path| {
-            Confirm::new(&format!(
-                "No config file found at {}. Create it?",
-                path.display()
-            ))
-            .with_default(true)
-            .prompt()
-            .unwrap_or(false)
-        },
-        |path| edit::edit_file(path).map_err(Error::from),
-    )
-    .await
+    config_open_with_editor(cli_config_path, |path| edit::edit_file(path).map_err(Error::from)).await
 }
 
-async fn config_open_with_prompt_and_editor<P, E>(
+async fn config_open_with_editor<E>(
     cli_config_path: Option<PathBuf>,
-    prompt_fn: P,
     editor_fn: E,
 ) -> Result<String, Error>
 where
-    P: FnOnce(&Path) -> bool,
     E: FnOnce(&Path) -> Result<(), Error>,
 {
     let path = resolve_config_path(cli_config_path).await?;
-
-    if !path.exists() {
-        if !prompt_fn(&path) {
-            return Ok("Aborted: Config not created.".to_string());
-        }
-
-        let mut config = Config::new(None, path.clone()).await?;
-        config.touch_file().await?;
-        config.save().await?;
-    }
+    get_config(Some(path.clone())).await?;
 
     editor_fn(&path)?;
     Config::load(&path).await?;
@@ -703,37 +678,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_config_open_missing_prompt_no_aborts() {
+    async fn test_config_open_missing_returns_error() {
         let (_temp_dir, temp_path) = temp_config_path("missing_open_no.cfg");
 
-        let result = config_open_with_prompt_and_editor(
-            Some(temp_path.clone()),
-            |_| false,
-            |_| -> Result<(), Error> { panic!("editor should not be called") },
-        )
+        let result = config_open_with_editor(Some(temp_path.clone()), |_| -> Result<(), Error> {
+            panic!("editor should not be called")
+        })
         .await;
 
-        assert_eq!(result, Ok("Aborted: Config not created.".to_string()));
+        let err = result.expect_err("missing config should fail");
         assert!(
             !temp_path.exists(),
-            "Config file should not be created after abort"
+            "Config file should not be created"
         );
-    }
-
-    #[tokio::test]
-    async fn test_config_open_missing_prompt_yes_creates_and_validates() {
-        let (_temp_dir, temp_path) = temp_config_path("missing_open_yes.cfg");
-
-        let result =
-            config_open_with_prompt_and_editor(Some(temp_path.clone()), |_| true, |_| Ok(())).await;
-
-        assert!(result.is_ok(), "Expected Ok, got {result:?}");
-        assert!(temp_path.exists(), "Config file should be created");
-
-        let loaded = Config::load(&temp_path)
-            .await
-            .expect("Created config should load");
-        assert_eq!(loaded.path, temp_path);
+        assert!(
+            err.to_string()
+                .contains("Run 'tod auth login' to initialize tod."),
+            "missing config should guide user to auth login"
+        );
     }
 
     #[tokio::test]
@@ -745,9 +707,8 @@ mod tests {
             .await
             .expect("Failed to create temp config");
 
-        let result = config_open_with_prompt_and_editor(
+        let result = config_open_with_editor(
             Some(temp_path.clone()),
-            |_| -> bool { panic!("prompt should not be called") },
             |path| {
                 let mut file = std::fs::File::create(path).expect("Failed to open invalid config");
                 file.write_all(b"{ invalid")

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -1,18 +1,17 @@
 //! For config functions that operate on the filesystem
 
-use crate::config::{Args, Internal};
 #[cfg(test)]
 use crate::config::{SortDirection, SortKey, SortRule};
 use crate::{config::Config, errors::Error};
-use crate::{debug, format, input};
+use crate::{format, input};
 use serde_json::json;
 use std::path::{Path, PathBuf};
 use tokio::fs;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::sync::mpsc::UnboundedSender;
 
 impl Config {
     /// Creates a new config file, will overwrite an existing one
+    #[cfg(test)]
     pub async fn create(self) -> Result<Config, Error> {
         self.touch_file().await?;
         let mut config = self;
@@ -89,63 +88,6 @@ fn config_load_error(error: &serde_json::Error, path: &Path) -> Error {
     );
 
     Error::new(source, &message)
-}
-/// Fetches config from from disk and creates it if it doesn't exist
-/// Prompts for Todoist API token
-pub async fn get_or_create(
-    config_path: Option<PathBuf>,
-    verbose: bool,
-    timeout: Option<u64>,
-    tx: &UnboundedSender<Error>,
-) -> Result<Config, Error> {
-    let path = match config_path {
-        None => generate_path().await?,
-        Some(path) => maybe_expand_home_dir(path)?,
-    };
-
-    let config = match fs::File::open(&path).await {
-        Ok(_) => Config::load(&path).await,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            eprintln!("Config file not found, creating new config");
-            generate_new_configuration(tx, path).await
-        }
-        Err(err) => Err(Error::new(
-            "config.rs",
-            &format!("Failed to open config file: {err}"),
-        )),
-    }?;
-
-    let config = Config {
-        args: Args { verbose, timeout },
-        internal: Internal {
-            tx: Some(tx.clone()),
-        },
-        ..config
-    };
-
-    debug::maybe_print_redacted_config(&config);
-    Ok(config)
-}
-// create the config file and prompt timezone and token
-pub async fn generate_new_configuration(
-    tx: &UnboundedSender<Error>,
-    config_path: PathBuf,
-) -> Result<Config, Error> {
-    // Create the default in-memory config
-    let mut config = Config::new(Some(tx.clone()), config_path).await?;
-    // Create the empty file
-    config = config.create().await?;
-
-    // Populate the required fields - prompt for token or use existing token logic
-    config = config.maybe_set_token().await?;
-
-    // Populate the required timezone
-    config = config.maybe_set_timezone().await?;
-
-    // write updated config to disk
-    config.save().await?;
-
-    Ok(config)
 }
 pub async fn generate_path() -> Result<PathBuf, Error> {
     if cfg!(test) {
@@ -272,7 +214,10 @@ pub async fn get_config(config_path: Option<PathBuf>) -> Result<Config, Error> {
     if !check_config_exists(Some(path)).await? {
         return Err(Error::new(
             "get_config",
-            &format!("No config file found at {}.", path_for_error.display()),
+            &format!(
+                "No config file found at {}. Run 'tod auth login' to initialize tod.",
+                path_for_error.display()
+            ),
         ));
     }
 
@@ -310,11 +255,6 @@ mod tests {
             .with_token(&token.into())
     }
 
-    fn tx() -> UnboundedSender<Error> {
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-        tx
-    }
-
     fn temp_config_path(file_name: &str) -> (TempDir, PathBuf) {
         let dir = tempdir().expect("Could not create temp config directory");
         let path = dir.path().join(file_name);
@@ -344,16 +284,10 @@ mod tests {
         let config_create = config_with_mock(&mock_url)
             .await
             .with_path(temp_dir.path().join("create.cfg"));
-        let path_create = config_create.path.clone();
         config_create
             .create()
             .await
             .expect("Failed to create config in async call");
-
-        let created = get_or_create(Some(path_create.clone()), false, None, &tx())
-            .await
-            .expect("get_or_create (create) failed");
-        assert!(created.token.is_some());
 
         let config_load = config_with_mock_and_token(&mock_url, "loaded")
             .await
@@ -364,14 +298,10 @@ mod tests {
             .await
             .expect("Failed to create config load asynchronously");
 
-        let loaded = get_or_create(Some(path_load.clone()), false, None, &tx())
+        let loaded = Config::load(&path_load)
             .await
-            .expect("get_or_create (load) failed");
+            .expect("Failed to load config from path asynchronously");
         assert_eq!(loaded.token, Some("loaded".into()));
-        assert!(loaded.internal.tx.is_some());
-
-        let fetched = get_or_create(Some(path_load.clone()), false, None, &tx()).await;
-        assert_matches!(fetched, Ok(Config { .. }));
     }
 
     #[tokio::test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,7 +9,7 @@ use crate::legacy;
 use crate::projects::Project;
 use crate::tasks::Task;
 use crate::time::{SystemTimeProvider, TimeProviderEnum};
-use crate::{VERSION, cargo, format, input, oauth, time};
+use crate::{VERSION, cargo, format, input, time};
 use regex::Regex;
 use serde::de::Error as DeError;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -19,15 +19,11 @@ use tokio::sync::mpsc::UnboundedSender;
 
 const MAX_COMMENT_LENGTH: u32 = 500;
 pub const DEFAULT_TIMEOUT_SECONDS: u64 = 30;
-pub const OAUTH: &str = "Login with OAuth (recommended)";
-pub const DEVELOPER: &str = "Login with developer API token";
-pub const TOKEN_METHOD: &str = "Choose your Todoist login method";
 const TODOIST_INTEGRATIONS_URL: &str = "https://todoist.com/prefs/integrations";
 pub use file::config_open;
 pub use file::config_reset;
 pub use file::generate_path;
 pub use file::get_config;
-pub use file::get_or_create;
 pub use file::resolve_config_path;
 pub use legacy::LegacySortValue;
 
@@ -498,33 +494,6 @@ impl Config {
 
         self.set_token(trimmed_key.to_string()).await?;
         self.maybe_set_timezone().await
-    }
-
-    async fn maybe_set_token(self) -> Result<Config, Error> {
-        if self.token.clone().unwrap_or_default().trim().is_empty() {
-            let mock_select = Some(1);
-            let options = vec![OAUTH, DEVELOPER];
-            let mut config = match input::select(TOKEN_METHOD, options, mock_select)? {
-                OAUTH => {
-                    let mut config = self.clone();
-                    oauth::login(&mut config, None).await?;
-                    config
-                }
-                DEVELOPER => {
-                    let desc = self.token_message();
-
-                    // We can't use mock_string from config here because it can't be set in test.
-                    let fake_token = Some("faketoken".into());
-                    let token = input::string(&desc, fake_token)?;
-                    self.set_developer_token(&token).await?
-                }
-                _ => unreachable!(),
-            };
-            config.save().await?;
-            Ok(config)
-        } else {
-            Ok(self)
-        }
     }
 
     pub async fn edit_interactive(self) -> Result<String, Error> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -345,7 +345,9 @@ impl Config {
         let last_version = self.last_version_check.clone();
         let today = time::date_string_today(&self)?;
 
-        if last_version != Some(today.clone()) {
+        if last_version == Some(today.clone()) {
+            Ok(self)
+        } else {
             let mut new_config = Config {
                 last_version_check: Some(today),
                 ..self.clone()
@@ -378,8 +380,6 @@ impl Config {
                 }
             });
             Ok(new_config)
-        } else {
-            Ok(self)
         }
     }
 
@@ -496,6 +496,7 @@ impl Config {
         self.maybe_set_timezone().await
     }
 
+    #[allow(clippy::too_many_lines)]
     pub async fn edit_interactive(self) -> Result<String, Error> {
         let Config {
             bell_on_failure,
@@ -660,17 +661,17 @@ impl Config {
         // ---
 
         let mut config = Config {
-            bell_on_failure,
-            max_comment_length,
+            token,
             bell_on_success,
-            timeout,
-            comment_exclude_regex,
+            bell_on_failure,
             task_exclude_regex,
+            timeout,
             spinners,
             disable_links,
-            no_sections,
+            max_comment_length,
+            comment_exclude_regex,
             verbose,
-            token,
+            no_sections,
             natural_language_only,
             ..self.clone()
         };

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,9 +1,24 @@
 use crate::{config::Config, format};
+const TOKEN_SUFFIX_LENGTH: usize = 5;
 
 // Print a debug statement if in verbose mode
 pub fn maybe_print(config: &Config, text: &str) {
     if config.verbose.unwrap_or_default() || config.args.verbose {
         print(text);
+    }
+}
+
+// Print config with token redacted when in verbose mode.
+pub fn maybe_print_redacted_config(config: &Config) {
+    if config.verbose.unwrap_or_default() || config.args.verbose {
+        let token = config.token.as_ref().map(|token| {
+            let prefix = "x".repeat(token.len().saturating_sub(TOKEN_SUFFIX_LENGTH));
+            let suffix = &token[token.len().saturating_sub(TOKEN_SUFFIX_LENGTH)..];
+            format!("{prefix}{suffix}")
+        });
+        let mut redacted_config = config.clone();
+        redacted_config.token = token;
+        print(&format!("{redacted_config:#?}"));
     }
 }
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,5 +1,5 @@
 use crate::{config::Config, format};
-const TOKEN_SUFFIX_LENGTH: usize = 5;
+const TOKEN_PREFIX_LENGTH: usize = 4;
 
 // Print a debug statement if in verbose mode
 pub fn maybe_print(config: &Config, text: &str) {
@@ -11,15 +11,17 @@ pub fn maybe_print(config: &Config, text: &str) {
 // Print config with token redacted when in verbose mode.
 pub fn maybe_print_redacted_config(config: &Config) {
     if config.verbose.unwrap_or_default() || config.args.verbose {
-        let token = config.token.as_ref().map(|token| {
-            let prefix = "x".repeat(token.len().saturating_sub(TOKEN_SUFFIX_LENGTH));
-            let suffix = &token[token.len().saturating_sub(TOKEN_SUFFIX_LENGTH)..];
-            format!("{prefix}{suffix}")
-        });
+        let token = config.token.as_ref().map(|token| redact_token(token));
         let mut redacted_config = config.clone();
         redacted_config.token = token;
         print(&format!("{redacted_config:#?}"));
     }
+}
+
+fn redact_token(token: &str) -> String {
+    let visible: String = token.chars().take(TOKEN_PREFIX_LENGTH).collect();
+    let redacted_length = token.chars().count().saturating_sub(TOKEN_PREFIX_LENGTH);
+    format!("{visible}{}", "x".repeat(redacted_length))
 }
 
 // Print a debug statement

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,27 +1,9 @@
 use crate::{config::Config, format};
 
-const TOKEN_SUFFIX_LENGTH: usize = 5;
-const TOKEN_LENGTH: usize = 40;
-
 // Print a debug statement if in verbose mode
 pub fn maybe_print(config: &Config, text: &str) {
     if config.verbose.unwrap_or_default() || config.args.verbose {
         print(text);
-    }
-}
-
-// Print config with token redacted to console if in verbose mode
-// Everything but the last 5 characters are turned into x's before being printed to console
-pub fn maybe_print_redacted_config(config: &Config) {
-    if config.verbose.unwrap_or_default() || config.args.verbose {
-        let token = config.token.as_ref().map(|t| {
-            let redacted = "x".repeat(TOKEN_LENGTH - TOKEN_SUFFIX_LENGTH);
-            let suffix = t.len().saturating_sub(TOKEN_SUFFIX_LENGTH);
-            format!("{}{}", redacted, &t[suffix..])
-        });
-        let mut config = config.clone();
-        config.token = token;
-        print(&format!("{config:#?}"));
     }
 }
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -31,3 +31,30 @@ pub fn print(text: &str) {
 
     println!("{text}");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+
+    #[test]
+    fn redact_token_keeps_first_four_chars() {
+        let redacted = redact_token("abcd1234");
+        assert_eq!(redacted, "abcdxxxx");
+    }
+
+    #[test]
+    fn redact_token_handles_short_tokens() {
+        let redacted = redact_token("abc");
+        assert_eq!(redacted, "abc");
+    }
+
+    #[test]
+    fn maybe_print_redacted_config_with_token_does_not_panic() {
+        let mut config = Config::default();
+        config.verbose = Some(true);
+        config.token = Some("abcd1234".to_string());
+
+        maybe_print_redacted_config(&config);
+    }
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -143,7 +143,7 @@ pub fn confirm(desc: &str) -> Result<bool, Error> {
     Confirm::new(desc)
         .with_default(false)
         .prompt()
-        .map_err(|e| e.into())
+        .map_err(Into::into)
 }
 
 /// Get string input with default value
@@ -172,7 +172,7 @@ pub fn number_with_default(desc: &str, default_message: usize) -> Result<usize, 
 
 pub fn bool(desc: &str, default_value: bool, mock_select: Option<usize>) -> Result<bool, Error> {
     let options = vec![true, false];
-    let cursor_index = if default_value { 0 } else { 1 };
+    let cursor_index = usize::from(!default_value);
     select_with_cursor_index(desc, options, cursor_index, mock_select)
 }
 

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -62,9 +62,9 @@ pub(crate) fn detect_and_migrate_sort_value(
     ];
 
     weighted_keys.sort_by(|(left_key, left_weight), (right_key, right_weight)| {
-        right_weight
-            .cmp(left_weight)
-            .then_with(|| sort_key_default_index(left_key).cmp(&sort_key_default_index(right_key)))
+        right_weight.cmp(left_weight).then_with(|| {
+            sort_key_default_index(*left_key).cmp(&sort_key_default_index(*right_key))
+        })
     });
 
     let mut keys: Vec<SortKey> = weighted_keys.into_iter().map(|(key, _)| key).collect();
@@ -81,9 +81,9 @@ pub(crate) fn detect_and_migrate_sort_value(
     )
 }
 
-fn sort_key_default_index(key: &SortKey) -> usize {
+fn sort_key_default_index(key: SortKey) -> usize {
     SortKey::default_order()
         .iter()
-        .position(|default_key| default_key == key)
+        .position(|default_key| *default_key == key)
         .unwrap_or(usize::MAX)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,14 +78,14 @@ fn output_result(result: CommandResult) -> u8 {
         Ok(text) => {
             println!("{text}");
             if result.bell_success {
-                terminal_bell()
+                terminal_bell();
             }
             0
         }
         Err(e) => {
             eprintln!("\n\n{e}");
             if result.bell_failure {
-                terminal_bell()
+                terminal_bell();
             }
             1
         }

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -49,14 +49,16 @@ pub async fn login(config: &mut Config, test_tx: Option<Sender<()>>) -> Result<S
         .code
         .ok_or_else(|| Error::new("params", "no code provided"))?;
     let access_token = todoist::get_access_token(config, &code).await?;
-    let result = config.set_token(access_token).await;
+    let result = config.set_token(access_token).await?;
+    let current = std::mem::take(config);
+    *config = current.maybe_set_timezone().await?;
 
     // Print authentication success message to the terminal
     let check = green_string("Authentication Successful!");
     println!("{check}");
     println!("You can now use the `tod` command to manage your Todoist tasks.");
 
-    result
+    Ok(result)
 }
 
 fn print_oauth_url(config: &Config) -> String {
@@ -100,13 +102,13 @@ async fn receive_callback(
             }
 
             if let Some(tx) = response.lock().await.take() {
-                if let Some(error_message) = params.error.clone() {
-                    tx.send(params).expect(TRANSMIT_ERROR);
+                let response_message = if let Some(error_message) = params.error.as_deref() {
                     format!("Error from Todoist: {error_message}")
                 } else {
-                    tx.send(params).expect(TRANSMIT_ERROR);
                     String::from("Success! You can close this window and return to your terminal.")
-                }
+                };
+                tx.send(params).expect(TRANSMIT_ERROR);
+                response_message
             } else {
                 String::from("Error: Could not get response tx")
             }
@@ -125,7 +127,7 @@ async fn receive_callback(
 
     if let Some(message) = params.error {
         Err(Error::new("oauth get code", &message))
-    } else if params.state.clone().unwrap_or_default() == csrf_token {
+    } else if params.state.as_deref().unwrap_or_default() == csrf_token {
         Ok(params)
     } else {
         Err(Error::new(
@@ -147,7 +149,7 @@ pub fn new_uuid() -> String {
 mod tests {
 
     use super::*;
-    use crate::test::{self, responses::ResponseFromFile};
+    use crate::test::responses::ResponseFromFile;
     use pretty_assertions::assert_eq;
     use serde_test::{Token, assert_de_tokens};
 
@@ -180,11 +182,23 @@ mod tests {
             .with_body(ResponseFromFile::AccessToken.read().await)
             .create_async()
             .await;
+        let user_mock = server
+            .mock("GET", "/api/v1/user")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(ResponseFromFile::User.read().await)
+            .create_async()
+            .await;
 
-        let mut config = test::fixtures::config().await.with_mock_url(server.url());
+        let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+        let path = temp_dir.path().join("oauth-login.cfg");
+        let mut config = Config::new(None, path)
+            .await
+            .expect("config should be created")
+            .with_mock_url(server.url())
+            .with_token("alreadycreated");
 
-        config
-            .clone()
+        config = config
             .create()
             .await
             .expect("Failed to create config asynchronously in oauth test");
@@ -192,9 +206,10 @@ mod tests {
         assert_eq!(config.token, Some(String::from("alreadycreated")));
         let (test_tx, test_rx) = oneshot::channel::<()>();
         let login_handle = tokio::spawn(async move {
-            login(&mut config, Some(test_tx))
+            let result = login(&mut config, Some(test_tx))
                 .await
-                .expect("Login async operation failed")
+                .expect("Login async operation failed");
+            (result, config)
         });
 
         test_rx
@@ -217,11 +232,18 @@ mod tests {
             .expect("Failed to get text from response asynchronously");
         assert!(body.contains("Success"));
 
-        let result = login_handle
+        let (result, config) = login_handle
             .await
             .expect("Failed to await login handle completion");
         assert_eq!(result, String::from("✓"));
+        assert_eq!(
+            config
+                .get_timezone()
+                .expect("Timezone should be set after login"),
+            "America/Vancouver"
+        );
         mock.assert();
+        user_mock.assert();
     }
 
     #[tokio::test]

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -14,7 +14,6 @@ use tokio::sync::oneshot::{self, Sender};
 pub const CLIENT_ID: &str = "2696d64dc4f745679e21181c56b489fe";
 pub const CLIENT_SECRET: &str = "bfde0d10e3d740beb47f95879881634e";
 const FAKE_UUID: &str = "42963283-2bab-4b1f-bad2-278ef2b6ba2c";
-const TRANSMIT_ERROR: &str = "Could not transmit";
 /// Host to bind the OAuth server to in production.
 const PROD_LOCALHOST: &str = "127.0.0.1:8080";
 const SCOPE: &str = "data:read_write,data:delete,project:delete";
@@ -107,8 +106,11 @@ async fn receive_callback(
                 } else {
                     String::from("Success! You can close this window and return to your terminal.")
                 };
-                tx.send(params).expect(TRANSMIT_ERROR);
-                response_message
+                if tx.send(params).is_err() {
+                    String::from("Error: Could not transmit response")
+                } else {
+                    response_message
+                }
             } else {
                 String::from("Error: Could not get response tx")
             }

--- a/src/reminders.rs
+++ b/src/reminders.rs
@@ -33,11 +33,11 @@ impl Reminder {
 impl Display for Reminder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(dateinfo) = &self.due {
-            write!(f, "{}", dateinfo)
+            write!(f, "{dateinfo}")
         } else if let Some(minute_offset) = self.minute_offset {
-            write!(f, "{}", minute_offset)
+            write!(f, "{minute_offset}")
         } else {
-            write!(f, "{:?}", self)
+            write!(f, "{self:?}")
         }
     }
 }

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -855,7 +855,7 @@ pub fn sort_by_value(mut tasks: Vec<Task>, config: &Config) -> Vec<Task> {
 
 fn compare_by_sort_order(a: &Task, b: &Task, config: &Config) -> Ordering {
     for rule in config.sort_order.as_deref().unwrap_or_default() {
-        let ordering = compare_by_sort_key(a, b, config, &rule.key);
+        let ordering = compare_by_sort_key(a, b, config, rule.key);
         if ordering != Ordering::Equal {
             return match rule.direction {
                 SortDirection::Asc => ordering,
@@ -867,7 +867,7 @@ fn compare_by_sort_order(a: &Task, b: &Task, config: &Config) -> Ordering {
     Ordering::Equal
 }
 
-fn compare_by_sort_key(a: &Task, b: &Task, config: &Config, key: &SortKey) -> Ordering {
+fn compare_by_sort_key(a: &Task, b: &Task, config: &Config, key: SortKey) -> Ordering {
     match key {
         SortKey::Priority => a.priority.to_integer().cmp(&b.priority.to_integer()),
         SortKey::DueDate => compare_datetime(a.datetime(config), b.datetime(config)),
@@ -1007,13 +1007,12 @@ pub async fn create_reminder(config: &Config, task: Task) -> Result<Option<JoinH
             let handle = spawn_complete_task(config, task.id);
             Ok(Some(handle))
         }
-        DateTimeInput::Skip => Ok(None),
+        DateTimeInput::Skip | input::DateTimeInput::None => Ok(None),
 
         input::DateTimeInput::Text(date) => {
             let handle = spawn_create_reminder(config, task, date);
             Ok(Some(handle))
         }
-        input::DateTimeInput::None => Ok(None),
     }
 }
 

--- a/src/todoist/request.rs
+++ b/src/todoist/request.rs
@@ -154,8 +154,8 @@ pub async fn get_todoist(config: &Config, url: &str, spinner: bool) -> Result<St
 const CODES_REQUIRING_LOGIN: [u16; 2] = [HTTP_FORBIDDEN, HTTP_UNAUTHORIZED];
 const PRO_PLAN_URLS: [&str; 1] = [REMINDERS_URL];
 
-fn requires_login(status_code: &u16) -> bool {
-    CODES_REQUIRING_LOGIN.contains(status_code)
+fn requires_login(status_code: u16) -> bool {
+    CODES_REQUIRING_LOGIN.contains(&status_code)
 }
 
 /// Returns true if this url can only be accessed by Todoist pro plan users
@@ -175,7 +175,7 @@ async fn handle_response(
         let json_string = response.text().await?;
         debug::maybe_print(config, &format!("{method} {url}\nresponse: {json_string}"));
         Ok(json_string)
-    } else if requires_login(&status_code) && !is_pro_plan_url(url) {
+    } else if requires_login(status_code) && !is_pro_plan_url(url) {
         let command = format::blue_string("tod auth login");
         Err(Error::new(
             "reqwest",
@@ -183,7 +183,7 @@ async fn handle_response(
                 "Unauthorized or Forbidden response from Todoist\nRun {command} to reauthenticate"
             ),
         ))
-    } else if requires_login(&status_code) && is_pro_plan_url(url) {
+    } else if requires_login(status_code) && is_pro_plan_url(url) {
         Err(Error::new("reqwest", REMINDERS_PRO_PLAN_MESSAGE))
     } else {
         let json_string = response.text().await?;
@@ -275,10 +275,10 @@ mod tests {
 
     #[test]
     fn test_requires_login() {
-        assert!(requires_login(&HTTP_UNAUTHORIZED));
-        assert!(requires_login(&HTTP_FORBIDDEN));
-        assert!(!requires_login(&200));
-        assert!(!requires_login(&500));
+        assert!(requires_login(HTTP_UNAUTHORIZED));
+        assert!(requires_login(HTTP_FORBIDDEN));
+        assert!(!requires_login(200));
+        assert!(!requires_login(500));
     }
 
     #[test]


### PR DESCRIPTION
# 📦 Pull Request

## Summary

This PR does several things:
1) It removes all other config creation and auth edit workflows besides "tod auth login" or "tod auth token"
2) It returns an error that config file is not initialized and prompts to run those commands if it is not set or present.
3) Removes the unnecessary and unused helper functions, edit prompts, and other code that is now unused as the only config creation commands are now the auth login.

See https://github.com/tod-org/tod/issues/1397#issuecomment-3074390643 for workflow now followed
All other commands now state "initialize tod with 'tod auth login' " if the config file doesn't exist.

This fixes #1685 #1684 #1680 

Also more fully completes #1397 and #1672

## PR Checklist

> Please confirm all items below before requesting a review (required for approval)

- [X] This PR/commit messages follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [X] All CI checks pass
- [X] Documentation is updated if necessary
- [X] This PR is tagged with any appropriate tags
- [X] This PR is ready for **review**  

Important note:

- All CI Checks must pass before PR is committed.
- All PRs must be reviewed before PR is committed.
- Only rebasing is allowed. Any merge commits in the chain will block PR from being commited.
