### PR TITLE
fix(config): fail reset when config is missing

### DIFF
--- a/src/commands/config_commands.rs
+++ b/src/commands/config_commands.rs
@@ -432,6 +432,98 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_config_check_aborts_when_remove_declined() {
+        let dir = tempdir().expect("temp dir should be created");
+        let path = dir.path().join("tod.cfg");
+        let contents = serde_json::json!({
+            "path": path,
+            "timezone": "UTC",
+            "unknown_key": []
+        })
+        .to_string();
+        tokio::fs::write(&path, &contents)
+            .await
+            .expect("config should be written");
+
+        let response = check_with_prompts(Some(path.clone()), |_| Ok(false), |_| Ok(true))
+            .await
+            .expect("config check should abort when remove prompt is declined");
+
+        assert_eq!(response, "Config check aborted. No changes made.");
+        let unchanged = tokio::fs::read_to_string(&path)
+            .await
+            .expect("config should still be readable");
+        assert_eq!(unchanged, contents);
+    }
+
+    #[tokio::test]
+    async fn test_config_check_reports_parse_error_for_invalid_json() {
+        let dir = tempdir().expect("temp dir should be created");
+        let path = dir.path().join("tod.cfg");
+        tokio::fs::write(&path, "{ invalid")
+            .await
+            .expect("invalid config should be written");
+
+        let error = check_with_prompts(Some(path.clone()), |_| Ok(true), |_| Ok(true))
+            .await
+            .expect_err("invalid JSON should fail config check");
+
+        assert_eq!(error.source, "config_check");
+        assert!(
+            error.message.contains("could not be parsed as JSON"),
+            "Expected parse guidance in error message, got: {}",
+            error.message
+        );
+    }
+
+    #[tokio::test]
+    async fn test_config_check_reports_unrepairable_config_error() {
+        let dir = tempdir().expect("temp dir should be created");
+        let path = dir.path().join("tod.cfg");
+        let contents = serde_json::json!({
+            "path": path,
+            "timezone": 123
+        })
+        .to_string();
+        tokio::fs::write(&path, contents)
+            .await
+            .expect("invalid config should be written");
+
+        let error = check_with_prompts(Some(path.clone()), |_| Ok(true), |_| Ok(true))
+            .await
+            .expect_err("non-repairable config should fail");
+
+        assert_eq!(error.source, "config_check");
+        assert!(
+            error
+                .message
+                .contains("could not be automatically repaired"),
+            "Expected repair guidance in error message, got: {}",
+            error.message
+        );
+    }
+
+    #[tokio::test]
+    async fn test_config_check_valid_file_returns_valid_message() {
+        let dir = tempdir().expect("temp dir should be created");
+        let path = dir.path().join("tod.cfg");
+        Config::default_test()
+            .with_path(path.clone())
+            .create()
+            .await
+            .expect("valid config should be created");
+
+        let response = check_with_prompts(Some(path.clone()), |_| Ok(true), |_| Ok(true))
+            .await
+            .expect("valid config should pass check");
+
+        assert_eq!(
+            response,
+            format!("Config file at {} is valid.", path.display())
+        );
+    }
+
+    #[tokio::test]
     async fn test_config_check_version_outdated() {
         // Start mock server
         let mut server = Server::new_async().await;

--- a/src/commands/project_commands.rs
+++ b/src/commands/project_commands.rs
@@ -198,3 +198,25 @@ pub async fn empty(config: &mut Config, args: &Empty) -> Result<String, Error> {
 
     projects::empty(config, &project).await
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn remove_rejects_conflicting_all_and_auto_flags() {
+        let mut config = Config::default();
+        let args = Remove {
+            auto: true,
+            repeat: false,
+            all: true,
+            project: None,
+        };
+
+        let error = remove(&mut config, &args)
+            .await
+            .expect_err("conflicting flags should fail");
+        assert_eq!(error.source, "project_remove");
+        assert_eq!(error.message, "Incorrect flags provided");
+    }
+}

--- a/src/commands/reminder_commands.rs
+++ b/src/commands/reminder_commands.rs
@@ -16,3 +16,48 @@ pub struct List {}
 pub async fn list(config: &mut Config, _args: &List) -> Result<String, Error> {
     reminders::list(config).await
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test;
+    use crate::test::responses::ResponseFromFile;
+    use mockito::Server;
+
+    #[tokio::test]
+    async fn list_delegates_to_reminders_module() {
+        let mut server = Server::new_async().await;
+        let reminders_mock = server
+            .mock("GET", "/api/v1/reminders?limit=200")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(ResponseFromFile::Reminders.read().await)
+            .create_async()
+            .await;
+
+        let tasks_mock = server
+            .mock("GET", "/api/v1/tasks/?ids=6Xqhv4cwxgjwG9w8&limit=200")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(ResponseFromFile::TodayTasks.read().await)
+            .create_async()
+            .await;
+
+        let mut config = test::fixtures::config()
+            .await
+            .create()
+            .await
+            .expect("config should be created")
+            .with_mock_url(server.url())
+            .with_projects(vec![test::fixtures::project()]);
+        config.save().await.expect("config should be saved");
+
+        let output = list(&mut config, &List {})
+            .await
+            .expect("reminder list command should succeed");
+        assert!(output.contains("Reminders"));
+
+        reminders_mock.assert();
+        tasks_mock.assert();
+    }
+}

--- a/src/commands/section_commands.rs
+++ b/src/commands/section_commands.rs
@@ -31,3 +31,24 @@ pub async fn create(config: &Config, args: &Create) -> Result<String, Error> {
     todoist::create_section(config, &name, &project, true).await?;
     Ok(format::green_string("Section created successfully"))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn create_fails_when_no_projects_exist_in_config() {
+        let config = Config::default();
+        let args = Create {
+            name: Some("new-section".to_string()),
+            project: None,
+        };
+
+        let error = create(&config, &args)
+            .await
+            .expect_err("creating a section should fail without configured projects");
+
+        assert_eq!(error.source, "fetch_project");
+        assert!(error.message.contains("No projects in config"));
+    }
+}

--- a/src/commands/task_commands.rs
+++ b/src/commands/task_commands.rs
@@ -300,3 +300,51 @@ pub async fn comment(config: Config, args: &Comment) -> Result<String, Error> {
         )),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_args() -> Create {
+        Create {
+            project: None,
+            due: None,
+            description: String::new(),
+            content: None,
+            no_section: false,
+            priority: None,
+            label: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn no_flags_used_returns_true_for_default_create_args() {
+        let args = create_args();
+        assert!(no_flags_used(&args));
+    }
+
+    #[test]
+    fn no_flags_used_returns_false_when_any_flag_is_set() {
+        let mut args = create_args();
+        args.priority = Some(3);
+        assert!(!no_flags_used(&args));
+    }
+
+    #[test]
+    fn is_no_sections_respects_argument_flag() {
+        let mut args = create_args();
+        args.no_section = true;
+
+        let config = Config::default();
+        assert!(is_no_sections(&args, &config));
+    }
+
+    #[test]
+    fn is_no_sections_respects_config_setting() {
+        let args = create_args();
+        let mut config = Config::default();
+        config.no_sections = Some(true);
+
+        assert!(is_no_sections(&args, &config));
+    }
+}

--- a/src/commands/test_commands.rs
+++ b/src/commands/test_commands.rs
@@ -15,3 +15,13 @@ pub struct All {}
 pub async fn all(config: &Config, _args: &All) -> Result<String, Error> {
     todoist::test_all_endpoints(config).await
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_command_is_constructible() {
+        let _ = All {};
+    }
+}

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -641,6 +641,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_config_reset_with_prompt_directory_path_returns_delete_error() {
+        let temp_dir = tempdir().expect("temp dir should be created");
+        let dir_path = temp_dir.path().to_path_buf();
+
+        let result = config_reset_with_prompt(Some(dir_path.clone()), true, |_| {
+            panic!("prompt should not be called when force is enabled")
+        })
+        .await;
+
+        let err = result.expect_err("directory paths should fail file deletion");
+        assert_eq!(err.source, "config_reset");
+        assert!(
+            err.message.contains(&format!(
+                "Could not delete config file at {}",
+                dir_path.display()
+            )),
+            "Expected deletion error with path, got: {}",
+            err.message
+        );
+    }
+
+    #[tokio::test]
     async fn test_config_open_missing_returns_error() {
         let (_temp_dir, temp_path) = temp_config_path("missing_open_no.cfg");
 

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -151,7 +151,7 @@ where
         None => generate_path().await?,
     };
 
-    if !path.exists() {
+    if !fs::try_exists(&path).await? {
         return Err(Error::new(
             "config_reset",
             &format!("No config file found at {}.", path.display()),

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -152,7 +152,10 @@ where
     };
 
     if !path.exists() {
-        return Ok(format!("No config file found at {}.", path.display()));
+        return Err(Error::new(
+            "config_reset",
+            &format!("No config file found at {}.", path.display()),
+        ));
     }
 
     if !force && !prompt_fn(&path) {
@@ -616,6 +619,25 @@ mod tests {
 
         assert_eq!(result, Ok("Aborted: Config not deleted.".to_string()));
         assert_eq!(prompted_path, Some(temp_path));
+    }
+
+    #[tokio::test]
+    async fn test_config_reset_with_prompt_missing_config_returns_error() {
+        let (_temp_dir, temp_path) = temp_config_path("temp_test_config_prompt_missing.cfg");
+
+        let result = config_reset_with_prompt(Some(temp_path.clone()), true, |_| {
+            panic!("prompt should not be called for missing config")
+        })
+        .await;
+
+        let err = result.expect_err("missing config should return an error");
+        assert_eq!(err.source, "config_reset");
+        assert!(
+            err.message
+                .contains(&format!("No config file found at {}", temp_path.display())),
+            "Expected missing config path in error message, got: {}",
+            err.message
+        );
     }
 
     #[tokio::test]

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -87,3 +87,37 @@ fn sort_key_default_index(key: SortKey) -> usize {
         .position(|default_key| *default_key == key)
         .unwrap_or(usize::MAX)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_and_migrate_sort_value_returns_none_for_missing_input() {
+        assert_eq!(detect_and_migrate_sort_value(None), None);
+    }
+
+    #[test]
+    fn detect_and_migrate_sort_value_prioritizes_highest_weighted_key() {
+        let legacy = LegacySortValue {
+            priority_none: Some(0),
+            priority_low: Some(0),
+            priority_medium: Some(0),
+            priority_high: Some(0),
+            no_due_date: Some(0),
+            not_recurring: Some(0),
+            today: Some(0),
+            overdue: Some(9),
+            now: Some(0),
+            deadline_value: Some(1),
+            deadline_days: Some(0),
+        };
+
+        let migrated = detect_and_migrate_sort_value(Some(&legacy))
+            .expect("legacy sort config should migrate");
+        let first = migrated
+            .first()
+            .expect("migrated sort order should not be empty");
+        assert_eq!(first.key, SortKey::Overdue);
+    }
+}

--- a/tests/config_create.rs
+++ b/tests/config_create.rs
@@ -182,7 +182,7 @@ fn config_reset_force_deletes_existing_config() {
     assert!(!path.exists(), "config should be gone after reset --force");
 }
 
-/// `config reset --force` when no config file exists reports the path and succeeds.
+/// `config reset --force` when no config file exists reports the path and fails.
 #[test]
 fn config_reset_force_when_config_absent_reports_not_found() {
     let dir = tempdir().expect("temp dir should be created");
@@ -195,8 +195,8 @@ fn config_reset_force_when_config_absent_reports_not_found() {
         .arg(&path)
         .args(["config", "reset", "--force"])
         .assert()
-        .success()
-        .stdout(predicate::str::contains("No config file found at"));
+        .failure()
+        .stderr(predicate::str::contains("No config file found at"));
 }
 
 /// `-c` passes an explicit config path through reset and reports that exact path on deletion.
@@ -230,6 +230,6 @@ fn config_reset_force_with_short_config_flag_reports_missing_manual_path() {
         .arg(&path)
         .args(["config", "reset", "--force"])
         .assert()
-        .success()
-        .stdout(predicate::str::contains(expected));
+        .failure()
+        .stderr(predicate::str::contains(expected));
 }


### PR DESCRIPTION
Return an error from config reset when the target config file does not exist so the CLI exits with code 1.

Align integration and unit tests to assert failure and stderr for missing config paths.

Fixes #1689 

Also adds several recommended tests by Coilot to expand Codecov.
