### PR TITLE
feat: add JSON output for prioritize, remind, schedule, and deadline commands

### DIFF
--- a/src/commands/list_commands.rs
+++ b/src/commands/list_commands.rs
@@ -1,4 +1,6 @@
 use clap::{Parser, Subcommand};
+use futures::future;
+use std::collections::HashSet;
 use std::path::Path;
 use walkdir::WalkDir;
 
@@ -8,7 +10,8 @@ use crate::{
     filters, input,
     lists::{self, Flag},
     projects,
-    tasks::SortOrder,
+    tasks::{self, SortOrder, Task},
+    tasks::priority::{self, Priority},
     todoist,
 };
 
@@ -133,6 +136,10 @@ pub struct Prioritize {
     )]
     /// Choose how results should be sorted
     sort: SortOrder,
+
+    #[arg(short = 'P', long)]
+    /// Priority to assign (1-4). Required in JSON mode.
+    priority: Option<u8>,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -154,6 +161,10 @@ pub struct Remind {
     )]
     /// Choose how results should be sorted
     sort: SortOrder,
+
+    #[arg(short = 'd', long)]
+    /// Datetime string in natural language (e.g. "tomorrow at 3pm"). Required in JSON mode.
+    datetime: Option<String>,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -199,6 +210,10 @@ pub struct Schedule {
     /// Only schedule overdue tasks
     overdue: bool,
 
+    #[arg(short = 'd', long)]
+    /// Datetime string in natural language (e.g. "tomorrow at 3pm"). Required in JSON mode.
+    datetime: Option<String>,
+
     #[arg(
         short = 't',
         long,
@@ -229,6 +244,10 @@ pub struct Deadline {
     )]
     /// Choose how results should be sorted
     sort: SortOrder,
+
+    #[arg(short = 'd', long)]
+    /// Date string in natural language (e.g. "next Friday"). Required in JSON mode.
+    date: Option<String>,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -299,26 +318,114 @@ pub async fn timebox(config: Config, args: &Timebox) -> Result<String, Error> {
     lists::timebox(&config, flag, sort).await
 }
 
-pub async fn prioritize(config: Config, args: &Prioritize) -> Result<String, Error> {
+pub async fn prioritize(config: Config, args: &Prioritize, json: bool) -> Result<String, Error> {
     let Prioritize {
         project,
         filter,
         sort,
+        priority,
     } = args;
-    let flag =
-        super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await?;
-    lists::prioritize(&config, flag, sort).await
+
+    if json {
+        let priority = match priority {
+            Some(p) => match priority::from_integer(Some(*p))? {
+                Some(p) => p,
+                None => {
+                    return Err(Error::new(
+                        "json_mode",
+                        "Invalid priority. Use 1 (p4), 2 (p3), 3 (p2), or 4 (p1).",
+                    ));
+                }
+            },
+            None => {
+                return Err(Error::new(
+                    "json_mode",
+                    "--priority flag is required in JSON mode. Use 1 (p4), 2 (p3), 3 (p2), or 4 (p1).",
+                ));
+            }
+        };
+
+        let flag =
+            super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await?;
+        let tasks =
+            lists::fetch_tasks_by_flag(&config, &flag, |t| t.priority == Priority::None, |_| true)
+                .await?;
+        let count = tasks.len();
+
+        let handles: Vec<_> = tasks
+            .iter()
+            .map(|task| {
+                let config = config.clone();
+                let id = task.id.clone();
+                async move {
+                    todoist::update_task_priority(&config, &id, &priority, false).await
+                }
+            })
+            .collect();
+        future::join_all(handles).await;
+
+        let json = serde_json::json!({"tasks": tasks, "count": count, "priority": priority});
+        Ok(json.to_string())
+    } else {
+        let flag =
+            super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await?;
+        lists::prioritize(&config, flag, sort).await
+    }
 }
 
-pub async fn remind(config: Config, args: &Remind) -> Result<String, Error> {
+pub async fn remind(config: Config, args: &Remind, json: bool) -> Result<String, Error> {
     let Remind {
         project,
         filter,
         sort,
+        datetime,
     } = args;
-    let flag =
-        super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await?;
-    lists::remind(&config, flag, sort).await
+
+    if json {
+        let datetime = match datetime {
+            Some(d) => d.clone(),
+            None => {
+                return Err(Error::new(
+                    "json_mode",
+                    "--datetime flag is required in JSON mode (e.g. \"tomorrow at 3pm\").",
+                ));
+            }
+        };
+
+        let reminder_task_ids = todoist::all_reminders(&config, None)
+            .await?
+            .into_iter()
+            .map(|r| r.item_id)
+            .collect::<HashSet<String>>();
+
+        let flag =
+            super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await?;
+        let tasks =
+            lists::fetch_tasks_by_flag(&config, &flag, |t| !reminder_task_ids.contains(&t.id), |t| !reminder_task_ids.contains(&t.id))
+                .await?;
+        let tasks = tasks::sort(tasks, &config, *sort);
+        let count = tasks.len();
+
+        let handles: Vec<_> = tasks
+            .iter()
+            .map(|task| {
+                let config = config.clone();
+                let reminder = datetime.clone();
+                async move {
+                    let task = task.clone();
+                    todoist::create_reminder(&config, &task, &reminder, false).await
+                }
+            })
+            .collect();
+        future::join_all(handles).await;
+
+        let json = serde_json::json!({"tasks": tasks, "count": count});
+        Ok(json.to_string())
+    } else {
+        let flag =
+            super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await?;
+        lists::remind(&config, flag, sort).await
+    }
 }
 pub async fn import(config: Config, args: &Import, json: bool) -> Result<String, Error> {
     let Import { path } = args;
@@ -362,37 +469,169 @@ fn is_md_file(entry: &walkdir::DirEntry) -> bool {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
 }
 
-pub async fn schedule(config: Config, args: &Schedule) -> Result<String, Error> {
+pub async fn schedule(config: Config, args: &Schedule, json: bool) -> Result<String, Error> {
     let Schedule {
         project,
         filter,
         skip_recurring,
         overdue,
         sort,
+        datetime,
     } = args;
-    match super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await? {
-        Flag::Filter(filter) => filters::schedule(&config, &filter, sort).await,
-        Flag::Project(project) => {
-            let task_filter = if *overdue {
-                projects::TaskFilter::Overdue
-            } else {
-                projects::TaskFilter::Unscheduled
-            };
 
-            projects::schedule(&config, &project, task_filter, *skip_recurring, sort).await
+    if json {
+        let datetime = match datetime {
+            Some(d) => d.clone(),
+            None => {
+                return Err(Error::new(
+                    "json_mode",
+                    "--datetime flag is required in JSON mode (e.g. \"tomorrow at 3pm\").",
+                ));
+            }
+        };
+
+        let flag =
+            super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await?;
+        let tasks = match &flag {
+            Flag::Project(project) => {
+                let tasks = todoist::all_tasks_by_project(&config, project, None).await?;
+                let tasks = tasks::sort(tasks, &config, *sort);
+                let task_filter = if *overdue {
+                    projects::TaskFilter::Overdue
+                } else {
+                    projects::TaskFilter::Unscheduled
+                };
+                let tasks: Vec<Task> = if *skip_recurring {
+                    tasks
+                        .into_iter()
+                        .filter(|task| {
+                            task.filter(&config, &task_filter)
+                                && !task.filter(&config, &projects::TaskFilter::Recurring)
+                        })
+                        .collect()
+                } else {
+                    tasks
+                        .into_iter()
+                        .filter(|task| task.filter(&config, &task_filter))
+                        .collect()
+                };
+                tasks
+            }
+            Flag::Filter(filter) => {
+                let tasks = todoist::all_tasks_by_filters(&config, filter)
+                    .await?
+                    .into_iter()
+                    .flat_map(|(_, tasks)| tasks)
+                    .collect::<Vec<Task>>();
+                tasks::sort(tasks, &config, *sort)
+            }
+        };
+        let count = tasks.len();
+
+        let handles: Vec<_> = tasks
+            .iter()
+            .map(|task| {
+                let config = config.clone();
+                let dt = datetime.clone();
+                let task = task.clone();
+                async move {
+                    todoist::update_task_due_natural_language(
+                        &config, &task, dt, None, false,
+                    )
+                    .await
+                }
+            })
+            .collect();
+        future::join_all(handles).await;
+
+        let json = serde_json::json!({"tasks": tasks, "count": count});
+        Ok(json.to_string())
+    } else {
+        match super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await? {
+            Flag::Filter(filter) => filters::schedule(&config, &filter, sort).await,
+            Flag::Project(project) => {
+                let task_filter = if *overdue {
+                    projects::TaskFilter::Overdue
+                } else {
+                    projects::TaskFilter::Unscheduled
+                };
+
+                projects::schedule(&config, &project, task_filter, *skip_recurring, sort).await
+            }
         }
     }
 }
 
-pub async fn deadline(config: Config, args: &Deadline) -> Result<String, Error> {
+pub async fn deadline(config: Config, args: &Deadline, json: bool) -> Result<String, Error> {
     let Deadline {
         project,
         filter,
         sort,
+        date,
     } = args;
-    match super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await? {
-        Flag::Filter(filter) => filters::deadline(&config, &filter, sort).await,
-        Flag::Project(project) => projects::deadline(&config, &project, sort).await,
+
+    if json {
+        let date = match date {
+            Some(d) => d.clone(),
+            None => {
+                return Err(Error::new(
+                    "json_mode",
+                    "--date flag is required in JSON mode (e.g. \"next Friday\").",
+                ));
+            }
+        };
+
+        let flag =
+            super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await?;
+        let tasks = match &flag {
+            Flag::Project(project) => {
+                let tasks = todoist::all_tasks_by_project(&config, project, None).await?;
+                let tasks = tasks::sort(tasks, &config, *sort);
+                tasks
+                    .into_iter()
+                    .filter(|task| {
+                        !task.filter(&config, &projects::TaskFilter::Recurring)
+                            && task.deadline.is_none()
+                    })
+                    .collect::<Vec<Task>>()
+            }
+            Flag::Filter(filter) => {
+                let tasks = todoist::all_tasks_by_filters(&config, filter)
+                    .await?
+                    .into_iter()
+                    .flat_map(|(_, tasks)| tasks)
+                    .collect::<Vec<Task>>();
+                let tasks = tasks::sort(tasks, &config, *sort);
+                tasks
+                    .into_iter()
+                    .filter(|task| {
+                        !task.filter(&config, &projects::TaskFilter::Recurring)
+                    })
+                    .collect::<Vec<Task>>()
+            }
+        };
+        let count = tasks.len();
+
+        let handles: Vec<_> = tasks
+            .iter()
+            .map(|task| {
+                let config = config.clone();
+                let d = date.clone();
+                let id = task.id.clone();
+                async move {
+                    todoist::update_task_deadline(&config, &id, Some(d), false).await
+                }
+            })
+            .collect();
+        future::join_all(handles).await;
+
+        let json = serde_json::json!({"tasks": tasks, "count": count});
+        Ok(json.to_string())
+    } else {
+        match super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await? {
+            Flag::Filter(filter) => filters::deadline(&config, &filter, sort).await,
+            Flag::Project(project) => projects::deadline(&config, &project, sort).await,
+        }
     }
 }
 

--- a/src/commands/list_commands.rs
+++ b/src/commands/list_commands.rs
@@ -326,51 +326,46 @@ pub async fn prioritize(config: Config, args: &Prioritize, json: bool) -> Result
         priority,
     } = args;
 
-    if json {
-        let priority = match priority {
-            Some(p) => match priority::from_integer(Some(*p))? {
-                Some(p) => p,
-                None => {
-                    return Err(Error::new(
-                        "json_mode",
-                        "Invalid priority. Use 1 (p4), 2 (p3), 3 (p2), or 4 (p1).",
-                    ));
-                }
-            },
-            None => {
-                return Err(Error::new(
-                    "json_mode",
-                    "--priority flag is required in JSON mode. Use 1 (p4), 2 (p3), 3 (p2), or 4 (p1).",
-                ));
-            }
-        };
-
+    if !json {
         let flag =
             super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await?;
-        let tasks =
-            lists::fetch_tasks_by_flag(&config, &flag, |t| t.priority == Priority::None, |_| true)
-                .await?;
-        let count = tasks.len();
-
-        let handles: Vec<_> = tasks
-            .iter()
-            .map(|task| {
-                let config = config.clone();
-                let id = task.id.clone();
-                async move {
-                    todoist::update_task_priority(&config, &id, &priority, false).await
-                }
-            })
-            .collect();
-        future::join_all(handles).await;
-
-        let json = serde_json::json!({"tasks": tasks, "count": count, "priority": priority});
-        Ok(json.to_string())
-    } else {
-        let flag =
-            super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await?;
-        lists::prioritize(&config, flag, sort).await
+        return lists::prioritize(&config, flag, sort).await;
     }
+
+    let Some(p) = priority else {
+        return Err(Error::new(
+            "json_mode",
+            "--priority flag is required in JSON mode. Use 1 (p4), 2 (p3), 3 (p2), or 4 (p1).",
+        ));
+    };
+    let Some(priority) = priority::from_integer(Some(*p))? else {
+        return Err(Error::new(
+            "json_mode",
+            "Invalid priority. Use 1 (p4), 2 (p3), 3 (p2), or 4 (p1).",
+        ));
+    };
+
+    let flag =
+        super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await?;
+    let tasks =
+        lists::fetch_tasks_by_flag(&config, &flag, |t| t.priority == Priority::None, |_| true)
+            .await?;
+    let count = tasks.len();
+
+    let handles: Vec<_> = tasks
+        .iter()
+        .map(|task| {
+            let config = config.clone();
+            let id = task.id.clone();
+            async move {
+                todoist::update_task_priority(&config, &id, &priority, false).await
+            }
+        })
+        .collect();
+    future::join_all(handles).await;
+
+    let json_output = serde_json::json!({"tasks": tasks, "count": count, "priority": priority});
+    Ok(json_output.to_string())
 }
 
 pub async fn remind(config: Config, args: &Remind, json: bool) -> Result<String, Error> {
@@ -381,51 +376,53 @@ pub async fn remind(config: Config, args: &Remind, json: bool) -> Result<String,
         datetime,
     } = args;
 
-    if json {
-        let datetime = match datetime {
-            Some(d) => d.clone(),
-            None => {
-                return Err(Error::new(
-                    "json_mode",
-                    "--datetime flag is required in JSON mode (e.g. \"tomorrow at 3pm\").",
-                ));
-            }
-        };
-
-        let reminder_task_ids = todoist::all_reminders(&config, None)
-            .await?
-            .into_iter()
-            .map(|r| r.item_id)
-            .collect::<HashSet<String>>();
-
+    if !json {
         let flag =
             super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await?;
-        let tasks =
-            lists::fetch_tasks_by_flag(&config, &flag, |t| !reminder_task_ids.contains(&t.id), |t| !reminder_task_ids.contains(&t.id))
-                .await?;
-        let tasks = tasks::sort(tasks, &config, *sort);
-        let count = tasks.len();
-
-        let handles: Vec<_> = tasks
-            .iter()
-            .map(|task| {
-                let config = config.clone();
-                let reminder = datetime.clone();
-                async move {
-                    let task = task.clone();
-                    todoist::create_reminder(&config, &task, &reminder, false).await
-                }
-            })
-            .collect();
-        future::join_all(handles).await;
-
-        let json = serde_json::json!({"tasks": tasks, "count": count});
-        Ok(json.to_string())
-    } else {
-        let flag =
-            super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await?;
-        lists::remind(&config, flag, sort).await
+        return lists::remind(&config, flag, sort).await;
     }
+
+    let Some(datetime) = datetime else {
+        return Err(Error::new(
+            "json_mode",
+            "--datetime flag is required in JSON mode (e.g. \"tomorrow at 3pm\").",
+        ));
+    };
+
+    let reminder_task_ids = todoist::all_reminders(&config, None)
+        .await?
+        .into_iter()
+        .map(|r| r.item_id)
+        .collect::<HashSet<String>>();
+
+    let flag =
+        super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await?;
+    let tasks =
+        lists::fetch_tasks_by_flag(
+            &config,
+            &flag,
+            |t| !reminder_task_ids.contains(&t.id),
+            |t| !reminder_task_ids.contains(&t.id),
+        )
+        .await?;
+    let tasks = tasks::sort(tasks, &config, *sort);
+    let count = tasks.len();
+
+    let handles: Vec<_> = tasks
+        .iter()
+        .map(|task| {
+            let config = config.clone();
+            let reminder = datetime.clone();
+            let task = task.clone();
+            async move {
+                todoist::create_reminder(&config, &task, &reminder, false).await
+            }
+        })
+        .collect();
+    future::join_all(handles).await;
+
+    let json_output = serde_json::json!({"tasks": tasks, "count": count});
+    Ok(json_output.to_string())
 }
 pub async fn import(config: Config, args: &Import, json: bool) -> Result<String, Error> {
     let Import { path } = args;
@@ -469,6 +466,77 @@ fn is_md_file(entry: &walkdir::DirEntry) -> bool {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
 }
 
+async fn fetch_schedule_tasks(
+    config: &Config,
+    flag: &Flag,
+    sort: &SortOrder,
+    overdue: bool,
+    skip_recurring: bool,
+) -> Result<Vec<Task>, Error> {
+    match flag {
+        Flag::Project(project) => {
+            let tasks = todoist::all_tasks_by_project(config, project, None).await?;
+            let tasks = tasks::sort(tasks, config, *sort);
+            let task_filter = if overdue {
+                projects::TaskFilter::Overdue
+            } else {
+                projects::TaskFilter::Unscheduled
+            };
+            Ok(tasks
+                .into_iter()
+                .filter(|task| {
+                    let matches_filter = task.filter(config, &task_filter);
+                    if skip_recurring {
+                        matches_filter && !task.filter(config, &projects::TaskFilter::Recurring)
+                    } else {
+                        matches_filter
+                    }
+                })
+                .collect())
+        }
+        Flag::Filter(filter) => {
+            let tasks = todoist::all_tasks_by_filters(config, filter)
+                .await?
+                .into_iter()
+                .flat_map(|(_, tasks)| tasks)
+                .collect::<Vec<Task>>();
+            Ok(tasks::sort(tasks, config, *sort))
+        }
+    }
+}
+
+async fn fetch_deadline_tasks(
+    config: &Config,
+    flag: &Flag,
+    sort: &SortOrder,
+) -> Result<Vec<Task>, Error> {
+    match flag {
+        Flag::Project(project) => {
+            let tasks = todoist::all_tasks_by_project(config, project, None).await?;
+            let tasks = tasks::sort(tasks, config, *sort);
+            Ok(tasks
+                .into_iter()
+                .filter(|task| {
+                    !task.filter(config, &projects::TaskFilter::Recurring)
+                        && task.deadline.is_none()
+                })
+                .collect())
+        }
+        Flag::Filter(filter) => {
+            let tasks = todoist::all_tasks_by_filters(config, filter)
+                .await?
+                .into_iter()
+                .flat_map(|(_, tasks)| tasks)
+                .collect::<Vec<Task>>();
+            let tasks = tasks::sort(tasks, config, *sort);
+            Ok(tasks
+                .into_iter()
+                .filter(|task| !task.filter(config, &projects::TaskFilter::Recurring))
+                .collect())
+        }
+    }
+}
+
 pub async fn schedule(config: Config, args: &Schedule, json: bool) -> Result<String, Error> {
     let Schedule {
         project,
@@ -479,75 +547,14 @@ pub async fn schedule(config: Config, args: &Schedule, json: bool) -> Result<Str
         datetime,
     } = args;
 
-    if json {
-        let datetime = match datetime {
-            Some(d) => d.clone(),
-            None => {
-                return Err(Error::new(
-                    "json_mode",
-                    "--datetime flag is required in JSON mode (e.g. \"tomorrow at 3pm\").",
-                ));
-            }
-        };
-
-        let flag =
-            super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await?;
-        let tasks = match &flag {
-            Flag::Project(project) => {
-                let tasks = todoist::all_tasks_by_project(&config, project, None).await?;
-                let tasks = tasks::sort(tasks, &config, *sort);
-                let task_filter = if *overdue {
-                    projects::TaskFilter::Overdue
-                } else {
-                    projects::TaskFilter::Unscheduled
-                };
-                let tasks: Vec<Task> = if *skip_recurring {
-                    tasks
-                        .into_iter()
-                        .filter(|task| {
-                            task.filter(&config, &task_filter)
-                                && !task.filter(&config, &projects::TaskFilter::Recurring)
-                        })
-                        .collect()
-                } else {
-                    tasks
-                        .into_iter()
-                        .filter(|task| task.filter(&config, &task_filter))
-                        .collect()
-                };
-                tasks
-            }
-            Flag::Filter(filter) => {
-                let tasks = todoist::all_tasks_by_filters(&config, filter)
-                    .await?
-                    .into_iter()
-                    .flat_map(|(_, tasks)| tasks)
-                    .collect::<Vec<Task>>();
-                tasks::sort(tasks, &config, *sort)
-            }
-        };
-        let count = tasks.len();
-
-        let handles: Vec<_> = tasks
-            .iter()
-            .map(|task| {
-                let config = config.clone();
-                let dt = datetime.clone();
-                let task = task.clone();
-                async move {
-                    todoist::update_task_due_natural_language(
-                        &config, &task, dt, None, false,
-                    )
-                    .await
-                }
-            })
-            .collect();
-        future::join_all(handles).await;
-
-        let json = serde_json::json!({"tasks": tasks, "count": count});
-        Ok(json.to_string())
-    } else {
-        match super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await? {
+    if !json {
+        return match super::fetch_project_or_filter(
+            project.as_deref(),
+            filter.as_deref(),
+            &config,
+        )
+        .await?
+        {
             Flag::Filter(filter) => filters::schedule(&config, &filter, sort).await,
             Flag::Project(project) => {
                 let task_filter = if *overdue {
@@ -555,11 +562,39 @@ pub async fn schedule(config: Config, args: &Schedule, json: bool) -> Result<Str
                 } else {
                     projects::TaskFilter::Unscheduled
                 };
-
                 projects::schedule(&config, &project, task_filter, *skip_recurring, sort).await
             }
-        }
+        };
     }
+
+    let Some(datetime) = datetime else {
+        return Err(Error::new(
+            "json_mode",
+            "--datetime flag is required in JSON mode (e.g. \"tomorrow at 3pm\").",
+        ));
+    };
+
+    let flag =
+        super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await?;
+    let tasks =
+        fetch_schedule_tasks(&config, &flag, sort, *overdue, *skip_recurring).await?;
+    let count = tasks.len();
+
+    let handles: Vec<_> = tasks
+        .iter()
+        .map(|task| {
+            let config = config.clone();
+            let dt = datetime.clone();
+            let task = task.clone();
+            async move {
+                todoist::update_task_due_natural_language(&config, &task, dt, None, false).await
+            }
+        })
+        .collect();
+    future::join_all(handles).await;
+
+    let json_output = serde_json::json!({"tasks": tasks, "count": count});
+    Ok(json_output.to_string())
 }
 
 pub async fn deadline(config: Config, args: &Deadline, json: bool) -> Result<String, Error> {
@@ -570,69 +605,46 @@ pub async fn deadline(config: Config, args: &Deadline, json: bool) -> Result<Str
         date,
     } = args;
 
-    if json {
-        let date = match date {
-            Some(d) => d.clone(),
-            None => {
-                return Err(Error::new(
-                    "json_mode",
-                    "--date flag is required in JSON mode (e.g. \"next Friday\").",
-                ));
-            }
-        };
-
-        let flag =
-            super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await?;
-        let tasks = match &flag {
-            Flag::Project(project) => {
-                let tasks = todoist::all_tasks_by_project(&config, project, None).await?;
-                let tasks = tasks::sort(tasks, &config, *sort);
-                tasks
-                    .into_iter()
-                    .filter(|task| {
-                        !task.filter(&config, &projects::TaskFilter::Recurring)
-                            && task.deadline.is_none()
-                    })
-                    .collect::<Vec<Task>>()
-            }
-            Flag::Filter(filter) => {
-                let tasks = todoist::all_tasks_by_filters(&config, filter)
-                    .await?
-                    .into_iter()
-                    .flat_map(|(_, tasks)| tasks)
-                    .collect::<Vec<Task>>();
-                let tasks = tasks::sort(tasks, &config, *sort);
-                tasks
-                    .into_iter()
-                    .filter(|task| {
-                        !task.filter(&config, &projects::TaskFilter::Recurring)
-                    })
-                    .collect::<Vec<Task>>()
-            }
-        };
-        let count = tasks.len();
-
-        let handles: Vec<_> = tasks
-            .iter()
-            .map(|task| {
-                let config = config.clone();
-                let d = date.clone();
-                let id = task.id.clone();
-                async move {
-                    todoist::update_task_deadline(&config, &id, Some(d), false).await
-                }
-            })
-            .collect();
-        future::join_all(handles).await;
-
-        let json = serde_json::json!({"tasks": tasks, "count": count});
-        Ok(json.to_string())
-    } else {
-        match super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await? {
+    if !json {
+        return match super::fetch_project_or_filter(
+            project.as_deref(),
+            filter.as_deref(),
+            &config,
+        )
+        .await?
+        {
             Flag::Filter(filter) => filters::deadline(&config, &filter, sort).await,
             Flag::Project(project) => projects::deadline(&config, &project, sort).await,
-        }
+        };
     }
+
+    let Some(date) = date else {
+        return Err(Error::new(
+            "json_mode",
+            "--date flag is required in JSON mode (e.g. \"next Friday\").",
+        ));
+    };
+
+    let flag =
+        super::fetch_project_or_filter(project.as_deref(), filter.as_deref(), &config).await?;
+    let tasks = fetch_deadline_tasks(&config, &flag, sort).await?;
+    let count = tasks.len();
+
+    let handles: Vec<_> = tasks
+        .iter()
+        .map(|task| {
+            let config = config.clone();
+            let d = date.clone();
+            let id = task.id.clone();
+            async move {
+                todoist::update_task_deadline(&config, &id, Some(d), false).await
+            }
+        })
+        .collect();
+    future::join_all(handles).await;
+
+    let json_output = serde_json::json!({"tasks": tasks, "count": count});
+    Ok(json_output.to_string())
 }
 
 #[cfg(test)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -287,12 +287,12 @@ async fn list_command(
         }
         ListCommands::Prioritize(args) => {
             let config = fetch_config(cli, tx).await?;
-            let result = list_commands::prioritize(config.clone(), args).await;
+            let result = list_commands::prioritize(config.clone(), args, cli.json).await;
             Ok(build_command_result(result, &config))
         }
         ListCommands::Remind(args) => {
             let config = fetch_config(cli, tx).await?;
-            let result = list_commands::remind(config.clone(), args).await;
+            let result = list_commands::remind(config.clone(), args, cli.json).await;
             Ok(build_command_result(result, &config))
         }
         ListCommands::Label(args) => {
@@ -302,12 +302,12 @@ async fn list_command(
         }
         ListCommands::Schedule(args) => {
             let config = fetch_config(cli, tx).await?;
-            let result = list_commands::schedule(config.clone(), args).await;
+            let result = list_commands::schedule(config.clone(), args, cli.json).await;
             Ok(build_command_result(result, &config))
         }
         ListCommands::Deadline(args) => {
             let config = fetch_config(cli, tx).await?;
-            let result = list_commands::deadline(config.clone(), args).await;
+            let result = list_commands::deadline(config.clone(), args, cli.json).await;
             Ok(build_command_result(result, &config))
         }
         ListCommands::Timebox(args) => {


### PR DESCRIPTION
## Summary

Adds JSON output support for four interactive list commands as part of #1734.

When the \`--json\` / \`-j\` global flag is combined with the new per-command flags, each command applies its action non-interactively to all matching tasks and returns structured JSON output.

## New CLI flags

| Command | Flag | Description |
|---|---|---|
| \`list prioritize\` | \`--priority\` / \`-P\` (u8) | Priority 1-4 to assign |
| \`list remind\` | \`--datetime\` / \`-d\` (String) | Natural language datetime |
| \`list schedule\` | \`--datetime\` / \`-d\` (String) | Natural language datetime |
| \`list deadline\` | \`--date\` / \`-d\` (String) | Natural language date |

## JSON output shape

All commands return \`{"tasks": [...], "count": N}\`. Prioritize also includes the \`"priority"\` field.

## Error handling

When \`--json\` is set but the required task-specific flag is missing, a clear structured error is returned:

\`\`\`json
{"error": {"message": "--priority flag is required in JSON mode. Use 1 (p4), 2 (p3), 3 (p2), or 4 (p1).", "source": "json_mode"}}
\`\`\`

## Files changed

- \`src/commands/list_commands.rs\` — Added flags to structs, JSON output branches in handlers
- \`src/commands/mod.rs\` — Pass \`cli.json\` to the four handlers

Closes #1734