### PR TITLE
feat: structured JSON for config about command

### DIFF
--- a/src/commands/config_commands.rs
+++ b/src/commands/config_commands.rs
@@ -364,10 +364,19 @@ pub async fn edit(config: Config, _args: &Edit) -> Result<String, Error> {
 }
 
 #[allow(clippy::unused_async)]
-pub async fn about(_args: &About) -> Result<String, Error> {
-    Ok(format!(
-        "APP:             {NAME}\nVERSION:         {VERSION}\nBUILD_PROFILE:   {BUILD_PROFILE}\nBUILD_TARGET:    {BUILD_TARGET}\nBUILD_TIMESTAMP: {BUILD_TIMESTAMP}"
-    ))
+pub async fn about(_args: &About, json: bool) -> Result<String, Error> {
+    if json {
+        let json = serde_json::json!({
+            "version": VERSION,
+            "target": BUILD_TARGET,
+            "profile": BUILD_PROFILE,
+        });
+        Ok(json.to_string())
+    } else {
+        Ok(format!(
+            "APP:             {NAME}\nVERSION:         {VERSION}\nBUILD_PROFILE:   {BUILD_PROFILE}\nBUILD_TARGET:    {BUILD_TARGET}\nBUILD_TIMESTAMP: {BUILD_TIMESTAMP}"
+        ))
+    }
 }
 
 #[cfg(test)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -348,7 +348,7 @@ async fn config_command(
             Ok(build_command_result_without_config(result, cli.json))
         }
         ConfigCommands::About(args) => {
-            let result = config_commands::about(args).await;
+            let result = config_commands::about(args, cli.json).await;
             Ok(build_command_result_without_config(result, cli.json))
         }
         ConfigCommands::Reset(args) => {


### PR DESCRIPTION
Closes #1737

## Summary
- Added \`json: bool\` parameter to \`config_commands::about()\`
- When \`--json\` / \`-j\` is passed, \`config about\` returns structured JSON: \`{"version", "target", "profile"}\`
- Human-readable output unchanged when JSON mode is off

## Verification
- \`cargo run -- -j config about\` → \`{"data":{"profile":"...","target":"...","version":"..."}}\`
- \`cargo run -- config about\` → same human-readable block as before
- All 411 tests pass