### PR TITLE
fix: cleanup dynamic project before quick task create test

### DIFF
--- a/crates/tod-e2e/tests/e2e_todoist.rs
+++ b/crates/tod-e2e/tests/e2e_todoist.rs
@@ -874,6 +874,9 @@ fn quick_project_create_and_task_create() {
     import_projects(&config);
     ensure_project_exists(&config, DYNAMIC_PROJECT);
 
+    cleanup_project_tasks(&config, DYNAMIC_PROJECT);
+    pause_for_api_sync();
+
     tod()
         .arg("--config")
         .arg(&config)


### PR DESCRIPTION
The shared `TOD_DEV_CI_DYNAMIC` project can accumulate stale `[E2E]` tasks from prior test runs (e.g. cancelled CI jobs). `quick_project_create_and_task_create` did not clean them up before creating its own task, causing `assert_next_task` to find a leftover task instead of the freshly created one.

Add `cleanup_project_tasks` and `pause_for_api_sync` after `ensure_project_exists`, matching the pattern already used by `dynamic_task_lifecycle`.