### PR TITLE
feat: return structured JSON for task mutation commands

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -237,12 +237,12 @@ async fn task_command(
     match command {
         TaskCommands::QuickAdd(args) => {
             let config = fetch_config(cli, tx).await?;
-            let result = task_commands::quick_add(&config, args).await;
+            let result = task_commands::quick_add(&config, args, cli.json).await;
             Ok(build_command_result(result, &config))
         }
         TaskCommands::Create(args) => {
             let config = fetch_config(cli, tx).await?;
-            let result = task_commands::create(config.clone(), args).await;
+            let result = task_commands::create(config.clone(), args, cli.json).await;
             Ok(build_command_result(result, &config))
         }
         TaskCommands::Edit(args) => {
@@ -257,7 +257,7 @@ async fn task_command(
         }
         TaskCommands::Complete(args) => {
             let config = fetch_config(cli, tx).await?;
-            let result = task_commands::complete(config.clone(), args).await;
+            let result = task_commands::complete(config.clone(), args, cli.json).await;
             Ok(build_command_result(result, &config))
         }
         TaskCommands::Comment(args) => {

--- a/src/commands/task_commands.rs
+++ b/src/commands/task_commands.rs
@@ -109,7 +109,7 @@ pub struct Comment {
     /// Content for comment
     content: Option<String>,
 }
-pub async fn quick_add(config: &Config, args: &QuickAdd) -> Result<String, Error> {
+pub async fn quick_add(config: &Config, args: &QuickAdd, json: bool) -> Result<String, Error> {
     let QuickAdd { content } = args;
     let maybe_string = content.as_ref().map(|c| c.join(" "));
     let content = super::fetch_string(maybe_string.as_deref(), config, input::CONTENT)?;
@@ -123,8 +123,12 @@ pub async fn quick_add(config: &Config, args: &QuickAdd) -> Result<String, Error
     } else {
         (content, None)
     };
-    todoist::quick_create_task(config, &content, reminder).await?;
-    Ok(format::green_string("✓"))
+    let task = todoist::quick_create_task(config, &content, reminder).await?;
+    if json {
+        Ok(serde_json::to_string(&task)?)
+    } else {
+        Ok(format::green_string("✓"))
+    }
 }
 
 /// User does not want to use sections
@@ -132,8 +136,8 @@ fn is_no_sections(args: &Create, config: &Config) -> bool {
     args.no_section || config.no_sections.unwrap_or_default()
 }
 
-pub async fn create(config: Config, args: &Create) -> Result<String, Error> {
-    if no_flags_used(args) {
+pub async fn create(config: Config, args: &Create, json: bool) -> Result<String, Error> {
+    let task = if no_flags_used(args) {
         let options = tasks::create_task_attributes();
         let selections = input::multi_select(input::ATTRIBUTES, options, config.mock_select)?;
 
@@ -199,7 +203,7 @@ pub async fn create(config: Config, args: &Create) -> Result<String, Error> {
             due.as_deref(),
             &labels,
         )
-        .await?;
+        .await?
     } else {
         let Create {
             project,
@@ -233,9 +237,13 @@ pub async fn create(config: Config, args: &Create) -> Result<String, Error> {
             due.as_deref(),
             labels,
         )
-        .await?;
+        .await?
+    };
+    if json {
+        Ok(serde_json::to_string(&task)?)
+    } else {
+        Ok(format::green_string("✓"))
     }
-    Ok(format::green_string("✓"))
 }
 
 fn no_flags_used(args: &Create) -> bool {
@@ -272,12 +280,16 @@ pub async fn next(config: Config, args: &Next) -> Result<String, Error> {
     }
 }
 
-pub async fn complete(config: Config, _args: &Complete) -> Result<String, Error> {
+pub async fn complete(config: Config, _args: &Complete, json: bool) -> Result<String, Error> {
     match config.next_task() {
         Some(task) => {
             todoist::complete_task(&config, &task.id, true).await?;
 
-            Ok(format::green_string("Task completed successfully"))
+            if json {
+                Ok(serde_json::to_string(&task)?)
+            } else {
+                Ok(format::green_string("Task completed successfully"))
+            }
         }
         None => Err(Error::new(
             "task_complete",


### PR DESCRIPTION
Implements #1739 — Phase 4 of the JSON output feature.

## Changes

- \`quick_add()\`, \`create()\`, and \`complete()\` now accept a \`json: bool\` parameter
- When \`--json\` is set, the returned \`Task\` is serialized via \`serde_json::to_string()\`
- Non-JSON mode keeps existing human-readable output
- Dispatch in \`task_command()\` passes \`cli.json\` through to all three handlers

## How it works

The handlers return plain serialized JSON strings; \`main.rs\` wraps them in \`{"data": ...}\` via the existing \`output_json()\` envelope from #1736. Errors are automatically formatted as \`{"error": {"message": "...", "source": "..."}}\`.