### PR TITLE
feat: support parent_id for subtask creation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 - `docs/usage.md` — User-facing command examples; keep in sync with CLI changes
 
 ### Todoist API
-- `src/todoist/` — REST API client (`mod.rs`) and HTTP layer (`request.rs`)
+- `src/todoist/` — REST API client (`mod.rs`) and HTTP layer (`request.rs`). Base URL: `https://api.todoist.com` with `/api/v1/` prefix (see `TODOIST_URL` in `request.rs`).
 
 ### Business logic
 - `src/projects.rs` — `Project` struct, CRUD operations, task scheduling
@@ -27,6 +27,12 @@
 
 ### CLI dispatch
 - `src/commands/` — Dispatch via clap `Subcommand` enum (`mod.rs`) and command handlers for auth, config, list, project, reminder, section, shell, task, test
+
+## Pre-commit checklist
+
+- Run `cargo fmt` to format the codebase
+- Run `scripts/test.sh` to verify formatting, compilation, clippy, tests, and forbidden strings
+- Both must pass before committing
 
 ## GitHub conventions
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -104,6 +104,9 @@ tod task create
 # Create a task in a project
 tod task create --content "Write more rust" --project code
 
+# Create a subtask under an existing task
+tod task create --content "Add tests" --project code --parent-id 1234567890
+
 # Import your projects
 tod project import
 tod project import -p work # or --id 123

--- a/src/commands/task_commands.rs
+++ b/src/commands/task_commands.rs
@@ -380,6 +380,13 @@ mod tests {
     }
 
     #[test]
+    fn no_flags_used_returns_false_when_parent_id_is_set() {
+        let mut args = create_args();
+        args.parent_id = Some("123".to_string());
+        assert!(!no_flags_used(&args));
+    }
+
+    #[test]
     fn is_no_sections_respects_argument_flag() {
         let mut args = create_args();
         args.no_section = true;

--- a/src/commands/task_commands.rs
+++ b/src/commands/task_commands.rs
@@ -79,6 +79,10 @@ pub struct Create {
     #[arg(short, long)]
     /// List of labels to choose from, to be applied to each entry. Use flag once per label
     label: Vec<String>,
+
+    #[arg(long)]
+    /// Parent task ID to create this task as a subtask of
+    parent_id: Option<String>,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -214,6 +218,7 @@ pub async fn create(config: Config, args: &Create, json: bool) -> Result<String,
             &description,
             due.as_deref(),
             &labels,
+            args.parent_id.as_deref(),
         )
         .await?
     } else {
@@ -225,6 +230,7 @@ pub async fn create(config: Config, args: &Create, json: bool) -> Result<String,
             priority,
             label: labels,
             no_section: _no_section,
+            parent_id,
         } = args;
         let project = match super::fetch_project(project.as_deref(), &config).await? {
             Flag::Project(project) => project,
@@ -248,6 +254,7 @@ pub async fn create(config: Config, args: &Create, json: bool) -> Result<String,
             description,
             due.as_deref(),
             labels,
+            parent_id.as_deref(),
         )
         .await?
     };
@@ -267,6 +274,7 @@ fn no_flags_used(args: &Create) -> bool {
         no_section: _no_section,
         priority,
         label,
+        parent_id,
     } = args;
 
     project.is_none()
@@ -275,6 +283,7 @@ fn no_flags_used(args: &Create) -> bool {
         && content.is_none()
         && priority.is_none()
         && label.is_empty()
+        && parent_id.is_none()
 }
 
 /// Edits a task's attributes interactively. Blocks interactive prompts in JSON mode.
@@ -353,6 +362,7 @@ mod tests {
             no_section: false,
             priority: None,
             label: Vec::new(),
+            parent_id: None,
         }
     }
 

--- a/src/todoist/mod.rs
+++ b/src/todoist/mod.rs
@@ -69,6 +69,7 @@ pub async fn test_all_endpoints(config: &Config) -> Result<String, Error> {
         &name,
         None,
         &[],
+        None,
     )
     .await?;
 
@@ -187,6 +188,7 @@ pub async fn create_task(
     description: &str,
     due: Option<&str>,
     labels: &[String],
+    parent_id: Option<&str>,
 ) -> Result<Task, Error> {
     let project_id = project.id.clone();
     let url = TASKS_URL;
@@ -216,6 +218,10 @@ pub async fn create_task(
 
     if let Some(section) = section {
         body.insert("section_id".to_owned(), Value::String(section.id.clone()));
+    }
+
+    if let Some(parent_id) = parent_id {
+        body.insert("parent_id".to_owned(), Value::String(parent_id.to_owned()));
     }
 
     let body = json!(body);
@@ -896,7 +902,8 @@ mod tests {
                 priority,
                 "",
                 None,
-                &[]
+                &[],
+                None,
             )
             .await,
             Ok(test::fixtures::today_task().await)

--- a/src/todoist/mod.rs
+++ b/src/todoist/mod.rs
@@ -910,6 +910,92 @@ mod tests {
         );
         mock.assert();
     }
+
+    #[tokio::test]
+    async fn test_create_task_with_parent_id() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/api/v1/tasks/")
+            .match_body(mockito::Matcher::Regex(
+                r#""parent_id":"999""#.to_string(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(ResponseFromFile::TodayTask.read().await)
+            .create_async()
+            .await;
+
+        let config = test::fixtures::config()
+            .await
+            .with_mock_url(server.url())
+            .with_time_provider(TimeProviderEnum::Fixed(FixedTimeProvider));
+
+        let project = test::fixtures::project();
+        let priority = priority::Priority::None;
+
+        let result = create_task(
+            &config,
+            "Subtasks",
+            &project,
+            None,
+            priority,
+            "",
+            None,
+            &[],
+            Some("999"),
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "create_task with parent_id should succeed; got: {result:?}"
+        );
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_create_task_without_parent_id_omits_field() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/api/v1/tasks/")
+            .match_body(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::Regex(r#""content":"No parent task""#.to_string()),
+                mockito::Matcher::Regex(r#""project_id":"123""#.to_string()),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(ResponseFromFile::TodayTask.read().await)
+            .create_async()
+            .await;
+
+        let config = test::fixtures::config()
+            .await
+            .with_mock_url(server.url())
+            .with_time_provider(TimeProviderEnum::Fixed(FixedTimeProvider));
+
+        let project = test::fixtures::project();
+        let priority = priority::Priority::None;
+
+        let result = create_task(
+            &config,
+            "No parent task",
+            &project,
+            None,
+            priority,
+            "",
+            None,
+            &[],
+            None,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "create_task without parent_id should succeed; got: {result:?}"
+        );
+        mock.assert();
+    }
+
     #[tokio::test]
     async fn test_create_section() {
         let mut server = mockito::Server::new_async().await;

--- a/src/todoist/mod.rs
+++ b/src/todoist/mod.rs
@@ -916,9 +916,7 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         let mock = server
             .mock("POST", "/api/v1/tasks/")
-            .match_body(mockito::Matcher::Regex(
-                r#""parent_id":"999""#.to_string(),
-            ))
+            .match_body(mockito::Matcher::Regex(r#""parent_id":"999""#.to_string()))
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(ResponseFromFile::TodayTask.read().await)


### PR DESCRIPTION
Add optional \`--parent-id\` flag to \`tod task create\` that passes \`parent_id\` to the Todoist API, making the new task a subtask of the specified parent.

Closes #1769