### PR TITLE
docs: fix stale references, expand project structure, and remove dead code

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,22 +32,7 @@ Copilot should follow these conventions when generating or completing code, comm
 
 ## Error Handling & Messaging
 - **Prefer `expect` over `unwrap`** and include descriptive context.
-- Print **consistent, descriptive** errors for unexpected cases; only auto-fix safe, deterministic scenarios.
-- Centralize error reporting via a small helper so messages are uniform.
-
-### Standardized error reporter (example)
-```rust
-/// Prints a standardized error message with context and source.
-/// Use for unexpected errors you cannot recover from here.
-pub fn report_error(context: &str, err: &(dyn std::error::Error)) {
-    eprintln!("ERROR: {context}: {err}");
-    let mut src = err.source();
-    while let Some(cause) = src {
-        eprintln!("caused by: {cause}");
-        src = cause.source();
-    }
-}
-```
+- All errors use the `Error` type from `src/errors.rs` — `Error::new(source, message)` with lowercase function or feature names as `source`.
 
 ---
 
@@ -120,7 +105,7 @@ Refactor
 
 ## Checklist (what Copilot should auto-enforce)
 - [ ] Use `expect` over `unwrap` with clear messages.
-- [ ] Print consistent, descriptive errors via the standard helper.
+- [ ] Use `Error::new(source, message)` from `src/errors.rs` for ad-hoc errors.
 - [ ] Add tests for **every** new function and for all fixes/features.
 - [ ] Functions and modules have appropriate `///` docs; non-obvious logic has `//` comments.
 - [ ] Comments live beside the functions they describe.

--- a/.pi/skills/architecture/SKILL.md
+++ b/.pi/skills/architecture/SKILL.md
@@ -11,15 +11,17 @@ All commands funnel through a single output gateway:
 
 ```
 Command handler → Result<String, Error>
-  → build_command_result() → CommandResult { result, bell_success, bell_failure }
+  → build_command_result() → CommandResult { result, bell_success, bell_failure, json }
   → output_result() in main.rs:77-91
-      Ok  → println!("{text}") to stdout
-      Err → eprintln!("{e}") to stderr
+      json  → output_json(&result) — structured JSON to stdout
+      text → Ok  → println!("{text}") to stdout
+             Err → eprintln!("{e}") to stderr
 ```
 
-- `build_command_result()` — wraps `Result<String, Error>` with bell flags from `Config`
-- `build_command_result_without_config()` — variant for commands that don't load config (shell completions, auth token, config check/about/reset/open)
-- `CommandResult` — defined in `src/main.rs:56-64`
+- `build_command_result()` — wraps `Result<String, Error>` with bell flags and `json` from `Config`
+- `build_command_result_without_config()` — variant for commands that don't load config; takes explicit `json: bool`
+- `CommandResult` — defined in `src/main.rs:49-55` with `{ result, bell_success, bell_failure, json }`
+- `output_json()` / `output_text()` — dispatch branches in `src/main.rs:77-91`
 
 ## Config plumbing
 
@@ -43,7 +45,7 @@ Label (`src/labels.rs:8`), Section (`src/sections.rs:10`),
 LabelResponse (`src/labels.rs:19`), SectionResponse (`src/sections.rs:30`)
 
 ### Neither
-Error (`src/errors.rs:23`) — `{ message: String, source: String }`
+Error (`src/errors.rs:23`) — `{ message: String, source: String }` (but has `Serialize` derive — serializes for JSON error output)
 
 ## Key integration points
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,37 +8,48 @@
 
 ## Project structure
 
-- `src/todoist/mod.rs` — REST API client (~1,270L). Key exports: `all_tasks_by_*`, `quick_create_task`, `create_task`, `complete_task`, `update_task_*`, `all_projects`, `all_labels`, `all_comments`, `all_sections_by_project`
-- `src/todoist/request.rs` — HTTP layer (GET/POST/DELETE via reqwest)
-- `src/projects.rs` — Project struct, CRUD operations, task scheduling
-- `src/lists.rs` — Multi-task operations (view, process, label, timebox, etc.)
-- `src/commands/mod.rs` — CLI dispatch via clap `Subcommand` enum
-- `src/commands/task_commands.rs` — Task subcommand handlers
-- `src/commands/list_commands.rs` — List/view subcommand handlers
-- `src/config/mod.rs` — Config struct + serialization
-- `src/errors.rs` — Error type (`{message, source}`)
-- `src/tasks/mod.rs` — Task struct + formatting
+- `src/main.rs` — entry point, `CommandResult` struct, `output_result()` output gateway
+- `src/errors.rs` — `Error` type (`{message, source}`) with `Serialize` derive for JSON output
 - `src/format.rs` — Terminal color utilities
 - `src/input.rs` — inquire-based terminal prompts with mock support (`config.mock_string`, `config.mock_select`). Guards for JSON/non-interactive modes belong at the `fetch_*` call sites in `src/commands/mod.rs`, not inside `input.rs`.
+
+### Todoist API
+- `src/todoist/mod.rs` — REST API client. Key exports: `all_tasks_by_*`, `quick_create_task`, `create_task`, `complete_task`, `update_task_*`, `all_projects`, `all_labels`, `all_comments`, `all_sections_by_project`
+- `src/todoist/request.rs` — HTTP layer (GET/POST/DELETE via reqwest)
+
+### Business logic
+- `src/projects.rs` — `Project` struct, CRUD operations, task scheduling
+- `src/lists.rs` — Business-logic functions for multi-task operations (view, process, label, timebox, etc.). The clap arg structs live in `src/commands/list_commands.rs`.
+- `src/tasks/mod.rs` — `Task` struct + formatting
+
+### Config
+- `src/config/mod.rs` — `Config` struct + serialization (`#[serde(deny_unknown_fields)]`)
+- `src/config/file.rs` — File I/O: `Config::load()`, `save()`, `create()`, `reload()`, `touch_file()`
+- `src/config/projects.rs` — Project CRUD on the config's `projectsv1` field
+
+### CLI dispatch
+- `src/commands/mod.rs` — Dispatch via clap `Subcommand` enum. Defines the `Cli` struct (including `--json`/`-j` flag) and `fetch_*` helpers: `fetch_string`, `fetch_project`, `fetch_filter`, `fetch_priority`, `fetch_project_or_filter`, `maybe_fetch_labels`.
+- `src/commands/task_commands.rs` — Task subcommand handlers
+- `src/commands/list_commands.rs` — List/view subcommand handlers
+- `src/commands/project_commands.rs` — Project subcommand handlers
+- `src/commands/config_commands.rs` — Config subcommand handlers
+- `src/commands/auth_commands.rs` — Auth subcommand handlers
+- `src/commands/reminder_commands.rs` — Reminder subcommand handlers
+- `src/commands/section_commands.rs` — Section subcommand handlers
+- `src/commands/shell_commands.rs` — Shell completion handler
+- `src/commands/test_commands.rs` — Manual API test handler
 
 ## GitHub conventions
 
 - Fetch issue/PR content with `gh issue view <N>` or `gh pr view <N>`. Use `--json` for labels and comments. Do not use web_search for repo issues — GitHub issue pages are not indexed for web search.
-
 - Issue templates live in `.github/ISSUE_TEMPLATE/` — use `feature_request.md` for features, `bug_report.md` for bugs
-- Labels: `feature` (new capabilities), `improvement` (changes to existing code), `bug` (something broken), `doc`, `dev-test`, `discuss`
-- Create issues with: `gh issue create --title "..." --label "feature" --body "..." --repo tod-org/tod`
 
 ## Error handling
 
 - All errors use the `Error` type (`src/errors.rs`)
-- Use `Error::new(source, message)` for ad-hoc errors where `source` is a lowercase module or crate name (e.g. `"io"`, `"serde_json"`, `"reqwest"`, `"oneshot"`)
-- Use `From` impls for wrapped library errors
+- Use `Error::new(source, message)` for ad-hoc errors where `source` is a lowercase function or feature name (e.g. `"json_mode"`, `"fetch_project"`, `"config_check"`)
+- Use `From` impls for wrapped library errors (e.g. `"io"`, `"serde_json"`, `"reqwest"`, `"oneshot"`)
 - The `Display` impl applies `format::red_string` to messages and `format::yellow_string` to the source. Callers constructing error messages must not pre-apply `format::*_string` coloring — `Display` owns color output.
-
-## Commands
-
-- Run `./scripts/test.sh` as the single verification command — it runs format, check, clippy, tests, and forgotten-strings grep in one pass. Do not run `cargo test` separately before it.
 
 ## Commits and PRs
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ coverage:
   ignore:
     - src/errors.rs
     - src/input.rs
-    - src/color.rs
+    - src/format.rs
     - src/debug.rs
     - src/main.rs
   status:


### PR DESCRIPTION
## Summary

Session learning fixes from PR #1748 review. No behavioral changes — documentation and config only.

## Changes

### AGENTS.md
- **Expanded project structure** to list all 9 command submodules, \`config/file.rs\`, \`config/projects.rs\`, and \`src/main.rs\`
- **Removed stale line counts** (\`~1,270L\`, etc.) and redundant \`Commands\` section (duplicative with rust-checks skill)
- **Fixed error source naming convention** from "lowercase module or crate name" to "lowercase function or feature name" — matches actual code pattern (\`"json_mode"\`, \`"fetch_project"\`, \`"config_check"\`)
- **Clarified \`src/lists.rs\` vs \`src/commands/list_commands.rs\` split** — lists.rs contains business-logic functions, list_commands.rs contains clap arg structs
- **Trimmed GitHub conventions** — kept \`gh issue view\`/\`gh pr view\` guidance, removed label taxonomy and \`gh issue create\` example

### .github/copilot-instructions.md
- **Removed dead \`report_error()\` helper** — referenced a function that doesn't exist in the codebase
- **Updated checklist** to reference \`Error::new(source, message)\` from \`src/errors.rs\`

### .pi/skills/architecture/SKILL.md
- **Updated output flow diagram** with \`json: bool\` field on \`CommandResult\`, \`output_json\`/\`output_text\` dispatch
- **Fixed Error serialization status** — now notes \`Serialize\` derive for JSON error output

### codecov.yml
- **Replaced stale \`src/color.rs\`** with \`src/format.rs\` (color.rs was deleted in July 2026)

## Verification
- \`./scripts/test.sh\` — 422 tests pass