### PR TITLE
ci(dependabot): assign reviewers only for major or failing updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    assignees:
-      - alanvardy
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -21,8 +19,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    assignees:
-      - stacksjb
     commit-message:
       prefix: "chore"
       include: "scope"

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -31,6 +31,32 @@ jobs:
         with:
           github-token: ${{ steps.app-token.outputs.token }}
 
+      - id: assignee
+        name: Resolve assignee
+        env:
+          PACKAGE_ECOSYSTEM: ${{ steps.meta.outputs.package-ecosystem }}
+        run: |
+          case "${PACKAGE_ECOSYSTEM}" in
+            cargo)
+              echo "value=alanvardy" >> "$GITHUB_OUTPUT"
+              ;;
+            github-actions)
+              echo "value=stacksjb" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "value=" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Assign major updates for review
+        if: steps.meta.outputs.update-type == 'version-update:semver-major' && steps.assignee.outputs.value != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} \
+            --repo "${{ github.repository }}" \
+            --add-assignee "${{ steps.assignee.outputs.value }}"
+
       - name: Approve Dependabot PR (minor/patch only)
         if: steps.meta.outputs.update-type == 'version-update:semver-minor' || steps.meta.outputs.update-type == 'version-update:semver-patch'
         uses: hmarr/auto-approve-action@v4

--- a/.github/workflows/dependabot_review_assignment.yml
+++ b/.github/workflows/dependabot_review_assignment.yml
@@ -1,0 +1,65 @@
+name: Dependabot Review Assignment
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  workflow_run:
+    workflows:
+      - Dependabot Full CI
+    types: [completed]
+
+jobs:
+  assign-on-ci-failure:
+    name: Assign failed Dependabot updates
+    if: |
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'success' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]' &&
+      github.event.workflow_run.pull_requests[0] != null
+    runs-on: ubuntu-latest
+    steps:
+      - id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.TODD_APP_ID }}
+          private-key: ${{ secrets.TODD_PRIVATE_KEY }}
+          owner: tod-org
+          repositories: tod
+
+      - id: pr
+        name: Get pull request details
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          head_ref=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefName --jq '.headRefName')
+          echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "head_ref=${head_ref}" >> "$GITHUB_OUTPUT"
+
+      - id: assignee
+        name: Resolve assignee
+        env:
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+        run: |
+          case "${HEAD_REF}" in
+            dependabot/cargo/*)
+              echo "value=alanvardy" >> "$GITHUB_OUTPUT"
+              ;;
+            dependabot/github_actions/*)
+              echo "value=stacksjb" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "value=" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Assign for manual review
+        if: steps.assignee.outputs.value != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh pr edit "${{ steps.pr.outputs.number }}" \
+            --repo "${{ github.repository }}" \
+            --add-assignee "${{ steps.assignee.outputs.value }}"

--- a/.github/workflows/dependabot_review_assignment.yml
+++ b/.github/workflows/dependabot_review_assignment.yml
@@ -10,6 +10,10 @@ on:
       - Dependabot Full CI
     types: [completed]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.id }}
+  cancel-in-progress: true
+
 jobs:
   assign-on-ci-failure:
     name: Assign failed Dependabot updates

--- a/.github/workflows/dependabot_review_assignment.yml
+++ b/.github/workflows/dependabot_review_assignment.yml
@@ -13,11 +13,11 @@ on:
 jobs:
   assign-on-ci-failure:
     name: Assign failed Dependabot updates
-    if: |
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion != 'success' &&
-      github.event.workflow_run.actor.login == 'dependabot[bot]' &&
-      github.event.workflow_run.pull_requests[0] != null
+if: |
+  github.event.workflow_run.event == 'pull_request' &&
+  (github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out') &&
+  github.event.workflow_run.actor.login == 'dependabot[bot]' &&
+  github.event.workflow_run.pull_requests[0] != null
     runs-on: ubuntu-latest
     steps:
       - id: app-token


### PR DESCRIPTION
# 📦 Pull Request

Updates Dependabot CI to only assign based on the test results - dependabot merges that auto complete will automatically be resolved and won't be assigned. Major updates (based on semver) or those that fail willb e assigned for review.