### PR TITLE
ci: run codecov workflow on pull requests

### DIFF
--- a/.github/workflows/ci_codecov.yml
+++ b/.github/workflows/ci_codecov.yml
@@ -10,9 +10,14 @@ permissions:
 
 on:
   push:
-    # Post-merge only; PR branch coverage is handled by ci-pr.yml
     branches:
       - main
+    paths:
+      - "**/*.rs"
+      - "**/*.json"
+      - "**/*.lock"
+      - "**/*.toml"
+  pull_request:
     paths:
       - "**/*.rs"
       - "**/*.json"


### PR DESCRIPTION
Adds  trigger to the Codecov workflow so coverage is also collected on PRs, not just post-merge on main.