### PR TITLE
fix(e2e): force non-interactive project cleanup

### DIFF
--- a/crates/tod-e2e/tests/e2e_todoist.rs
+++ b/crates/tod-e2e/tests/e2e_todoist.rs
@@ -164,7 +164,7 @@ fn cleanup_project_tasks(config: &Path, project: &str) {
     let _ = tod()
         .arg("--config")
         .arg(config)
-        .args(["project", "empty", "--project", project])
+        .args(["project", "empty", "--force", "--project", project])
         .output();
 
     let mut consecutive_empty_checks = 0_u8;

--- a/crates/tod-e2e/tests/e2e_todoist.rs
+++ b/crates/tod-e2e/tests/e2e_todoist.rs
@@ -164,7 +164,7 @@ fn cleanup_project_tasks(config: &Path, project: &str) {
     let _ = tod()
         .arg("--config")
         .arg(config)
-        .args(["project", "empty", "--force", "--project", project])
+        .args(["project", "empty", "--project", project])
         .output();
 
     let mut consecutive_empty_checks = 0_u8;
@@ -875,21 +875,25 @@ fn quick_project_create_and_task_create() {
     ensure_project_exists(&config, DYNAMIC_PROJECT);
 
     tod()
-            .arg("--config")
-            .arg(&config)
-            .args([
-                "task",
-                "create",
-                "--content",
-                "[E2E] Quick Task",
-                "--project",
-                DYNAMIC_PROJECT,
-                "--priority",
-                "1",
-                "--no-section",
-            ])
-            .assert()
-            .success();
+        .arg("--config")
+        .arg(&config)
+        .args([
+            "task",
+            "create",
+            "--content",
+            "[E2E] Quick Task",
+            "--project",
+            DYNAMIC_PROJECT,
+            "--priority",
+            "1",
+            "--no-section",
+        ])
+        .assert()
+        .success();
+
+    assert_next_task(&config, DYNAMIC_PROJECT, "[E2E] Quick Task");
+    task_complete(&config);
+    pause_for_api_sync();
 
     cleanup_project_tasks(&config, DYNAMIC_PROJECT);
     pause_for_api_sync();

--- a/src/commands/project_commands.rs
+++ b/src/commands/project_commands.rs
@@ -117,10 +117,6 @@ pub struct Rename {
 }
 #[derive(Parser, Debug, Clone)]
 pub struct Empty {
-    #[arg(short, long, default_value_t = false)]
-    /// Skip confirmation prompts and complete tasks non-interactively
-    force: bool,
-
     #[arg(short, long)]
     /// Project to remove
     project: Option<String>,
@@ -218,15 +214,11 @@ pub async fn import(config: &mut Config, args: &Import) -> Result<String, Error>
 }
 
 pub async fn empty(config: &mut Config, args: &Empty) -> Result<String, Error> {
-    let Empty { force, project } = args;
+    let Empty { project } = args;
     let project = match super::fetch_project(project.as_deref(), config).await? {
         Flag::Project(project) => project,
         Flag::Filter(_) => unreachable!(),
     };
-
-    if *force {
-        config.mock_select = Some(1);
-    }
 
     projects::empty(config, &project).await
 }

--- a/src/commands/project_commands.rs
+++ b/src/commands/project_commands.rs
@@ -117,6 +117,10 @@ pub struct Rename {
 }
 #[derive(Parser, Debug, Clone)]
 pub struct Empty {
+    #[arg(short, long, default_value_t = false)]
+    /// Skip confirmation prompts and complete tasks non-interactively
+    force: bool,
+
     #[arg(short, long)]
     /// Project to remove
     project: Option<String>,
@@ -214,11 +218,15 @@ pub async fn import(config: &mut Config, args: &Import) -> Result<String, Error>
 }
 
 pub async fn empty(config: &mut Config, args: &Empty) -> Result<String, Error> {
-    let Empty { project } = args;
+    let Empty { force, project } = args;
     let project = match super::fetch_project(project.as_deref(), config).await? {
         Flag::Project(project) => project,
         Flag::Filter(_) => unreachable!(),
     };
+
+    if *force {
+        config.mock_select = Some(1);
+    }
 
     projects::empty(config, &project).await
 }


### PR DESCRIPTION
# 📦 Pull Request

## Summary

This PR udpates E2E test to cleanup the single new quickadd task which was causing it to fail.