### PR TITLE
feat: structured JSON output for remaining non-interactive commands

### DIFF
--- a/src/commands/auth_commands.rs
+++ b/src/commands/auth_commands.rs
@@ -53,15 +53,24 @@ pub(super) async fn load_or_create_config(config_path: Option<PathBuf>) -> Resul
 ///
 /// Creates the config file at `config_path` (or the platform default) if it does not yet exist,
 /// then fetches and saves the account timezone with the provided token.
-pub async fn token(config_path: Option<PathBuf>, args: &Token) -> Result<String, Error> {
+pub async fn token(
+    config_path: Option<PathBuf>,
+    args: &Token,
+    json: bool,
+) -> Result<String, Error> {
     let config = load_or_create_config(config_path).await?;
     let path = config.path.clone();
 
     config.set_developer_token(&args.key).await?;
-    Ok(format::green_string(&format!(
-        "✓ API token saved to {}",
-        path.display()
-    )))
+    if json {
+        let result = serde_json::json!({"status": "ok", "path": path.to_string_lossy()});
+        Ok(result.to_string())
+    } else {
+        Ok(format::green_string(&format!(
+            "✓ API token saved to {}",
+            path.display()
+        )))
+    }
 }
 
 #[cfg(test)]

--- a/src/commands/config_commands.rs
+++ b/src/commands/config_commands.rs
@@ -96,15 +96,32 @@ fn format_upgrade_hint(upgrade_cmd: &str) -> String {
     }
 }
 
-pub async fn check_version(args: &CheckVersion, mock_url: Option<String>) -> Result<String, Error> {
+pub async fn check_version(
+    args: &CheckVersion,
+    mock_url: Option<String>,
+    json: bool,
+) -> Result<String, Error> {
     let CheckVersion { force, repo } = args;
 
     match cargo::compare_versions(mock_url).await {
         Ok(Version::Latest) => {
-            let msg = format!("Tod is up to date with version: {VERSION}");
-            Ok(msg)
+            if json {
+                let result = serde_json::json!({"status": "latest", "version": VERSION});
+                Ok(result.to_string())
+            } else {
+                let msg = format!("Tod is up to date with version: {VERSION}");
+                Ok(msg)
+            }
         }
         Ok(Version::Dated(latest)) => {
+            if json {
+                let result = serde_json::json!({
+                    "status": "outdated",
+                    "installed": VERSION,
+                    "latest": latest
+                });
+                return Ok(result.to_string());
+            }
             let msg = format!(
                 "Tod is out of date. Installed version: {VERSION}, Latest version: {latest}"
             );
@@ -167,13 +184,68 @@ pub async fn check_version(args: &CheckVersion, mock_url: Option<String>) -> Res
     }
 }
 
-pub async fn check(cli_config_path: Option<PathBuf>) -> Result<String, Error> {
+pub async fn check(cli_config_path: Option<PathBuf>, json: bool) -> Result<String, Error> {
+    if json {
+        return check_json(cli_config_path).await;
+    }
     check_with_prompts(
         cli_config_path,
         |message| confirm(message, false),
         |message| confirm(message, false),
     )
     .await
+}
+
+async fn check_json(cli_config_path: Option<PathBuf>) -> Result<String, Error> {
+    let path = resolve_config_path(cli_config_path).await?;
+
+    if !tokio::fs::try_exists(&path).await? {
+        return Err(Error::new(
+            "config_check",
+            &format!(
+                "No config file found at {}. Run 'tod auth login' to initialize tod.",
+                path.display()
+            ),
+        ));
+    }
+
+    if Config::load(&path).await.is_ok() {
+        let result = serde_json::json!({"status": "valid", "path": path.to_string_lossy()});
+        return Ok(result.to_string());
+    }
+
+    let json_raw = tokio::fs::read_to_string(&path).await?;
+    let value: Value = serde_json::from_str(&json_raw).map_err(|e| {
+        Error::new(
+            "config_check",
+            &format!(
+                "Config file at {} is invalid and could not be parsed as JSON:\n{e}",
+                path.display()
+            ),
+        )
+    })?;
+
+    let repaired = repair_unknown_fields(value).map_err(|e| {
+        Error::new(
+            "config_check",
+            &format!(
+                "Config file at {} is invalid and could not be automatically repaired:\n{e}",
+                path.display()
+            ),
+        )
+    })?;
+
+    if repaired.removed_fields.is_empty() {
+        let result = serde_json::json!({"status": "valid", "path": path.to_string_lossy()});
+        return Ok(result.to_string());
+    }
+
+    let result = serde_json::json!({
+        "status": "invalid",
+        "path": path.to_string_lossy(),
+        "removed_fields": repaired.removed_fields
+    });
+    Ok(result.to_string())
 }
 
 async fn check_with_prompts<R, S>(
@@ -577,7 +649,7 @@ mod tests {
         };
 
         // Run the version check
-        let response = check_version(&args, Some(server.url()))
+        let response = check_version(&args, Some(server.url()), false)
             .await
             .expect("Expected version check to succeed");
 

--- a/src/commands/list_commands.rs
+++ b/src/commands/list_commands.rs
@@ -320,11 +320,11 @@ pub async fn remind(config: Config, args: &Remind) -> Result<String, Error> {
         super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await?;
     lists::remind(&config, flag, sort).await
 }
-pub async fn import(config: Config, args: &Import) -> Result<String, Error> {
+pub async fn import(config: Config, args: &Import, json: bool) -> Result<String, Error> {
     let Import { path } = args;
     let path = super::fetch_string(path.as_deref(), &config, input::PATH)?;
     let file_path = select_file(path, &config)?;
-    lists::import(&config, &file_path).await
+    lists::import(&config, &file_path, json).await
 }
 
 fn select_file(path_or_file: String, config: &Config) -> Result<String, Error> {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -167,7 +167,7 @@ async fn reminder_command(
     match command {
         ReminderCommands::List(args) => {
             let mut config = fetch_config(cli, tx).await?;
-            let result = reminder_commands::list(&mut config, args).await;
+            let result = reminder_commands::list(&mut config, args, cli.json).await;
             Ok(build_command_result(result, &config))
         }
     }
@@ -181,7 +181,7 @@ async fn section_command(
     match command {
         SectionCommands::Create(args) => {
             let config = fetch_config(cli, tx).await?;
-            let result = section_commands::create(&config, args).await;
+            let result = section_commands::create(&config, args, cli.json).await;
             Ok(build_command_result(result, &config))
         }
     }
@@ -195,7 +195,7 @@ async fn project_command(
     match command {
         ProjectCommands::Create(args) => {
             let mut config = fetch_config(cli, tx).await?;
-            let result = project_commands::create(&mut config, args).await;
+            let result = project_commands::create(&mut config, args, cli.json).await;
             Ok(build_command_result(result, &config))
         }
         ProjectCommands::List(args) => {
@@ -215,7 +215,7 @@ async fn project_command(
         }
         ProjectCommands::Import(args) => {
             let mut config = fetch_config(cli, tx).await?;
-            let result = project_commands::import(&mut config, args).await;
+            let result = project_commands::import(&mut config, args, cli.json).await;
             Ok(build_command_result(result, &config))
         }
         ProjectCommands::Empty(args) => {
@@ -249,12 +249,12 @@ async fn task_command(
         }
         TaskCommands::Edit(args) => {
             let config = fetch_config(cli, tx).await?;
-            let result = task_commands::edit(config.clone(), args).await;
+            let result = task_commands::edit(config.clone(), args, cli.json).await;
             Ok(build_command_result(result, &config))
         }
         TaskCommands::Next(args) => {
             let config = fetch_config(cli, tx).await?;
-            let result = task_commands::next(config.clone(), args).await;
+            let result = task_commands::next(config.clone(), args, cli.json).await;
             Ok(build_command_result(result, &config))
         }
         TaskCommands::Complete(args) => {
@@ -264,7 +264,7 @@ async fn task_command(
         }
         TaskCommands::Comment(args) => {
             let config = fetch_config(cli, tx).await?;
-            let result = task_commands::comment(config.clone(), args).await;
+            let result = task_commands::comment(config.clone(), args, cli.json).await;
             Ok(build_command_result(result, &config))
         }
     }
@@ -318,7 +318,7 @@ async fn list_command(
         }
         ListCommands::Import(args) => {
             let config = fetch_config(cli, tx).await?;
-            let result = list_commands::import(config.clone(), args).await;
+            let result = list_commands::import(config.clone(), args, cli.json).await;
             Ok(build_command_result(result, &config))
         }
     }
@@ -342,11 +342,11 @@ async fn config_command(
         }
 
         ConfigCommands::CheckVersion(args) => {
-            let result = config_commands::check_version(args, None).await;
+            let result = config_commands::check_version(args, None, cli.json).await;
             Ok(build_command_result_without_config(result, cli.json))
         }
         ConfigCommands::Check(_args) => {
-            let result = config_commands::check(cli.config.clone()).await;
+            let result = config_commands::check(cli.config.clone(), cli.json).await;
             Ok(build_command_result_without_config(result, cli.json))
         }
         ConfigCommands::About(args) => {
@@ -379,7 +379,7 @@ async fn auth_command(command: &AuthCommands, cli: &Cli) -> Result<CommandResult
         }
 
         AuthCommands::Token(args) => {
-            let result = auth_commands::token(cli.config.clone(), args).await;
+            let result = auth_commands::token(cli.config.clone(), args, cli.json).await;
             Ok(build_command_result_without_config(result, cli.json))
         }
     }

--- a/src/commands/project_commands.rs
+++ b/src/commands/project_commands.rs
@@ -122,7 +122,7 @@ pub struct Empty {
     project: Option<String>,
 }
 
-pub async fn create(config: &mut Config, args: &Create) -> Result<String, Error> {
+pub async fn create(config: &mut Config, args: &Create, json: bool) -> Result<String, Error> {
     let Create {
         name,
         description,
@@ -131,7 +131,7 @@ pub async fn create(config: &mut Config, args: &Create) -> Result<String, Error>
     let name = super::fetch_string(name.as_deref(), config, input::NAME)?;
     let description = description.as_deref().unwrap_or_default();
 
-    projects::create(config, name, description, *is_favorite).await
+    projects::create(config, name, description, *is_favorite, json).await
 }
 
 pub async fn list(config: &mut Config, _args: &List, json: bool) -> Result<String, Error> {
@@ -217,12 +217,12 @@ pub async fn rename(config: &mut Config, args: &Rename) -> Result<String, Error>
     projects::rename(config, &project, name.as_deref()).await
 }
 
-pub async fn import(config: &mut Config, args: &Import) -> Result<String, Error> {
+pub async fn import(config: &mut Config, args: &Import, json: bool) -> Result<String, Error> {
     let Import { auto, project, id } = args;
-    if !*auto && config.args.json {
+    if !*auto && json {
         return Err(Error::new("json_mode", super::JSON_INTERACTIVE_ERROR));
     }
-    projects::import(config, auto, project.as_deref(), id.as_deref()).await
+    projects::import(config, auto, project.as_deref(), id.as_deref(), json).await
 }
 
 pub async fn empty(config: &mut Config, args: &Empty) -> Result<String, Error> {

--- a/src/commands/reminder_commands.rs
+++ b/src/commands/reminder_commands.rs
@@ -13,8 +13,8 @@ pub enum ReminderCommands {
 #[derive(Parser, Debug, Clone)]
 pub struct List {}
 
-pub async fn list(config: &mut Config, _args: &List) -> Result<String, Error> {
-    reminders::list(config).await
+pub async fn list(config: &mut Config, _args: &List, json: bool) -> Result<String, Error> {
+    reminders::list(config, json).await
 }
 
 #[cfg(test)]
@@ -52,7 +52,7 @@ mod tests {
             .with_projects(vec![test::fixtures::project()]);
         config.save().await.expect("config should be saved");
 
-        let output = list(&mut config, &List {})
+        let output = list(&mut config, &List {}, false)
             .await
             .expect("reminder list command should succeed");
         assert!(output.contains("Reminders"));

--- a/src/commands/section_commands.rs
+++ b/src/commands/section_commands.rs
@@ -19,7 +19,7 @@ pub struct Create {
     project: Option<String>,
 }
 
-pub async fn create(config: &Config, args: &Create) -> Result<String, Error> {
+pub async fn create(config: &Config, args: &Create, json: bool) -> Result<String, Error> {
     let Create { name, project } = args;
     let name = super::fetch_string(name.as_deref(), config, input::NAME)?;
 
@@ -28,8 +28,12 @@ pub async fn create(config: &Config, args: &Create) -> Result<String, Error> {
         Flag::Filter(_) => unreachable!(),
     };
 
-    todoist::create_section(config, &name, &project, true).await?;
-    Ok(format::green_string("Section created successfully"))
+    let section = todoist::create_section(config, &name, &project, true).await?;
+    if json {
+        Ok(serde_json::to_string(&section)?)
+    } else {
+        Ok(format::green_string("Section created successfully"))
+    }
 }
 
 #[cfg(test)]
@@ -44,7 +48,7 @@ mod tests {
             project: None,
         };
 
-        let error = create(&config, &args)
+        let error = create(&config, &args, false)
             .await
             .expect_err("creating a section should fail without configured projects");
 

--- a/src/commands/task_commands.rs
+++ b/src/commands/task_commands.rs
@@ -268,18 +268,21 @@ fn no_flags_used(args: &Create) -> bool {
         && label.is_empty()
 }
 
-pub async fn edit(config: Config, args: &Edit) -> Result<String, Error> {
+pub async fn edit(config: Config, args: &Edit, json: bool) -> Result<String, Error> {
+    if json {
+        return Err(Error::new("json_mode", super::JSON_INTERACTIVE_ERROR));
+    }
     let Edit { project, filter } = args;
     match super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await? {
         Flag::Project(project) => projects::edit_task(&config, &project).await,
         Flag::Filter(filter) => filters::edit_task(&config, filter).await,
     }
 }
-pub async fn next(config: Config, args: &Next) -> Result<String, Error> {
+pub async fn next(config: Config, args: &Next, json: bool) -> Result<String, Error> {
     let Next { project, filter } = args;
     match super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await? {
-        Flag::Project(project) => projects::next_task(config, &project).await,
-        Flag::Filter(filter) => filters::next_task(&config, &filter).await,
+        Flag::Project(project) => projects::next_task(config, &project, json).await,
+        Flag::Filter(filter) => filters::next_task(&config, &filter, json).await,
     }
 }
 
@@ -301,13 +304,17 @@ pub async fn complete(config: Config, _args: &Complete, json: bool) -> Result<St
     }
 }
 
-pub async fn comment(config: Config, args: &Comment) -> Result<String, Error> {
+pub async fn comment(config: Config, args: &Comment, json: bool) -> Result<String, Error> {
     let Comment { content } = args;
     match config.next_task() {
         Some(task) => {
             let content = super::fetch_string(content.as_deref(), &config, input::CONTENT)?;
-            todoist::create_comment(&config, &task.id, &content, true).await?;
-            Ok(format::green_string("Comment created successfully"))
+            let comment = todoist::create_comment(&config, &task.id, &content, true).await?;
+            if json {
+                Ok(serde_json::to_string(&comment)?)
+            } else {
+                Ok(format::green_string("Comment created successfully"))
+            }
         }
         None => Err(Error::new(
             "task_comment",
@@ -408,7 +415,7 @@ mod tests {
             filter: Some("myfilter".to_string()),
         };
 
-        let result = edit(config, &args).await;
+        let result = edit(config, &args, false).await;
 
         assert!(result.is_ok(), "edit should succeed; got: {result:?}");
         assert!(result.unwrap().contains("Finished editing"));
@@ -455,7 +462,7 @@ mod tests {
             filter: Some("myfilter".to_string()),
         };
 
-        let result = next(config, &args).await;
+        let result = next(config, &args, false).await;
 
         assert!(result.is_ok(), "next should succeed; got: {result:?}");
         assert!(result.unwrap().contains("task(s) remaining"));

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -45,13 +45,20 @@ pub async fn edit_task(config: &Config, filter: String) -> Result<String, Error>
 }
 
 /// Get the next task by priority and save its id to config
-pub async fn next_task(config: &Config, filter: &str) -> Result<String, Error> {
+pub async fn next_task(config: &Config, filter: &str, json: bool) -> Result<String, Error> {
     match fetch_next_task(config, filter).await {
         Ok(Some((task, remaining))) => {
-            let comments = todoist::all_comments(config, &task.id, None).await?;
-            let task_string = task.fmt(comments, config, FormatType::Single, true).await?;
+            let task_json = task.clone();
             config.set_next_task(task).save().await?;
-            Ok(format!("{task_string}\n{remaining} task(s) remaining"))
+            if json {
+                Ok(serde_json::to_string(&task_json)?)
+            } else {
+                let comments = todoist::all_comments(config, &task_json.id, None).await?;
+                let task_string = task_json
+                    .fmt(comments, config, FormatType::Single, true)
+                    .await?;
+                Ok(format!("{task_string}\n{remaining} task(s) remaining"))
+            }
         }
         Ok(None) => Ok(format::green_string("No tasks on list")),
         Err(e) => Err(e),
@@ -197,7 +204,7 @@ mod tests {
             .expect("expected value or result, got None or Err");
 
         let filter = String::from("today");
-        let task = next_task(&config_with_timezone, &filter)
+        let task = next_task(&config_with_timezone, &filter, false)
             .await
             .expect("expected value or result, got None or Err");
 

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -292,23 +292,29 @@ pub async fn label(
     Ok(format::green_string(&success))
 }
 
-pub async fn import(config: &Config, file_path: &str) -> Result<String, Error> {
-    let mut lines = String::new();
+pub async fn import(config: &Config, file_path: &str, json: bool) -> Result<String, Error> {
+    let mut file_content = String::new();
     fs::File::open(file_path)
         .await?
-        .read_to_string(&mut lines)
+        .read_to_string(&mut file_content)
         .await?;
 
-    let lines: Vec<String> = lines
+    let lines: Vec<String> = file_content
         .split('\n')
         .map(std::borrow::ToOwned::to_owned)
         .filter(|s| !s.is_empty())
         .collect();
+    let count = lines.len();
     for line in lines {
         todoist::quick_create_task(config, &line, None).await?;
     }
 
-    Ok("✓".into())
+    if json {
+        let result = serde_json::json!({"imported": count});
+        Ok(result.to_string())
+    } else {
+        Ok("✓".into())
+    }
 }
 
 #[cfg(test)]
@@ -339,7 +345,10 @@ mod tests {
 
         let config = test::fixtures::config().await.with_mock_url(server.url());
 
-        assert_eq!(import(&config, import_file).await, Ok(String::from("✓")));
+        assert_eq!(
+            import(&config, import_file, false).await,
+            Ok(String::from("✓"))
+        );
 
         mock.assert();
     }

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -78,10 +78,15 @@ pub async fn create(
     name: String,
     description: &str,
     is_favorite: bool,
+    json: bool,
 ) -> Result<String, Error> {
     let project = todoist::create_project(config, &name, description, is_favorite, true).await?;
     add(config, &project).await?;
-    Ok(format!("Created project {name} and added to config"))
+    if json {
+        Ok(serde_json::to_string(&project)?)
+    } else {
+        Ok(format!("Created project {name} and added to config"))
+    }
 }
 /// List the projects in config with task counts
 pub async fn list(config: &mut Config) -> Result<String, Error> {
@@ -174,15 +179,20 @@ pub async fn rename(
 }
 
 /// Get the next task by priority and save its id to config
-pub async fn next_task(config: Config, project: &Project) -> Result<String, Error> {
+pub async fn next_task(config: Config, project: &Project, json: bool) -> Result<String, Error> {
     match fetch_next_task(&config, project).await {
         Ok(Some((task, remaining))) => {
-            let comments = todoist::all_comments(&config, &task.id, None).await?;
-            let task_string = task
-                .fmt(comments, &config, FormatType::Single, false)
-                .await?;
+            let task_json = task.clone();
             config.set_next_task(task).save().await?;
-            Ok(format!("{task_string}\n{remaining} task(s) remaining"))
+            if json {
+                Ok(serde_json::to_string(&task_json)?)
+            } else {
+                let comments = todoist::all_comments(&config, &task_json.id, None).await?;
+                let task_string = task_json
+                    .fmt(comments, &config, FormatType::Single, false)
+                    .await?;
+                Ok(format!("{task_string}\n{remaining} task(s) remaining"))
+            }
         }
         Ok(None) => Ok(format::green_string("No tasks on list")),
         Err(e) => Err(e),
@@ -272,6 +282,7 @@ pub async fn import(
     auto: &bool,
     project: Option<&str>,
     id: Option<&str>,
+    json: bool,
 ) -> Result<String, Error> {
     if project.is_some() && id.is_some() {
         return Err(Error::new(
@@ -295,7 +306,12 @@ pub async fn import(
         let new_projects = filter_new_projects(config, vec![target]).await?;
 
         return if let Some(project) = new_projects.into_iter().next() {
-            add_imported_project(config, &project).await
+            let result = add_imported_project(config, &project).await?;
+            if json {
+                Ok(serde_json::to_string(&project)?)
+            } else {
+                Ok(result)
+            }
         } else {
             Ok(format::green_string("Project already in config"))
         };
@@ -314,17 +330,37 @@ pub async fn import(
         let new_projects = filter_new_projects(config, vec![target]).await?;
 
         return if let Some(project) = new_projects.into_iter().next() {
-            add_imported_project(config, &project).await
+            let result = add_imported_project(config, &project).await?;
+            if json {
+                Ok(serde_json::to_string(&project)?)
+            } else {
+                Ok(result)
+            }
         } else {
             Ok(format::green_string("Project already in config"))
         };
     }
 
     let new_projects = filter_new_projects(config, projects).await?;
-    for project in new_projects {
-        maybe_add_project(config, project, auto).await?;
+    let added: Vec<Project> = if *auto {
+        let mut added = Vec::new();
+        for project in new_projects {
+            add(config, &project).await?;
+            added.push(project);
+        }
+        added
+    } else {
+        for project in new_projects {
+            maybe_add_project(config, project, auto).await?;
+        }
+        Vec::new()
+    };
+
+    if json {
+        Ok(serde_json::to_string(&added)?)
+    } else {
+        Ok(format::green_string("No more projects"))
     }
-    Ok(format::green_string("No more projects"))
 }
 
 /// Returns the projects that are not already in config
@@ -711,7 +747,7 @@ mod tests {
             .await
             .expect("expected value or result, got None or Err");
 
-        let response = next_task(config_with_timezone, project)
+        let response = next_task(config_with_timezone, project, false)
             .await
             .expect("expected value or result, got None or Err");
 
@@ -741,7 +777,7 @@ mod tests {
             .expect("expected value or result, got None or Err");
 
         assert_eq!(
-            import(&mut config, &false, None, None).await,
+            import(&mut config, &false, None, None, false).await,
             Ok("No more projects".to_string())
         );
         mock.assert_async().await;
@@ -779,7 +815,7 @@ mod tests {
             .expect("expected value or result, got None or Err");
 
         assert_eq!(
-            import(&mut config, &false, Some("Doomsday"), None).await,
+            import(&mut config, &false, Some("Doomsday"), None, false).await,
             Ok("✓ Added project Doomsday".to_string())
         );
         mock.assert_async().await;
@@ -804,7 +840,7 @@ mod tests {
             .expect("expected value or result, got None or Err");
 
         assert_eq!(
-            import(&mut config, &false, None, Some("890")).await,
+            import(&mut config, &false, None, Some("890"), false).await,
             Ok("✓ Added project Doomsday".to_string())
         );
         mock.assert_async().await;
@@ -828,7 +864,7 @@ mod tests {
             .await
             .expect("expected value or result, got None or Err");
 
-        let result = import(&mut config, &false, Some("does-not-exist"), None).await;
+        let result = import(&mut config, &false, Some("does-not-exist"), None, false).await;
         assert_eq!(
             result,
             Err(Error::new(
@@ -857,7 +893,7 @@ mod tests {
             .await
             .expect("expected value or result, got None or Err");
 
-        let result = import(&mut config, &false, None, Some("999999")).await;
+        let result = import(&mut config, &false, None, Some("999999"), false).await;
         assert_eq!(
             result,
             Err(Error::new(

--- a/src/reminders.rs
+++ b/src/reminders.rs
@@ -56,8 +56,12 @@ impl ReminderResponse {
 }
 
 /// List all the reminders with their tasks
-pub async fn list(config: &mut Config) -> Result<String, Error> {
+pub async fn list(config: &mut Config, json: bool) -> Result<String, Error> {
     let reminders = todoist::all_reminders(config, None).await?;
+
+    if json {
+        return Ok(serde_json::to_string(&reminders)?);
+    }
 
     let task_ids = reminders
         .clone()
@@ -129,7 +133,7 @@ mod tests {
 
         let str = "Reminders\n - 2026-01-18 17:00\n   TEST";
 
-        assert_eq!(list(&mut config).await, Ok(String::from(str)));
+        assert_eq!(list(&mut config, false).await, Ok(String::from(str)));
         mock.expect(1);
         mock2.expect(1);
     }


### PR DESCRIPTION
## Summary

Adds JSON output for all remaining non-interactive commands as specified in #1740 (Phase 5 of the JSON output feature).

## Commands updated

| Group | Commands | Serialize as |
|---|---|---|
| section | \`create\` | \`Section\` |
| reminder | \`list\` | \`Vec<Reminder>\` |
| task | \`comment\` | \`Comment\` |
| task | \`edit\` | guarded (inherently interactive) |
| task | \`next\` | \`Task\` |
| config | \`check\` | status struct \`{status, path, ...}\` |
| config | \`check-version\` | status struct \`{status, version, ...}\` |
| project | \`create\` | \`Project\` |
| project | \`import --auto\` | \`Vec<Project>\` |
| list | \`import --path\` | \`{imported: count}\` |
| auth | \`token\` | \`{status: ok, path}\` |

## Pattern

Each handler takes a \`json: bool\` parameter. When true, return data is serialized as JSON. When false, existing formatted output is preserved.

## Verification

- All 422 tests pass (format, check, clippy, test)
- \`cargo run -- -j config about\` → valid JSON
- \`cargo run -- -j config check-version\` → valid JSON
- \`cargo run -- -j config check\` → valid JSON
- \`cargo run -- -j auth token <key>\` → valid JSON
- \`cargo run -- -j task edit\` → structured error (interactive guard)

Closes #1740