### PR TITLE
test: add tests to catch missed cargo-mutants mutants

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -848,12 +848,17 @@ mod tests {
     #[tokio::test]
     async fn set_and_clear_next_task_should_work() {
         let config = test::fixtures::config().await;
+        let original_token = config.token.clone();
         assert_eq!(config.next_task, None);
         let task = test::fixtures::today_task().await;
         let config = config.set_next_task(task.clone());
         assert_eq!(config.next_task, Some(task));
         let config = config.clear_next_task();
         assert_eq!(config.next_task, None);
+        assert_eq!(
+            config.token, original_token,
+            "other fields must be preserved"
+        );
     }
 
     #[tokio::test]
@@ -1154,5 +1159,60 @@ mod tests {
                 .expect("Could not check if file exists"),
             "Config file should exist after edit_interactive"
         );
+    }
+
+    #[test]
+    fn bell_on_failure_default_returns_true() {
+        assert!(bell_on_failure_default());
+    }
+
+    #[test]
+    fn token_message_contains_url_and_prompt() {
+        let config = Config::default_test();
+        let message = config.token_message();
+        assert!(!message.is_empty());
+        assert!(message.contains("API token"));
+    }
+
+    #[tokio::test]
+    async fn increment_completed_increments_count_for_same_day() {
+        let config = crate::test::fixtures::config()
+            .await
+            .with_timezone("America/Vancouver");
+        // Set up an existing completed count for today
+        let today = time::naive_date_today(&config).expect("should get today");
+        let config = Config {
+            completed: Some(Completed {
+                date: today.to_string(),
+                count: 5,
+            }),
+            ..config
+        };
+        let updated = config
+            .increment_completed()
+            .expect("should increment completed");
+        let completed = updated.completed.expect("should have completed");
+        assert_eq!(completed.count, 6);
+        assert_eq!(completed.date, today.to_string());
+    }
+
+    #[tokio::test]
+    async fn increment_completed_starts_new_count_for_different_day() {
+        let config = crate::test::fixtures::config()
+            .await
+            .with_timezone("America/Vancouver");
+        let config = Config {
+            completed: Some(Completed {
+                date: "2000-01-01".to_string(),
+                count: 5,
+            }),
+            ..config
+        };
+        let updated = config
+            .increment_completed()
+            .expect("should increment completed");
+        let completed = updated.completed.expect("should have completed");
+        // Should reset count to 1 for the new day
+        assert_eq!(completed.count, 1);
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -404,4 +404,34 @@ mod tests {
         let result = bool("test", false, Some(1));
         assert_eq!(result, Ok(false));
     }
+
+    #[test]
+    fn datetime_no_natural_language_without_skip_complete_uses_else_branch() {
+        // no_natural_language=true, skip_or_complete=false
+        // Must not match no_natural_language && skip_or_complete.
+        // Goes to else branch with options: [SELECT_DATE(0), NAT_LANG(1), NO_DATE(2)]
+        let result = datetime(Some(2), None, None, true, false);
+        assert_eq!(result, Ok(DateTimeInput::None));
+    }
+
+    #[test]
+    #[should_panic(expected = "Must provide a vector of options")]
+    fn datetime_no_nat_lang_no_skip_complete_extra_index_panics() {
+        // no_natural_language=false, skip_or_complete=false
+        // Original (&&): !false && false = false → else (3 options) → mock_select=3 panics
+        // Mutant  (||): !false || false = true  → branch (5 options) → mock_select=3 → SKIP
+        let _ = datetime(Some(3), None, None, false, false);
+    }
+
+    #[test]
+    fn string_with_default_returns_default_message() {
+        let result = string_with_default("Test prompt", "default value");
+        assert_eq!(result, Ok("default value".to_string()));
+    }
+
+    #[test]
+    fn number_with_default_returns_default_number() {
+        let result = number_with_default("Test prompt", 42);
+        assert_eq!(result, Ok(42));
+    }
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -67,28 +67,32 @@ fn shell_command(command: &str) -> Command {
 }
 
 pub(crate) fn generate_completions(shell: Shell) {
+    generate_completions_to_writer(shell, &mut io::stdout());
+}
+
+fn generate_completions_to_writer(shell: Shell, writer: &mut dyn io::Write) {
     let mut cli = Cli::command();
 
     match shell {
         Shell::Bash => {
             let shell = clap_complete::shells::Bash;
-            clap_complete::generate(shell, &mut cli, LOWERCASE_NAME, &mut io::stdout());
+            clap_complete::generate(shell, &mut cli, LOWERCASE_NAME, writer);
         }
         Shell::Fish => {
             let shell = clap_complete::shells::Fish;
-            clap_complete::generate(shell, &mut cli, LOWERCASE_NAME, &mut io::stdout());
+            clap_complete::generate(shell, &mut cli, LOWERCASE_NAME, writer);
         }
         Shell::Zsh => {
             let shell = clap_complete::shells::Zsh;
-            clap_complete::generate(shell, &mut cli, LOWERCASE_NAME, &mut io::stdout());
+            clap_complete::generate(shell, &mut cli, LOWERCASE_NAME, writer);
         }
         Shell::PowerShell => {
             let shell = clap_complete::shells::PowerShell;
-            clap_complete::generate(shell, &mut cli, LOWERCASE_NAME, &mut io::stdout());
+            clap_complete::generate(shell, &mut cli, LOWERCASE_NAME, writer);
         }
         Shell::Elvish => {
             let shell = clap_complete::shells::Elvish;
-            clap_complete::generate(shell, &mut cli, LOWERCASE_NAME, &mut io::stdout());
+            clap_complete::generate(shell, &mut cli, LOWERCASE_NAME, writer);
         }
     }
 }
@@ -232,5 +236,53 @@ mod tests {
         cmd.assert()
             .failure()
             .stderr(contains("No such").or(contains("cannot find")));
+    }
+
+    #[test]
+    fn test_generate_completions_bash_produces_output() {
+        let mut buf = Vec::new();
+        generate_completions_to_writer(Shell::Bash, &mut buf);
+        let output = String::from_utf8(buf).expect("completions output should be valid UTF-8");
+        assert!(!output.is_empty());
+        assert!(output.contains(LOWERCASE_NAME));
+    }
+
+    #[test]
+    fn test_generate_completions_fish_produces_output() {
+        let mut buf = Vec::new();
+        generate_completions_to_writer(Shell::Fish, &mut buf);
+        let output = String::from_utf8(buf).expect("completions output should be valid UTF-8");
+        assert!(!output.is_empty());
+        assert!(output.contains(LOWERCASE_NAME));
+    }
+
+    #[test]
+    fn test_generate_completions_zsh_produces_output() {
+        let mut buf = Vec::new();
+        generate_completions_to_writer(Shell::Zsh, &mut buf);
+        let output = String::from_utf8(buf).expect("completions output should be valid UTF-8");
+        assert!(!output.is_empty());
+        assert!(output.contains(LOWERCASE_NAME));
+    }
+
+    // Uses gag::BufferRedirect which replaces the process-wide stdout fd.
+    // These cannot run in parallel — cargo nextest runs each in its own process.
+    #[test]
+    fn test_generate_completions_writes_to_stdout() {
+        use std::io::Read;
+        let mut buf = gag::BufferRedirect::stdout().expect("should buffer stdout");
+        generate_completions(Shell::Bash);
+        let mut output = String::new();
+        buf.read_to_string(&mut output)
+            .expect("output should be readable");
+        drop(buf);
+        assert!(
+            !output.is_empty(),
+            "generate_completions must write to stdout"
+        );
+        assert!(
+            output.contains(LOWERCASE_NAME),
+            "output must contain binary name"
+        );
     }
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -310,6 +310,15 @@ mod tests {
         assert_eq!(today, expected);
     }
 
+    #[test]
+    fn trait_default_now_string_is_used() {
+        let provider = SystemTimeProvider;
+        let tz: Tz = "UTC".parse().expect("failed to parse timezone 'UTC'");
+        let result = provider.now_string(tz);
+        assert!(!result.is_empty(), "now_string must not be empty");
+        assert!(result.contains('T'), "now_string must be RFC3339 format");
+    }
+
     #[tokio::test]
     async fn errors_when_no_timezone() {
         let path = config::generate_path()

--- a/src/update.rs
+++ b/src/update.rs
@@ -308,6 +308,30 @@ mod tests {
             InstallMethod::Unknown
         );
     }
+
+    #[test]
+    fn test_detect_install_method_from_components_debug_without_target() {
+        let components: Vec<String> = ["usr", "local", "bin", "tod"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(
+            detect_install_method_from_components(&components, true),
+            InstallMethod::FromSource
+        );
+    }
+
+    #[test]
+    fn test_detect_install_method_from_components_release_with_target() {
+        let components: Vec<String> = ["home", "user", "target", "release", "tod"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(
+            detect_install_method_from_components(&components, false),
+            InstallMethod::FromSource
+        );
+    }
     #[test]
     fn test_get_install_method_override_whitespace_case() {
         assert_eq!(get_install_method(Some("  CaRgO  ")), InstallMethod::Cargo);


### PR DESCRIPTION
## Summary

Add targeted unit tests across 5 files to eliminate ~15 missed mutation testing mutants found by \`cargo-mutants\`.

## Changes

### \`src/time.rs\`
- Add \`trait_default_now_string_is_used\` test for \`SystemTimeProvider::now_string\` default trait impl

### \`src/update.rs\`
- Add \`test_detect_install_method_from_components_debug_without_target\` — tests \`is_debug=true\` path without "target" in path
- Add \`test_detect_install_method_from_components_release_with_target\` — tests \`is_debug=false\` path with "target" in path

### \`src/input.rs\`
- Add \`datetime_no_nat_lang_no_skip_complete_extra_index_panics\` — catches \`&&\` → \`||\` mutation
- Add \`string_with_default_returns_default_message\` — tests \`string_with_default\` mock path
- Add \`number_with_default_returns_default_number\` — tests \`number_with_default\` mock path

### \`src/config/mod.rs\`
- Add \`bell_on_failure_default_returns_true\` test
- Add \`token_message_contains_url_and_prompt\` test
- Add \`increment_completed_increments_count_for_same_day\` and \`increment_completed_starts_new_count_for_different_day\` tests
- Strengthen \`set_and_clear_next_task_should_work\` to assert token preservation after clear

### \`src/shell.rs\`
- Refactor \`generate_completions\` to delegate to \`generate_completions_to_writer\`
- Add tests for Bash, Fish, Zsh completions via writer
- Add stdout-capture test via \`gag::BufferRedirect\`

## Legitimate skips

Several mutants were intentionally not addressed:
- **\`format.rs\`**: \`hyperlinks_disabled\` — terminal-dependent \`supports_hyperlinks::on()\` check, tests self-skip in CI
- **\`input.rs\`**: \`date()\`, \`confirm()\`, \`SELECT_DATE\` — require \`inquire\` mock infrastructure
- **\`input.rs\`**: \`!\` in \`bool\` — \`cursor_index\` not verifiable without mock refactor

## Verification

- \`./scripts/test.sh\` — 472 tests pass, 0 failures
- \`cargo-mutants\` re-runs confirm missed mutants now caught