### PR TITLE
test: add unit tests for add_project and remove_project None branches

### DIFF
--- a/src/config/projects.rs
+++ b/src/config/projects.rs
@@ -47,3 +47,78 @@ impl Config {
         self.projects = Some(projects);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn add_project_when_projects_is_none_initializes_vec() {
+        let mut config = Config::default();
+        config.projects = None;
+        assert!(config.projects.is_none());
+
+        let project = Project {
+            id: "123".to_string(),
+            can_assign_tasks: false,
+            child_order: 0,
+            color: "blue".to_string(),
+            created_at: None,
+            is_archived: false,
+            is_deleted: false,
+            is_favorite: false,
+            is_frozen: false,
+            name: "test".to_string(),
+            updated_at: None,
+            view_style: "list".to_string(),
+            default_order: 0,
+            description: String::new(),
+            parent_id: None,
+            inbox_project: None,
+            is_collapsed: false,
+            is_shared: false,
+        };
+
+        config.add_project(project.clone());
+
+        let projects = config.projects.expect("projects should be initialized");
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].id, "123");
+    }
+
+    #[test]
+    fn remove_project_when_projects_is_none_does_not_panic() {
+        let mut config = Config::default();
+        config.projects = None;
+        assert!(config.projects.is_none());
+
+        let project = Project {
+            id: "nonexistent".to_string(),
+            can_assign_tasks: false,
+            child_order: 0,
+            color: "blue".to_string(),
+            created_at: None,
+            is_archived: false,
+            is_deleted: false,
+            is_favorite: false,
+            is_frozen: false,
+            name: "dummy".to_string(),
+            updated_at: None,
+            view_style: "list".to_string(),
+            default_order: 0,
+            description: String::new(),
+            parent_id: None,
+            inbox_project: None,
+            is_collapsed: false,
+            is_shared: false,
+        };
+
+        config.remove_project(&project);
+
+        let projects = config
+            .projects
+            .expect("projects should be set to Some even when empty");
+        assert!(projects.is_empty());
+    }
+}


### PR DESCRIPTION
Cover the previously untested `None` paths in `Config::add_project` and `Config::remove_project`.

- **`add_project`**: when `self.projects` is `None`, verifies it initializes a new `Vec` with the project
- **`remove_project`**: when `self.projects` is `None`, verifies the `unwrap_or_default()` fallback does not panic and results in an empty `Some(vec![])`

Both are pure unit tests following existing codebase conventions — inline in `#[cfg(test)] mod tests`, no external dependencies.