### PR TITLE
ci(e2e): Fix API delays and break out dynamic tests

### DIFF
--- a/.github/workflows/e2e_todoist_clean.yml
+++ b/.github/workflows/e2e_todoist_clean.yml
@@ -1,0 +1,74 @@
+name: E2E Purge Dynamic Tasks
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  purge:
+    name: Purge Todoist dynamic test projects
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate Todoist token
+        env:
+          TODOIST_TOKEN: ${{ secrets.TODOIST_DEV_API_TEST }}
+        run: |
+          test -n "${TODOIST_TOKEN}" || {
+            echo "TODOIST_DEV_API_TEST secret is required";
+            exit 1;
+          }
+
+      - name: Delete tasks from dynamic projects
+        env:
+          TODOIST_TOKEN: ${{ secrets.TODOIST_DEV_API_TEST }}
+        run: |
+          set -euo pipefail
+
+          python - <<'PY'
+          import json
+          import os
+          import sys
+          import urllib.error
+          import urllib.request
+
+          token = os.environ["TODOIST_TOKEN"]
+          project_names = ["TOD_DEV_CI_DYNAMIC_1", "TOD_DEV_CI_DYNAMIC_2"]
+          api_base = "https://api.todoist.com/rest/v2"
+
+          def request(path: str, method: str = "GET"):
+              req = urllib.request.Request(
+                  f"{api_base}{path}",
+                  method=method,
+                  headers={"Authorization": f"Bearer {token}"},
+              )
+              with urllib.request.urlopen(req) as response:
+                  if response.status == 204:
+                      return None
+                  return response.read().decode("utf-8")
+
+          projects_payload = request("/projects")
+          projects = json.loads(projects_payload)
+          project_ids = {project["name"]: project["id"] for project in projects if project["name"] in project_names}
+
+          missing = [name for name in project_names if name not in project_ids]
+          if missing:
+              raise SystemExit(f"Missing projects: {', '.join(missing)}")
+
+          for name in project_names:
+              project_id = project_ids[name]
+              tasks_payload = request(f"/tasks?project_id={project_id}")
+              tasks = json.loads(tasks_payload)
+              print(f"Found {len(tasks)} task(s) in {name}")
+
+              for task in tasks:
+                  try:
+                      request(f"/tasks/{task['id']}", method="DELETE")
+                  except urllib.error.HTTPError as exc:
+                      if exc.code != 404:
+                          raise
+                  print(f"Deleted task {task['id']} from {name}")
+
+          print("Purge complete")
+          PY

--- a/.github/workflows/e2e_todoist_clean.yml
+++ b/.github/workflows/e2e_todoist_clean.yml
@@ -3,6 +3,10 @@ name: E2E Purge Dynamic Tasks
 on:
   workflow_dispatch:
 
+concurrency:
+  group: e2e-todoist-clean
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/e2e_todoist_clean.yml
+++ b/.github/workflows/e2e_todoist_clean.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          python - <<'PY'
+          python3 - <<'PY'
           import json
           import os
           import sys

--- a/crates/tod-e2e/Cargo.toml
+++ b/crates/tod-e2e/Cargo.toml
@@ -10,5 +10,4 @@ assert_cmd = "2.2.2"
 predicates = "3.1.4"
 reqwest = { version = "0.13", features = ["blocking", "json"] }
 serde_json = "1.0.150"
-serial_test = { version = "4.0.1", features = ["file_locks"] }
 tempfile = "3.27.0"

--- a/crates/tod-e2e/tests/e2e_todoist.rs
+++ b/crates/tod-e2e/tests/e2e_todoist.rs
@@ -28,7 +28,6 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tempfile::{TempDir, tempdir};
 
 const STATIC_READ_PROJECT: &str = "TOD_DEV_CI_STATIC_READ";
-const DYNAMIC_PROJECT: &str = "TOD_DEV_CI_DYNAMIC";
 const DYNAMIC_PROJECT_1: &str = "TOD_DEV_CI_DYNAMIC_1";
 const DYNAMIC_PROJECT_2: &str = "TOD_DEV_CI_DYNAMIC_2";
 
@@ -224,7 +223,7 @@ fn assert_next_task(config: &Path, project: &str, expected: &str) {
             }
         }
 
-        sleep(Duration::from_millis(750));
+        pause_for_api_sync();
     }
 
     panic!("expected task next output to contain {expected:?}, last output was {last_stdout:?}");
@@ -250,7 +249,7 @@ fn assert_list_view_contains(config: &Path, project: &str, expected: &[&str]) {
             }
         }
 
-        sleep(Duration::from_millis(750));
+        pause_for_api_sync();
     }
 
     panic!(
@@ -260,7 +259,7 @@ fn assert_list_view_contains(config: &Path, project: &str, expected: &[&str]) {
 }
 
 fn pause_for_api_sync() {
-    sleep(Duration::from_millis(1000));
+    sleep(Duration::from_millis(750));
 }
 
 /// Calls `task complete` (completes the last task returned by `task next`).

--- a/crates/tod-e2e/tests/e2e_todoist.rs
+++ b/crates/tod-e2e/tests/e2e_todoist.rs
@@ -737,12 +737,8 @@ fn filter_by_section_returns_expected_tasks() {
     assert_eq!(actual_priorities, vec![1, 4]);
 }
 
-// ---------------------------------------------------------------------------
-// Dynamic tests — reuse TOD_DEV_CI_DYNAMIC, cleanup between tests
-// (and run serially via serial_test lock)
-// ---------------------------------------------------------------------------
-
-/// Create 2 tasks, verify list and next, then complete them.
+// Dynamic tests — use TOD_DEV_CI_DYNAMIC_1 & TOD_DEV_CI_DYNAMIC_2, cleanup after tests
+// Create 2 tasks, verify list and next, then complete them.
 #[test]
 fn dynamic_task_lifecycle() {
     let (_dir, config) = setup_config();
@@ -882,7 +878,7 @@ fn empty_project_list_and_next_show_nothing_present() {
     pause_for_api_sync();
 }
 
-/// Create a task in the existing dynamic project and clean the project up afterward.
+/// Create a task in the existing dynamic project and complete it.
 #[test]
 fn quick_project_create_and_task_create() {
     let (_dir, config) = setup_config();

--- a/crates/tod-e2e/tests/e2e_todoist.rs
+++ b/crates/tod-e2e/tests/e2e_todoist.rs
@@ -159,50 +159,6 @@ fn ensure_project_exists(config: &Path, project: &str) {
     pause_for_api_sync();
 }
 
-/// Cleanup helper: repeatedly calls `task next --project` and completes any
-/// returned task until the project is empty.
-fn cleanup_project_tasks(config: &Path, project: &str) {
-    let _ = tod()
-        .arg("--config")
-        .arg(config)
-        .args(["project", "empty", "--project", project])
-        .output();
-
-    let mut consecutive_empty_checks = 0_u8;
-    for _ in 0..80 {
-        let output = tod()
-            .arg("--config")
-            .arg(config)
-            .args(["task", "next", "--project", project])
-            .output()
-            .expect("task next should run");
-
-        if !output.status.success() {
-            sleep(Duration::from_millis(350));
-            continue;
-        }
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        if stdout.contains("No tasks on list") {
-            consecutive_empty_checks += 1;
-            if consecutive_empty_checks >= 3 {
-                break;
-            }
-            sleep(Duration::from_millis(350));
-            continue;
-        }
-        consecutive_empty_checks = 0;
-
-        tod()
-            .arg("--config")
-            .arg(config)
-            .args(["task", "complete"])
-            .assert()
-            .success();
-        sleep(Duration::from_millis(350));
-    }
-}
-
 /// Calls `task next --project <project>` and waits until the output contains `expected`.
 fn assert_next_task(config: &Path, project: &str, expected: &str) {
     let mut last_stdout = String::new();

--- a/crates/tod-e2e/tests/e2e_todoist.rs
+++ b/crates/tod-e2e/tests/e2e_todoist.rs
@@ -30,6 +30,8 @@ use tempfile::{TempDir, tempdir};
 
 const STATIC_READ_PROJECT: &str = "TOD_DEV_CI_STATIC_READ";
 const DYNAMIC_PROJECT: &str = "TOD_DEV_CI_DYNAMIC";
+const DYNAMIC_PROJECT_1: &str = "TOD_DEV_CI_DYNAMIC_1";
+const DYNAMIC_PROJECT_2: &str = "TOD_DEV_CI_DYNAMIC_2";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -788,15 +790,10 @@ fn filter_by_section_returns_expected_tasks() {
 
 /// Create 2 tasks, verify list and next, then complete them.
 #[test]
-#[serial]
 fn dynamic_task_lifecycle() {
     let (_dir, config) = setup_config();
     import_projects(&config);
-    sleep(Duration::from_millis(500));
-    ensure_project_exists(&config, DYNAMIC_PROJECT);
-    sleep(Duration::from_millis(500));
-    cleanup_project_tasks(&config, DYNAMIC_PROJECT);
-    pause_for_api_sync();
+    ensure_project_exists(&config, DYNAMIC_PROJECT_1);
 
     for priority in [4, 2].iter() {
         tod()
@@ -808,7 +805,7 @@ fn dynamic_task_lifecycle() {
                 "--content",
                 &format!("[E2E] Task Priority {}", priority),
                 "--project",
-                DYNAMIC_PROJECT,
+                DYNAMIC_PROJECT_1,
                 "--priority",
                 &priority.to_string(),
                 "--no-section",
@@ -820,18 +817,15 @@ fn dynamic_task_lifecycle() {
 
     assert_list_view_contains(
         &config,
-        DYNAMIC_PROJECT,
+        DYNAMIC_PROJECT_1,
         &["[E2E] Task Priority 4", "[E2E] Task Priority 2"],
     );
 
     for _ in 0..2 {
-        assert_next_task(&config, DYNAMIC_PROJECT, "[E2E] Task Priority");
+        assert_next_task(&config, DYNAMIC_PROJECT_1, "[E2E] Task Priority");
         task_complete(&config);
         pause_for_api_sync();
     }
-
-    cleanup_project_tasks(&config, DYNAMIC_PROJECT);
-    pause_for_api_sync();
 }
 
 /// Add a comment to the recurring static fixture task and verify it appears in the next output.
@@ -937,14 +931,10 @@ fn empty_project_list_and_next_show_nothing_present() {
 
 /// Create a task in the existing dynamic project and clean the project up afterward.
 #[test]
-#[serial]
 fn quick_project_create_and_task_create() {
     let (_dir, config) = setup_config();
     import_projects(&config);
-    ensure_project_exists(&config, DYNAMIC_PROJECT);
-
-    cleanup_project_tasks(&config, DYNAMIC_PROJECT);
-    pause_for_api_sync();
+    ensure_project_exists(&config, DYNAMIC_PROJECT_2);
 
     tod()
         .arg("--config")
@@ -955,7 +945,7 @@ fn quick_project_create_and_task_create() {
             "--content",
             "[E2E] Quick Task",
             "--project",
-            DYNAMIC_PROJECT,
+            DYNAMIC_PROJECT_2,
             "--priority",
             "1",
             "--no-section",
@@ -963,14 +953,10 @@ fn quick_project_create_and_task_create() {
         .assert()
         .success();
 
-    assert_next_task(&config, DYNAMIC_PROJECT, "[E2E] Quick Task");
+    assert_next_task(&config, DYNAMIC_PROJECT_2, "[E2E] Quick Task");
     task_complete(&config);
     pause_for_api_sync();
-
-    cleanup_project_tasks(&config, DYNAMIC_PROJECT);
-    pause_for_api_sync();
 }
-
 /// Create a random project, rename it, then delete it.
 #[test]
 fn dynamic_empty_project_create_query_delete() {

--- a/crates/tod-e2e/tests/e2e_todoist.rs
+++ b/crates/tod-e2e/tests/e2e_todoist.rs
@@ -215,7 +215,7 @@ fn assert_list_view_contains(config: &Path, project: &str, expected: &[&str]) {
 }
 
 fn pause_for_api_sync() {
-    sleep(Duration::from_millis(750));
+    sleep(Duration::from_millis(500));
 }
 
 /// Calls `task complete` (completes the last task returned by `task next`).
@@ -767,7 +767,6 @@ fn dynamic_task_lifecycle() {
             .assert()
             .success();
     }
-    pause_for_api_sync();
 
     assert_list_view_contains(
         &config,

--- a/crates/tod-e2e/tests/e2e_todoist.rs
+++ b/crates/tod-e2e/tests/e2e_todoist.rs
@@ -252,7 +252,10 @@ fn assert_list_view_contains(config: &Path, project: &str, expected: &[&str]) {
         sleep(Duration::from_millis(750));
     }
 
-    panic!("expected list view output to contain {:?}, last output was {:?}", expected, last_stdout);
+    panic!(
+        "expected list view output to contain {:?}, last output was {:?}",
+        expected, last_stdout
+    );
 }
 
 fn pause_for_api_sync() {
@@ -789,8 +792,9 @@ fn filter_by_section_returns_expected_tasks() {
 fn dynamic_task_lifecycle() {
     let (_dir, config) = setup_config();
     import_projects(&config);
+    sleep(Duration::from_millis(500));
     ensure_project_exists(&config, DYNAMIC_PROJECT);
-
+    sleep(Duration::from_millis(500));
     cleanup_project_tasks(&config, DYNAMIC_PROJECT);
     pause_for_api_sync();
 
@@ -892,7 +896,6 @@ fn recurring_filter_returns_recurring_task() {
 
 /// Empty project shows no tasks in list view and task next.
 #[test]
-#[serial]
 fn empty_project_list_and_next_show_nothing_present() {
     let (_dir, config) = setup_config();
     import_projects(&config);
@@ -970,12 +973,11 @@ fn quick_project_create_and_task_create() {
 
 /// Create a random project, rename it, then delete it.
 #[test]
-#[serial]
 fn dynamic_empty_project_create_query_delete() {
     let (_dir, config) = setup_config();
     import_projects(&config);
 
-    let project = random_project_name("TOD_CI_PRJ");
+    let project = random_project_name("TOD_CI_RND_PRJ");
     let renamed_project = format!("{project}_REN");
 
     tod()

--- a/crates/tod-e2e/tests/e2e_todoist.rs
+++ b/crates/tod-e2e/tests/e2e_todoist.rs
@@ -1,8 +1,8 @@
 //! End-to-end tests against the live Todoist API.
 //!
-//! Requires two Todoist projects to be pre-existing:
+//! Requires three Todoist projects to be pre-existing:
 //! - `TOD_DEV_CI_STATIC_READ` — read-only, pre-populated with test data
-//! - `TOD_DEV_CI_DYNAMIC` — reused across tests, tasks cleaned between runs
+//! - `TOD_DEV_CI_DYNAMIC_1` and `TOD_DEV_CI_DYNAMIC_2` — reused across tests, tasks cleaned between runs
 //! - A third `TOD_DEV_CI_PROJECTXXXX` — for project lifecycle tests (rename, delete, import) will be automatically created and deleted.
 //!
 //! The API token (`TOD_E2E_TOKEN`) is available to maintainers, in Github Secrets, or in CI only.

--- a/crates/tod-e2e/tests/e2e_todoist.rs
+++ b/crates/tod-e2e/tests/e2e_todoist.rs
@@ -19,7 +19,6 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 use serde_json::Value;
-use serial_test::serial;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command as StdCommand;

--- a/docs/dev_docs/ci_end2end.md
+++ b/docs/dev_docs/ci_end2end.md
@@ -20,6 +20,8 @@ The workflow maps this secret to `TOD_E2E_TOKEN` before running tests.
 
 The required projects can be imported from 'e2e_todoist_fixtures'
 
+If the dynamic projects are in an unclean state, manually run "E2E purge Dynamic Tasks" workflow
+
 ## Test model
 
 ### Static fixture project
@@ -31,7 +33,8 @@ The required projects can be imported from 'e2e_todoist_fixtures'
 
 ### Dynamic mutable project
 
-- `TOD_DEV_CI_DYNAMIC`
+- `TOD_DEV_CI_DYNAMIC_1` and `TOD_DEV_CI_DYNAMIC_2`
+- Two blank projects in which tasks are created/deleted
 - Used for create/complete/comment/empty-state flows
 - Must return to empty state after dynamic tests
 

--- a/docs/dev_docs/ci_end2end.md
+++ b/docs/dev_docs/ci_end2end.md
@@ -20,7 +20,7 @@ The workflow maps this secret to `TOD_E2E_TOKEN` before running tests.
 
 The required projects can be imported from 'e2e_todoist_fixtures'
 
-If the dynamic projects are in an unclean state, manually run "E2E purge Dynamic Tasks" workflow
+If the dynamic projects are in an unclean state, manually run "E2E Purge Dynamic Tasks" workflow
 
 ## Test model
 

--- a/src/commands/list_commands.rs
+++ b/src/commands/list_commands.rs
@@ -402,7 +402,7 @@ mod tests {
         std::fs::write(dir.path().join("readme.md"), "# Hello").expect("file should be created");
         let entry = walkdir::WalkDir::new(dir.path())
             .into_iter()
-            .filter_map(|e| e.ok())
+            .filter_map(std::result::Result::ok)
             .find(|e| e.file_name() == "readme.md")
             .expect("readme.md should be found");
         assert!(is_md_file(&entry));
@@ -414,7 +414,7 @@ mod tests {
         std::fs::write(dir.path().join("NOTES.MD"), "# Notes").expect("file should be created");
         let entry = walkdir::WalkDir::new(dir.path())
             .into_iter()
-            .filter_map(|e| e.ok())
+            .filter_map(std::result::Result::ok)
             .find(|e| e.file_name() == "NOTES.MD")
             .expect("NOTES.MD should be found");
         assert!(is_md_file(&entry));
@@ -426,7 +426,7 @@ mod tests {
         std::fs::write(dir.path().join("data.txt"), "hello").expect("file should be created");
         let entry = walkdir::WalkDir::new(dir.path())
             .into_iter()
-            .filter_map(|e| e.ok())
+            .filter_map(std::result::Result::ok)
             .find(|e| e.file_name() == "data.txt")
             .expect("data.txt should be found");
         assert!(!is_md_file(&entry));
@@ -438,7 +438,7 @@ mod tests {
         std::fs::write(dir.path().join("Makefile"), "all:").expect("file should be created");
         let entry = walkdir::WalkDir::new(dir.path())
             .into_iter()
-            .filter_map(|e| e.ok())
+            .filter_map(std::result::Result::ok)
             .find(|e| e.file_name() == "Makefile")
             .expect("Makefile should be found");
         assert!(!is_md_file(&entry));

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -542,7 +542,6 @@ mod tests {
     use crate::test::responses::ResponseFromFile;
     use crate::test_time::FixedTimeProvider;
     use crate::time::TimeProviderEnum;
-    use mockito;
     use tokio::sync::mpsc;
 
     #[test]

--- a/src/tasks/format.rs
+++ b/src/tasks/format.rs
@@ -409,7 +409,7 @@ mod tests {
         let mut task = test::fixtures::today_task().await;
         task.labels = vec!["foo".to_string(), "bar".to_string()];
         let result = labels(&task);
-        assert!(result.contains("@"));
+        assert!(result.contains('@'));
         assert!(result.contains("foo"));
         assert!(result.contains("bar"));
     }
@@ -510,7 +510,7 @@ mod tests {
             ..base_task.clone()
         };
         let out = due(&task_date, &config, "");
-        assert!(out.contains("!"));
+        assert!(out.contains('!'));
 
         // Datetime due with duration and recurring flag (→ DateTimeInfo::DateTime)
         let task_datetime = Task {


### PR DESCRIPTION
# 📦 Pull Request

## Summary

>This resolves the issue with E2E tests by breaking out the two Dynamic tests to run in separate projects, preventing the API interactions between the two.

It also removes the cleanup steps and puts them into a separate workflow file that can be run on demand if needed, as well as updating the appropriate documentaiton.