### PR TITLE
feat: --json flag foundation — Serialize, config plumbing, output gateway

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -59,6 +59,10 @@ pub struct Cli {
     /// Time to wait for a response from API in seconds. Defaults to 30.
     pub timeout: Option<u64>,
 
+    #[arg(short = 'j', long, global = true, default_value_t = false)]
+    /// Output results as JSON for machine-readable consumption
+    pub json: bool,
+
     #[command(subcommand)]
     pub command: Commands,
 }
@@ -137,18 +141,18 @@ pub async fn select_command(cli: Cli, tx: UnboundedSender<Error>) -> Result<Comm
         Commands::Project(command) => project_command(command, &cli, &tx).await,
         Commands::Reminder(command) => reminder_command(command, &cli, &tx).await,
         Commands::Section(command) => section_command(command, &cli, &tx).await,
-        Commands::Shell(command) => shell_command(command).await,
+        Commands::Shell(command) => shell_command(command, cli.json).await,
         Commands::Task(command) => task_command(command, &cli, &tx).await,
         Commands::Test(command) => test_command(command, &cli, &tx).await,
         // Shell
     }
 }
 
-async fn shell_command(command: &ShellCommands) -> Result<CommandResult, Error> {
+async fn shell_command(command: &ShellCommands, json: bool) -> Result<CommandResult, Error> {
     match command {
         ShellCommands::Completions(args) => {
             let result = shell_commands::completions(args).await;
-            Ok(build_command_result_without_config(result))
+            Ok(build_command_result_without_config(result, json))
         }
     }
 }
@@ -337,23 +341,23 @@ async fn config_command(
 
         ConfigCommands::CheckVersion(args) => {
             let result = config_commands::check_version(args, None).await;
-            Ok(build_command_result_without_config(result))
+            Ok(build_command_result_without_config(result, cli.json))
         }
         ConfigCommands::Check(_args) => {
             let result = config_commands::check(cli.config.clone()).await;
-            Ok(build_command_result_without_config(result))
+            Ok(build_command_result_without_config(result, cli.json))
         }
         ConfigCommands::About(args) => {
             let result = config_commands::about(args).await;
-            Ok(build_command_result_without_config(result))
+            Ok(build_command_result_without_config(result, cli.json))
         }
         ConfigCommands::Reset(args) => {
             let result = crate::config::config_reset(cli.config.clone(), args.force).await;
-            Ok(build_command_result_without_config(result))
+            Ok(build_command_result_without_config(result, cli.json))
         }
         ConfigCommands::Open(_args) => {
             let result = crate::config::config_open(cli.config.clone()).await;
-            Ok(build_command_result_without_config(result))
+            Ok(build_command_result_without_config(result, cli.json))
         }
     }
 }
@@ -368,7 +372,7 @@ async fn auth_command(command: &AuthCommands, cli: &Cli) -> Result<CommandResult
 
         AuthCommands::Token(args) => {
             let result = auth_commands::token(cli.config.clone(), args).await;
-            Ok(build_command_result_without_config(result))
+            Ok(build_command_result_without_config(result, cli.json))
         }
     }
 }
@@ -391,14 +395,16 @@ fn build_command_result(result: Result<String, Error>, config: &Config) -> Comma
     CommandResult {
         bell_success: config.bell_on_success,
         bell_failure: config.bell_on_failure,
+        json: config.args.json,
         result,
     }
 }
 
-fn build_command_result_without_config(result: Result<String, Error>) -> CommandResult {
+fn build_command_result_without_config(result: Result<String, Error>, json: bool) -> CommandResult {
     CommandResult {
         bell_success: false,
         bell_failure: true,
+        json,
         result,
     }
 }
@@ -424,7 +430,11 @@ async fn get_existing_config_exists(config_path: Option<PathBuf>) -> Result<Conf
 fn with_cli_context(mut config: Config, cli: &Cli, tx: &UnboundedSender<Error>) -> Config {
     config.args.verbose = cli.verbose;
     config.args.timeout = cli.timeout;
+    config.args.json = cli.json;
     config.internal.tx = Some(tx.clone());
+    if cli.json {
+        config.spinners = Some(false);
+    }
     config
 }
 
@@ -549,18 +559,21 @@ mod tests {
         let mut config = Config::default_test();
         config.bell_on_success = true;
         config.bell_on_failure = false;
+        config.args.json = true;
 
         let result = build_command_result(Ok("ok".to_string()), &config);
         assert!(result.bell_success);
         assert!(!result.bell_failure);
+        assert!(result.json);
         assert!(matches!(result.result, Ok(text) if text == "ok"));
     }
 
     #[test]
     fn build_command_result_without_config_uses_defaults() {
-        let result = build_command_result_without_config(Ok("ok".to_string()));
+        let result = build_command_result_without_config(Ok("ok".to_string()), false);
         assert!(!result.bell_success);
         assert!(result.bell_failure);
+        assert!(!result.json);
         assert!(matches!(result.result, Ok(text) if text == "ok"));
     }
 
@@ -600,6 +613,7 @@ mod tests {
             verbose: true,
             config: None,
             timeout: Some(42),
+            json: false,
             command: Commands::Test(TestCommands::All(test_commands::All {})),
         };
         let config = Config::default_test();

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -129,6 +129,7 @@ fn bell_on_failure_default() -> bool {
 pub struct Args {
     pub verbose: bool,
     pub timeout: Option<u64>,
+    pub json: bool,
 }
 
 #[derive(Default, Clone, Debug)]
@@ -442,6 +443,7 @@ impl Config {
             args: Args {
                 verbose: false,
                 timeout: None,
+                json: false,
             },
             time_provider: TimeProviderEnum::System(SystemTimeProvider),
             task_comment_command: None,
@@ -713,6 +715,7 @@ impl Default for Config {
             args: Args {
                 verbose: false,
                 timeout: None,
+                json: false,
             },
             time_provider: TimeProviderEnum::System(SystemTimeProvider),
             projects: Some(Vec::new()),
@@ -738,6 +741,7 @@ mod tests {
                 args: Args {
                     verbose: false,
                     timeout: None,
+                    json: false,
                 },
                 internal: Internal { tx: None },
                 sort_order: Some(SortRule::default_order()),
@@ -887,11 +891,13 @@ mod tests {
         let args = Args {
             verbose: true,
             timeout: Some(42),
+            json: false,
         };
         let args_debug = format!("{args:?}");
         assert!(args_debug.contains("Args"));
         assert!(args_debug.contains("verbose"));
         assert!(args_debug.contains("timeout"));
+        assert!(args_debug.contains("json"));
 
         let (tx, _rx) = unbounded_channel::<Error>();
         let internal = Internal { tx: Some(tx) };
@@ -908,6 +914,7 @@ mod tests {
         let args = Args {
             verbose: true,
             timeout: Some(10),
+            json: false,
         };
         let args_clone = args.clone();
         assert_eq!(args, args_clone);
@@ -924,20 +931,23 @@ mod tests {
             args,
             Args {
                 verbose: true,
-                timeout: Some(10)
+                timeout: Some(10),
+                json: false,
             }
         );
         assert_ne!(
             args,
             Args {
                 verbose: false,
-                timeout: Some(5)
+                timeout: Some(5),
+                json: false,
             }
         );
 
         let default_args = Args::default();
         assert_eq!(default_args.verbose, false);
         assert_eq!(default_args.timeout, None);
+        assert_eq!(default_args.json, false);
 
         let default_internal = Internal::default();
         assert!(default_internal.tx.is_none());

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,6 +5,7 @@ use std::{
 
 use crate::format;
 use homedir::GetHomeError;
+use serde::Serialize;
 use tokio::{sync::oneshot::error::RecvError, task::JoinError};
 
 /// The project-wide error type.
@@ -19,7 +20,7 @@ use tokio::{sync::oneshot::error::RecvError, task::JoinError};
 /// messages must **not** pre-apply [`format`] coloring — `Display` owns
 /// color output. The `colored` crate strips ANSI codes under `cfg!(test)`,
 /// so unit tests will not catch double-coloring bugs.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Error {
     pub message: String,
     pub source: String,

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -1,9 +1,9 @@
 use std::fmt::Display;
 
 use crate::{config::Config, errors::Error, todoist};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
 pub struct Label {
     pub id: String,
     pub name: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ struct CommandResult {
     result: Result<String, Error>,
     bell_success: bool,
     bell_failure: bool,
+    json: bool,
 }
 
 #[tokio::main]
@@ -74,6 +75,37 @@ async fn main() -> ExitCode {
 }
 
 fn output_result(result: CommandResult) -> u8 {
+    if result.json {
+        output_json(result)
+    } else {
+        output_text(result)
+    }
+}
+
+fn output_json(result: CommandResult) -> u8 {
+    match &result.result {
+        Ok(text) => {
+            let data = match serde_json::from_str::<serde_json::Value>(text) {
+                Ok(value) => serde_json::json!({"data": value}),
+                Err(_) => serde_json::json!({"data": {"text": text}}),
+            };
+            println!("{data}");
+            0
+        }
+        Err(e) => {
+            let error_json = serde_json::json!({
+                "error": {
+                    "message": e.message,
+                    "source": e.source,
+                }
+            });
+            println!("{error_json}");
+            1
+        }
+    }
+}
+
+fn output_text(result: CommandResult) -> u8 {
     match result.result {
         Ok(text) => {
             println!("{text}");
@@ -91,14 +123,15 @@ fn output_result(result: CommandResult) -> u8 {
         }
     }
 }
-
 async fn run_command(cli: Cli, tx: UnboundedSender<Error>) -> CommandResult {
+    let json = cli.json;
     commands::select_command(cli, tx)
         .await
         .unwrap_or_else(|e| CommandResult {
             result: Err(e),
             bell_success: true,
             bell_failure: true,
+            json,
         })
 }
 

--- a/src/sections.rs
+++ b/src/sections.rs
@@ -1,9 +1,9 @@
 use crate::{config::Config, errors::Error, input, projects::Project, todoist};
 use futures::future;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 // Projects are split into sections
-#[derive(PartialEq, Deserialize, Clone, Debug)]
+#[derive(PartialEq, Deserialize, Serialize, Clone, Debug)]
 pub struct Section {
     pub id: String,
     pub name: String,
@@ -26,7 +26,7 @@ impl Section {
     }
 }
 
-#[derive(PartialEq, Deserialize, Clone, Debug)]
+#[derive(PartialEq, Deserialize, Serialize, Clone, Debug)]
 pub struct SectionResponse {
     pub results: Vec<Section>,
     pub next_cursor: Option<String>,

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -164,9 +164,9 @@ struct Body {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub enum Unit {
-    #[serde(rename(deserialize = "minute"))]
+    #[serde(rename = "minute")]
     Minute,
-    #[serde(rename(deserialize = "day"))]
+    #[serde(rename = "day")]
     Day,
 }
 


### PR DESCRIPTION
## Summary

Implements the foundational plumbing for the \`--json\` / \`-j\` flag (#1736), the first step in the JSON output feature (#1732).

## Changes

- **Serialize derives**: Added \`Serialize\` to \`Error\`, \`Label\`, \`Section\`, and \`SectionResponse\`
- **Unit enum**: Fixed serialize renames for lowercase output (\`"minute"\` / \`"day"\`)
- **CLI flag**: Added global \`--json\`/\`-j\` flag to \`Cli\` struct
- **Config plumbing**: Threaded \`json: bool\` through \`Args\` → \`Config\` → \`CommandResult\`
- **Output gateway**: Rewrote \`output_result()\` with JSON branch:
  - Success: \`{"data": ...}\` envelope (tries JSON parse, falls back to \`{"data": {"text": "..."}}\`)
  - Error: \`{"error": {"message": "...", "source": "..."}}\` on stdout
- **Terminal suppression**: Spinners disabled, terminal bell skipped in JSON mode

## Verification

- \`./scripts/test.sh\` — all 411 tests pass
- \`cargo run -- -j config about | jq .\` — produces valid JSON

Closes #1736