### PR TITLE
feat: add 'tod auth view' command to display current API token

### DIFF
--- a/.pi/skills/docs-sync/SKILL.md
+++ b/.pi/skills/docs-sync/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: docs-sync
+description: Keep docs/usage.md in sync when adding or modifying CLI commands. Use after implementing a feature that changes the CLI surface area.
+---
+
+# Docs Sync
+
+When adding or modifying CLI commands (new subcommands, renamed flags, changed aliases), check `docs/usage.md` for stale example output and update it.
+
+## Checklist
+
+1. Run `tod <changed-command> -h` to get current help output
+2. Search `docs/usage.md` for the old command listing (the `Commands:` block in the code fence)
+3. Update the example output to match current help text
+4. Commit the doc change alongside the code change — same branch, same PR

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,38 +11,31 @@
 - `src/main.rs` — entry point, `CommandResult` struct, `output_result()` output gateway
 - `src/errors.rs` — `Error` type (`{message, source}`) with `Serialize` derive for JSON output
 - `src/format.rs` — Terminal color utilities
-- `src/input.rs` — inquire-based terminal prompts with mock support (`config.mock_string`, `config.mock_select`). Guards for JSON/non-interactive modes belong at the `fetch_*` call sites in `src/commands/mod.rs`, not inside `input.rs`.
+- `src/input.rs` — inquire-based terminal prompts with mock support. Guards for JSON/non-interactive modes belong at the `fetch_*` call sites in `src/commands/mod.rs`, not inside `input.rs`.
+- `docs/usage.md` — User-facing command examples; keep in sync with CLI changes
 
 ### Todoist API
-- `src/todoist/mod.rs` — REST API client. Key exports: `all_tasks_by_*`, `quick_create_task`, `create_task`, `complete_task`, `update_task_*`, `all_projects`, `all_labels`, `all_comments`, `all_sections_by_project`
-- `src/todoist/request.rs` — HTTP layer (GET/POST/DELETE via reqwest)
+- `src/todoist/` — REST API client (`mod.rs`) and HTTP layer (`request.rs`)
 
 ### Business logic
 - `src/projects.rs` — `Project` struct, CRUD operations, task scheduling
-- `src/lists.rs` — Business-logic functions for multi-task operations (view, process, label, timebox, etc.). The clap arg structs live in `src/commands/list_commands.rs`.
+- `src/lists.rs` — Multi-task operations (view, process, label, timebox, etc.)
 - `src/tasks/mod.rs` — `Task` struct + formatting
 
 ### Config
-- `src/config/mod.rs` — `Config` struct + serialization (`#[serde(deny_unknown_fields)]`)
-- `src/config/file.rs` — File I/O: `Config::load()`, `save()`, `create()`, `reload()`, `touch_file()`
-- `src/config/projects.rs` — Project CRUD on the config's `projectsv1` field
+- `src/config/` — `Config` struct + serialization (`mod.rs`), file I/O (`file.rs`), project CRUD (`projects.rs`)
 
 ### CLI dispatch
-- `src/commands/mod.rs` — Dispatch via clap `Subcommand` enum. Defines the `Cli` struct (including `--json`/`-j` flag) and `fetch_*` helpers: `fetch_string`, `fetch_project`, `fetch_filter`, `fetch_priority`, `fetch_project_or_filter`, `maybe_fetch_labels`.
-- `src/commands/task_commands.rs` — Task subcommand handlers
-- `src/commands/list_commands.rs` — List/view subcommand handlers
-- `src/commands/project_commands.rs` — Project subcommand handlers
-- `src/commands/config_commands.rs` — Config subcommand handlers
-- `src/commands/auth_commands.rs` — Auth subcommand handlers
-- `src/commands/reminder_commands.rs` — Reminder subcommand handlers
-- `src/commands/section_commands.rs` — Section subcommand handlers
-- `src/commands/shell_commands.rs` — Shell completion handler
-- `src/commands/test_commands.rs` — Manual API test handler
+- `src/commands/` — Dispatch via clap `Subcommand` enum (`mod.rs`) and command handlers for auth, config, list, project, reminder, section, shell, task, test
 
 ## GitHub conventions
 
-- Fetch issue/PR content with `gh issue view <N>` or `gh pr view <N>`. Use `--json` for labels and comments. Do not use web_search for repo issues — GitHub issue pages are not indexed for web search.
-- Issue templates live in `.github/ISSUE_TEMPLATE/` — use `feature_request.md` for features, `bug_report.md` for bugs
+- Use `gh issue view <N>` or `gh pr view <N>` to fetch issue/PR content. Never use web_search for repo issues.
+- Issue templates live in `.github/ISSUE_TEMPLATE/` — `feature_request.md` for features, `bug_report.md` for bugs
+
+## Docs
+
+- When adding or changing CLI commands, check `docs/usage.md` for example output that references the changed subcommands and keep it up to date.
 
 ## Error handling
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -64,6 +64,7 @@ Usage: tod auth <COMMAND>
 Commands:
   login  (l) Log into Todoist using OAuth
   token  (t) Save a Todoist developer API token directly to the config (non-interactive)
+  view   (v) Display the current Todoist API token
   help   Print this message or the help of the given subcommand(s)
 ```
 

--- a/src/commands/auth_commands.rs
+++ b/src/commands/auth_commands.rs
@@ -16,6 +16,10 @@ pub enum AuthCommands {
     #[clap(alias = "t")]
     /// (t) Save a Todoist developer API token directly to the config (non-interactive)
     Token(Token),
+
+    #[clap(alias = "v")]
+    /// (v) Display the current Todoist API token
+    View(View),
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -51,6 +55,28 @@ pub(super) async fn load_or_create_config(config_path: Option<PathBuf>) -> Resul
     }
 }
 
+/// Displays the current Todoist API token from the config.
+///
+/// Loads the existing config and outputs the stored token in plain text or JSON format.
+pub async fn view(config_path: Option<PathBuf>, json: bool) -> Result<String, Error> {
+    let config = crate::config::get_config(config_path).await?;
+
+    let token = config
+        .token
+        .as_ref()
+        .filter(|t| !t.trim().is_empty())
+        .ok_or_else(|| Error::new("auth view", "No auth present - run \"tod auth login\""))?;
+
+    if json {
+        Ok(serde_json::json!({"token": token}).to_string())
+    } else {
+        Ok(token.clone())
+    }
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct View {}
+
 /// Saves the given Todoist API token to the config without any interactive prompts.
 ///
 /// Creates the config file at `config_path` (or the platform default) if it does not yet exist,
@@ -78,6 +104,7 @@ pub async fn token(
 #[cfg(test)]
 mod tests {
     use super::load_or_create_config;
+    use super::view;
     use crate::config::Config;
     use tempfile::tempdir;
 
@@ -182,5 +209,98 @@ mod tests {
             "error should be from the non-NotFound IO conversion, got source: {}",
             err.source
         );
+    }
+
+    #[tokio::test]
+    async fn view_returns_token_for_valid_config() {
+        let dir = tempdir().expect("temp dir should be created");
+        let path = dir.path().join("tod.cfg");
+        let mut config = Config::new(None, path.clone())
+            .await
+            .expect("config should be created")
+            .with_token("my-api-token")
+            .with_timezone("UTC");
+        config
+            .touch_file()
+            .await
+            .expect("config file should be created");
+        config.save().await.expect("config should save");
+
+        let result = view(Some(path), false).await;
+        assert_eq!(result.expect("should return token"), "my-api-token");
+    }
+
+    #[tokio::test]
+    async fn view_returns_json_when_json_flag_set() {
+        let dir = tempdir().expect("temp dir should be created");
+        let path = dir.path().join("tod.cfg");
+        let mut config = Config::new(None, path.clone())
+            .await
+            .expect("config should be created")
+            .with_token("my-api-token")
+            .with_timezone("UTC");
+        config
+            .touch_file()
+            .await
+            .expect("config file should be created");
+        config.save().await.expect("config should save");
+
+        let result = view(Some(path), true).await;
+        assert_eq!(
+            result.expect("should return JSON"),
+            serde_json::json!({"token": "my-api-token"}).to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn view_errors_when_no_config_exists() {
+        let dir = tempdir().expect("temp dir should be created");
+        let path = dir.path().join("nonexistent.cfg");
+
+        let result = view(Some(path), false).await;
+        let err = result.expect_err("should error for missing config");
+        assert_eq!(err.source, "get_config");
+        assert!(err.message.contains("No config file found"));
+    }
+
+    #[tokio::test]
+    async fn view_errors_when_token_is_none() {
+        let dir = tempdir().expect("temp dir should be created");
+        let path = dir.path().join("tod.cfg");
+        let mut config = Config::new(None, path.clone())
+            .await
+            .expect("config should be created")
+            .with_timezone("UTC");
+        config
+            .touch_file()
+            .await
+            .expect("config file should be created");
+        config.save().await.expect("config should save");
+
+        let result = view(Some(path), false).await;
+        let err = result.expect_err("should error for missing token");
+        assert_eq!(err.source, "auth view");
+        assert!(err.message.contains("tod auth login"));
+    }
+
+    #[tokio::test]
+    async fn view_errors_when_token_is_whitespace() {
+        let dir = tempdir().expect("temp dir should be created");
+        let path = dir.path().join("tod.cfg");
+        let mut config = Config::new(None, path.clone())
+            .await
+            .expect("config should be created")
+            .with_token("   ")
+            .with_timezone("UTC");
+        config
+            .touch_file()
+            .await
+            .expect("config file should be created");
+        config.save().await.expect("config should save");
+
+        let result = view(Some(path), false).await;
+        let err = result.expect_err("should error for whitespace token");
+        assert_eq!(err.source, "auth view");
+        assert!(err.message.contains("tod auth login"));
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -384,6 +384,11 @@ async fn auth_command(command: &AuthCommands, cli: &Cli) -> Result<CommandResult
             let result = auth_commands::token(cli.config.clone(), args, cli.json).await;
             Ok(build_command_result_without_config(result, cli.json))
         }
+
+        AuthCommands::View(_args) => {
+            let result = auth_commands::view(cli.config.clone(), cli.json).await;
+            Ok(build_command_result_without_config(result, cli.json))
+        }
     }
 }
 


### PR DESCRIPTION
Closes #1761

Adds a \`tod auth view\` subcommand that outputs the stored Todoist API token, enabling users and AI agents to retrieve their token for direct API requests beyond tod's built-in coverage — similar to \`gh auth token\` in the GitHub CLI.

- Plain text output by default, JSON with \`-j\`/\`--json\`
- Errors with helpful guidance when no config or token exists
- Five tests covering text/JSON output and all error paths