### PR TITLE
feat: interactive command guards for JSON mode

### DIFF
--- a/src/commands/config_commands.rs
+++ b/src/commands/config_commands.rs
@@ -361,10 +361,7 @@ pub async fn set_timezone(config: Config, _args: &SetTimezone) -> Result<String,
 
 pub async fn edit(config: Config, _args: &Edit) -> Result<String, Error> {
     if config.args.json {
-        return Err(Error::new(
-            "json_mode",
-            "Interactive input not available in JSON mode. Provide the required argument via CLI flags.",
-        ));
+        return Err(Error::new("json_mode", super::JSON_INTERACTIVE_ERROR));
     }
     config.edit_interactive().await
 }

--- a/src/commands/config_commands.rs
+++ b/src/commands/config_commands.rs
@@ -360,6 +360,12 @@ pub async fn set_timezone(config: Config, _args: &SetTimezone) -> Result<String,
 }
 
 pub async fn edit(config: Config, _args: &Edit) -> Result<String, Error> {
+    if config.args.json {
+        return Err(Error::new(
+            "json_mode",
+            "Interactive input not available in JSON mode. Provide the required argument via CLI flags.",
+        ));
+    }
     config.edit_interactive().await
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -39,6 +39,8 @@ const LONG_VERSION: &str = concat!(
 const AUTHOR: &str = env!("CARGO_PKG_AUTHORS");
 const ABOUT: &str = env!("CARGO_PKG_DESCRIPTION");
 const NO_PROJECTS_ERR: &str = "No projects in config. Add projects with `tod project import`";
+const JSON_INTERACTIVE_ERROR: &str =
+    "Interactive input not available in JSON mode. Provide the required argument via CLI flags.";
 
 #[derive(Parser, Clone)]
 #[command(name = NAME)]
@@ -365,6 +367,12 @@ async fn config_command(
 async fn auth_command(command: &AuthCommands, cli: &Cli) -> Result<CommandResult, Error> {
     match command {
         AuthCommands::Login(args) => {
+            if cli.json {
+                return Ok(build_command_result_without_config(
+                    Err(Error::new("json_mode", JSON_INTERACTIVE_ERROR)),
+                    cli.json,
+                ));
+            }
             let mut config = auth_commands::load_or_create_config(cli.config.clone()).await?;
             let result = auth_commands::login(&mut config, args).await;
             Ok(build_command_result(result, &config))
@@ -460,7 +468,12 @@ fn fetch_string(
 ) -> Result<String, Error> {
     match maybe_string {
         Some(string) => Ok(string.to_owned()),
-        None => input::string(prompt, config.mock_string.clone()),
+        None => {
+            if config.args.json {
+                return Err(Error::new("json_mode", JSON_INTERACTIVE_ERROR));
+            }
+            input::string(prompt, config.mock_string.clone())
+        }
     }
 }
 async fn fetch_project(project_name: Option<&str>, config: &Config) -> Result<Flag, Error> {
@@ -482,7 +495,12 @@ async fn fetch_project(project_name: Option<&str>, config: &Config) -> Result<Fl
                 },
                 |p| Ok(Flag::Project(p.to_owned())),
             ),
-        None => input::select(input::PROJECT, projects, config.mock_select).map(Flag::Project),
+        None => {
+            if config.args.json {
+                return Err(Error::new("json_mode", JSON_INTERACTIVE_ERROR));
+            }
+            input::select(input::PROJECT, projects, config.mock_select).map(Flag::Project)
+        }
     }
 }
 
@@ -490,6 +508,9 @@ fn fetch_filter(filter: Option<&str>, config: &Config) -> Result<Flag, Error> {
     if let Some(string) = filter {
         Ok(Flag::Filter(string.to_owned()))
     } else {
+        if config.args.json {
+            return Err(Error::new("json_mode", JSON_INTERACTIVE_ERROR));
+        }
         let string = input::string(input::FILTER, config.mock_string.clone())?;
         Ok(Flag::Filter(string))
     }
@@ -508,6 +529,9 @@ async fn fetch_project_or_filter(
             "Must select project OR filter",
         )),
         (None, None) => {
+            if config.args.json {
+                return Err(Error::new("json_mode", JSON_INTERACTIVE_ERROR));
+            }
             let options = vec![FlagOptions::Project, FlagOptions::Filter];
             match input::select(input::OPTION, options, config.mock_select)? {
                 FlagOptions::Project => fetch_project(project, config).await,
@@ -521,6 +545,9 @@ fn fetch_priority(priority: Option<u8>, config: &Config) -> Result<Priority, Err
     if let Some(priority) = priority::from_integer(priority)? {
         Ok(priority)
     } else {
+        if config.args.json {
+            return Err(Error::new("json_mode", JSON_INTERACTIVE_ERROR));
+        }
         let options = vec![
             Priority::None,
             Priority::Low,
@@ -723,5 +750,145 @@ mod tests {
         );
         assert!(!result.unwrap().is_empty());
         mock.assert();
+    }
+
+    #[test]
+    fn fetch_string_json_mode_errors_when_no_input() {
+        let mut config = Config::default_test();
+        config.args.json = true;
+
+        let result = fetch_string(None, &config, "test prompt");
+        let error = result.expect_err("should error in JSON mode");
+        assert_eq!(error.source, "json_mode");
+        assert!(error.message.contains("JSON mode"));
+    }
+
+    #[test]
+    fn fetch_string_json_mode_ok_when_provided() {
+        let mut config = Config::default_test();
+        config.args.json = true;
+
+        let result = fetch_string(Some("hello"), &config, "test prompt");
+        assert_eq!(result.expect("should succeed"), "hello");
+    }
+
+    #[test]
+    fn fetch_filter_json_mode_errors_when_no_input() {
+        let mut config = Config::default_test();
+        config.args.json = true;
+
+        let result = fetch_filter(None, &config);
+        let error = result.expect_err("should error in JSON mode");
+        assert_eq!(error.source, "json_mode");
+        assert!(error.message.contains("JSON mode"));
+    }
+
+    #[test]
+    fn fetch_filter_json_mode_ok_when_provided() {
+        let mut config = Config::default_test();
+        config.args.json = true;
+
+        let result = fetch_filter(Some("myfilter"), &config);
+        let flag = result.expect("should succeed");
+        assert!(matches!(flag, Flag::Filter(f) if f == "myfilter"));
+    }
+
+    #[test]
+    fn fetch_priority_json_mode_errors_when_no_input() {
+        let mut config = Config::default_test();
+        config.args.json = true;
+
+        let result = fetch_priority(None, &config);
+        let error = result.expect_err("should error in JSON mode");
+        assert_eq!(error.source, "json_mode");
+        assert!(error.message.contains("JSON mode"));
+    }
+
+    #[test]
+    fn fetch_priority_json_mode_ok_when_provided() {
+        let mut config = Config::default_test();
+        config.args.json = true;
+
+        let result = fetch_priority(Some(4), &config);
+        assert_eq!(result.expect("should succeed"), Priority::High);
+    }
+
+    fn test_project() -> crate::projects::Project {
+        crate::projects::Project {
+            id: "123".to_string(),
+            name: "test-project".to_string(),
+            can_assign_tasks: false,
+            child_order: 0,
+            color: "red".to_string(),
+            created_at: None,
+            is_archived: false,
+            is_deleted: false,
+            is_favorite: false,
+            is_frozen: false,
+            updated_at: None,
+            view_style: "list".to_string(),
+            default_order: 0,
+            description: String::new(),
+            parent_id: None,
+            inbox_project: None,
+            is_collapsed: false,
+            is_shared: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_project_json_mode_errors_when_no_project_name() {
+        let mut config = Config::default_test();
+        config.add_project(test_project());
+        config.args.json = true;
+
+        let result = fetch_project(None, &config).await;
+        let error = result.expect_err("should error in JSON mode");
+        assert_eq!(error.source, "json_mode");
+        assert!(error.message.contains("JSON mode"));
+    }
+
+    #[tokio::test]
+    async fn fetch_project_json_mode_ok_when_provided() {
+        let mut config = Config::default_test();
+        config.add_project(test_project());
+        config.args.json = true;
+
+        let result = fetch_project(Some("test-project"), &config).await;
+        let flag = result.expect("should succeed");
+        assert!(matches!(flag, Flag::Project(p) if p.name == "test-project"));
+    }
+
+    #[tokio::test]
+    async fn fetch_project_or_filter_json_mode_errors_when_both_none() {
+        let mut config = Config::default_test();
+        config.add_project(test_project());
+        config.args.json = true;
+
+        let result = fetch_project_or_filter(None, None, &config).await;
+        let error = result.expect_err("should error in JSON mode");
+        assert_eq!(error.source, "json_mode");
+        assert!(error.message.contains("JSON mode"));
+    }
+
+    #[tokio::test]
+    async fn fetch_project_or_filter_json_mode_ok_with_project() {
+        let mut config = Config::default_test();
+        config.add_project(test_project());
+        config.args.json = true;
+
+        let result = fetch_project_or_filter(Some("test-project"), None, &config).await;
+        let flag = result.expect("should succeed");
+        assert!(matches!(flag, Flag::Project(p) if p.name == "test-project"));
+    }
+
+    #[tokio::test]
+    async fn fetch_project_or_filter_json_mode_ok_with_filter() {
+        let mut config = Config::default_test();
+        config.args.json = true;
+
+        let result = fetch_project_or_filter(None, Some("myfilter"), &config).await;
+        let flag = result.expect("should succeed");
+        assert!(matches!(flag, Flag::Filter(f) if f == "myfilter"));
     }
 }

--- a/src/commands/project_commands.rs
+++ b/src/commands/project_commands.rs
@@ -183,6 +183,9 @@ pub async fn delete(config: &mut Config, args: &Delete) -> Result<String, Error>
         let tasks = todoist::all_tasks_by_project(config, &project, None).await?;
 
         if !force && !tasks.is_empty() {
+            if config.args.json {
+                return Err(Error::new("json_mode", super::JSON_INTERACTIVE_ERROR));
+            }
             println!();
             let options = vec![input::CANCEL, input::DELETE];
             let num_tasks = tasks.len();
@@ -216,11 +219,17 @@ pub async fn rename(config: &mut Config, args: &Rename) -> Result<String, Error>
 
 pub async fn import(config: &mut Config, args: &Import) -> Result<String, Error> {
     let Import { auto, project, id } = args;
+    if !*auto && config.args.json {
+        return Err(Error::new("json_mode", super::JSON_INTERACTIVE_ERROR));
+    }
     projects::import(config, auto, project.as_deref(), id.as_deref()).await
 }
 
 pub async fn empty(config: &mut Config, args: &Empty) -> Result<String, Error> {
     let Empty { project } = args;
+    if config.args.json {
+        return Err(Error::new("json_mode", super::JSON_INTERACTIVE_ERROR));
+    }
     let project = match super::fetch_project(project.as_deref(), config).await? {
         Flag::Project(project) => project,
         Flag::Filter(_) => unreachable!(),

--- a/src/commands/task_commands.rs
+++ b/src/commands/task_commands.rs
@@ -138,6 +138,9 @@ fn is_no_sections(args: &Create, config: &Config) -> bool {
 
 pub async fn create(config: Config, args: &Create, json: bool) -> Result<String, Error> {
     let task = if no_flags_used(args) {
+        if config.args.json {
+            return Err(Error::new("json_mode", super::JSON_INTERACTIVE_ERROR));
+        }
         let options = tasks::create_task_attributes();
         let selections = input::multi_select(input::ATTRIBUTES, options, config.mock_select)?;
 

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -12,7 +12,7 @@ use std::collections::HashSet;
 use std::fmt::Display;
 use tokio::{fs, io::AsyncReadExt, task::JoinError};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Flag {
     Project(Project),
     Filter(String),


### PR DESCRIPTION
## Summary

When \`--json\` / \`-j\` is set, interactive commands that lack required CLI input now return a structured JSON error instead of blocking on \`inquire\` prompts.

Closes #1741.

## Changes

### Core guards in \`src/commands/mod.rs\`
- \`fetch_string()\` — errors when \`maybe_string.is_none() && config.args.json\`
- \`fetch_project()\` — errors when \`project_name.is_none() && config.args.json\`
- \`fetch_filter()\` — errors when \`filter.is_none() && config.args.json\`
- \`fetch_priority()\` — errors when \`priority.is_none() && config.args.json\`
- \`fetch_project_or_filter()\` — errors when both \`None && config.args.json\`

### Command-specific guards
- **\`task create\`** — errors in JSON mode when no flags are provided (fully interactive path)
- **\`project delete\`** — errors when \`!force\` and project has tasks (confirmation prompt)
- **\`project empty\`** — errors in JSON mode (always interactive)
- **\`project import\`** — errors when \`!auto\` (per-project prompts)
- **\`config edit\`** — errors in JSON mode (inherently interactive editor)
- **\`auth login\`** — errors in JSON mode (inherently interactive OAuth)

### Other
- Added \`Debug\` derive to \`Flag\` enum for test assertions
- 11 new unit tests covering all guard conditions

## Error contract
\`\`\`json
{"error":{"message":"Interactive input not available in JSON mode. Provide the required argument via CLI flags.","source":"json_mode"}}
\`\`\`

## Verification
- \`./scripts/test.sh\` — 422 tests pass (was 411)
- Manual testing of all 13 affected commands confirmed