### PR TITLE
feat: structured JSON output for project list and list view commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@
 
 - `src/todoist/mod.rs` — REST API client (~1,270L). Key exports: `all_tasks_by_*`, `quick_create_task`, `create_task`, `complete_task`, `update_task_*`, `all_projects`, `all_labels`, `all_comments`, `all_sections_by_project`
 - `src/todoist/request.rs` — HTTP layer (GET/POST/DELETE via reqwest)
+- `src/projects.rs` — Project struct, CRUD operations, task scheduling
+- `src/lists.rs` — Multi-task operations (view, process, label, timebox, etc.)
 - `src/commands/mod.rs` — CLI dispatch via clap `Subcommand` enum
 - `src/commands/task_commands.rs` — Task subcommand handlers
 - `src/commands/list_commands.rs` — List/view subcommand handlers
@@ -42,5 +44,6 @@
 
 - Never push directly to `main` — all changes go through pull requests and are merged into `main`
 - Branch naming: `type/short-description` (e.g. `fix/error-coloring`, `feat/add-foo`)
+- Push the branch to origin before creating a PR: `git push -u origin <branch>`
 - Create PRs with `gh pr create --title "type: description" --body "..." --base main`
 - Commit format follows Conventional Commits (lowercase, 250-char line limit). See `.commitlint.config.mjs` for enforced rules.

--- a/src/commands/list_commands.rs
+++ b/src/commands/list_commands.rs
@@ -9,6 +9,7 @@ use crate::{
     lists::{self, Flag},
     projects,
     tasks::SortOrder,
+    todoist,
 };
 
 #[derive(Subcommand, Debug, Clone)]
@@ -236,7 +237,7 @@ pub struct Import {
     /// The file or directory to fuzzy find in
     path: Option<String>,
 }
-pub async fn view(config: &mut Config, args: &View) -> Result<String, Error> {
+pub async fn view(config: &mut Config, args: &View, json: bool) -> Result<String, Error> {
     let View {
         project,
         filter,
@@ -245,7 +246,22 @@ pub async fn view(config: &mut Config, args: &View) -> Result<String, Error> {
 
     let flag =
         super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), config).await?;
-    lists::view(config, flag, sort).await
+
+    if json {
+        let tasks = match &flag {
+            Flag::Project(project) => todoist::all_tasks_by_project(config, project, None).await?,
+            Flag::Filter(filter) => todoist::all_tasks_by_filters(config, filter)
+                .await?
+                .into_iter()
+                .flat_map(|(_, tasks)| tasks)
+                .collect(),
+        };
+        let count = tasks.len();
+        let json = serde_json::json!({"tasks": tasks, "count": count});
+        Ok(json.to_string())
+    } else {
+        lists::view(config, flag, sort).await
+    }
 }
 
 pub async fn label(config: Config, args: &Label) -> Result<String, Error> {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -198,7 +198,7 @@ async fn project_command(
         }
         ProjectCommands::List(args) => {
             let mut config = fetch_config(cli, tx).await?;
-            let result = project_commands::list(&mut config, args).await;
+            let result = project_commands::list(&mut config, args, cli.json).await;
             Ok(build_command_result(result, &config))
         }
         ProjectCommands::Remove(args) => {
@@ -276,7 +276,7 @@ async fn list_command(
     match command {
         ListCommands::View(args) => {
             let mut config = fetch_config(cli, tx).await?;
-            let result = list_commands::view(&mut config, args).await;
+            let result = list_commands::view(&mut config, args, cli.json).await;
             Ok(build_command_result(result, &config))
         }
         ListCommands::Process(args) => {

--- a/src/commands/project_commands.rs
+++ b/src/commands/project_commands.rs
@@ -134,8 +134,14 @@ pub async fn create(config: &mut Config, args: &Create) -> Result<String, Error>
     projects::create(config, name, description, *is_favorite).await
 }
 
-pub async fn list(config: &mut Config, _args: &List) -> Result<String, Error> {
-    projects::list(config).await
+pub async fn list(config: &mut Config, _args: &List, json: bool) -> Result<String, Error> {
+    if json {
+        config.reload_projects().await?;
+        let projects = config.projects().await?;
+        Ok(serde_json::to_string(&projects)?)
+    } else {
+        projects::list(config).await
+    }
 }
 
 pub async fn remove(config: &mut Config, args: &Remove) -> Result<String, Error> {


### PR DESCRIPTION
Adds structured JSON output for read-only query commands when \`--json\` / \`-j\` flag is used.

## Changes
- **project list**: serializes \`Vec<Project>\` directly → \`{"data": [project1, project2, ...]}\`
- **list view**: returns \`{"tasks": [...], "count": N}\` → \`{"data": {"tasks": [...], "count": N}}\`

Closes #1738