### PR TITLE
test: add proptest serde roundtrip tests for Task, Project, and Label

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,6 +1559,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,6 +1714,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1921,6 +1970,18 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -2443,6 +2504,7 @@ dependencies = [
  "pad",
  "predicates",
  "pretty_assertions",
+ "proptest",
  "rand 0.10.2",
  "rayon",
  "regex",
@@ -2586,6 +2648,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ mockito = "1.7.2"
 gag = "1.0.0"
 predicates = "3.1.4"
 pretty_assertions = "1.4.1"
+proptest = "1.5"
 serde_test = "1.0.177"
 
 [build-dependencies]

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -75,4 +75,55 @@ mod tests {
         let result = LabelResponse::from_json("not json");
         assert!(result.is_err());
     }
+
+    mod proptests {
+        use super::*;
+        use pretty_assertions::assert_eq;
+        use proptest::prelude::*;
+
+        fn arb_label() -> impl Strategy<Value = Label> {
+            (
+                "[0-9a-f]{5,20}",
+                "[A-Za-z0-9 _-]{1,30}",
+                "[a-z]{3,10}",
+                proptest::option::of(0u32..100),
+                proptest::bool::ANY,
+            )
+                .prop_map(|(id, name, color, order, is_favorite)| Label {
+                    id,
+                    name,
+                    color,
+                    order,
+                    is_favorite,
+                })
+        }
+
+        proptest! {
+            #[test]
+            fn label_serde_roundtrip(label in arb_label()) {
+                let json = serde_json::to_string(&label).unwrap();
+                let roundtripped: Label = serde_json::from_str(&json).unwrap();
+                assert_eq!(label, roundtripped);
+            }
+
+            #[test]
+            fn label_response_deserialize_from_labels(
+                labels in proptest::collection::vec(arb_label(), 0..10),
+                next_cursor in proptest::option::of("[a-zA-Z0-9]{5,20}"),
+            ) {
+                let results_json = serde_json::to_string(&labels).unwrap();
+                let cursor_json = match &next_cursor {
+                    Some(c) => format!("\"{}\"", c),
+                    None => "null".to_string(),
+                };
+                let json = format!(
+                    "{{\"results\":{},\"next_cursor\":{}}}",
+                    results_json, cursor_json
+                );
+                let response = LabelResponse::from_json(&json).unwrap();
+                assert_eq!(response.results, labels);
+                assert_eq!(response.next_cursor, next_cursor);
+            }
+        }
+    }
 }

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -1700,4 +1700,104 @@ mod tests {
         assert!(displayed.contains("https://app.todoist.com/app/project"));
         assert!(displayed.contains(&project.id));
     }
+
+    mod proptests {
+        use super::*;
+        use pretty_assertions::assert_eq;
+        use proptest::prelude::*;
+
+        fn arb_project() -> impl Strategy<Value = Project> {
+            // Split into two smaller tuples to stay under proptest's 10-element limit.
+            let base = (
+                "[0-9]{5,15}",
+                proptest::bool::ANY,
+                -100i32..1000i32,
+                "[a-z]{3,10}",
+                proptest::option::of("[0-9T:+-]{10,25}"),
+                proptest::bool::ANY,
+                proptest::bool::ANY,
+                proptest::bool::ANY,
+                proptest::bool::ANY,
+            );
+            let rest = (
+                "[A-Za-z0-9 _-]{1,40}",
+                proptest::option::of("[0-9T:+-]{10,25}"),
+                "(list|board)",
+                -100i32..1000i32,
+                "\\PC{0,50}",
+                proptest::option::of("[0-9]{5,15}"),
+                proptest::option::of(proptest::bool::ANY),
+                proptest::bool::ANY,
+                proptest::bool::ANY,
+            );
+            (base, rest).prop_map(
+                |(
+                    (
+                        id,
+                        can_assign_tasks,
+                        child_order,
+                        color,
+                        created_at,
+                        is_archived,
+                        is_deleted,
+                        is_favorite,
+                        is_frozen,
+                    ),
+                    (
+                        name,
+                        updated_at,
+                        view_style,
+                        default_order,
+                        description,
+                        parent_id,
+                        inbox_project,
+                        is_collapsed,
+                        is_shared,
+                    ),
+                )| Project {
+                    id,
+                    can_assign_tasks,
+                    child_order,
+                    color,
+                    created_at,
+                    is_archived,
+                    is_deleted,
+                    is_favorite,
+                    is_frozen,
+                    name,
+                    updated_at,
+                    view_style,
+                    default_order,
+                    description,
+                    parent_id,
+                    inbox_project,
+                    is_collapsed,
+                    is_shared,
+                },
+            )
+        }
+
+        proptest! {
+            #[test]
+            fn project_serde_roundtrip(project in arb_project()) {
+                let json = serde_json::to_string(&project).unwrap();
+                let roundtripped: Project = serde_json::from_str(&json).unwrap();
+                assert_eq!(project, roundtripped);
+            }
+
+            #[test]
+            fn project_response_serde_roundtrip(
+                projects in proptest::collection::vec(arb_project(), 0..10),
+                next_cursor in proptest::option::of("[a-zA-Z0-9]{5,20}"),
+            ) {
+                let response = ProjectResponse {
+                    results: projects.clone(),
+                    next_cursor: next_cursor.clone(),
+                };
+                let json = serde_json::to_string(&response).unwrap();
+                let roundtripped: ProjectResponse = serde_json::from_str(&json).unwrap();
+                assert_eq!(response, roundtripped);
+            }
+        }
+    }
 }

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -2178,4 +2178,198 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].id, orphan.id);
     }
+
+    mod proptests {
+        use super::*;
+        use pretty_assertions::assert_eq;
+        use proptest::prelude::*;
+
+        // ── sub-type strategies ────────────────────────────────────
+
+        fn arb_unit() -> impl Strategy<Value = Unit> {
+            prop_oneof![Just(Unit::Minute), Just(Unit::Day)]
+        }
+
+        fn arb_duration() -> impl Strategy<Value = Duration> {
+            (0u32..1000, arb_unit()).prop_map(|(amount, unit)| Duration { amount, unit })
+        }
+
+        fn arb_deadline() -> impl Strategy<Value = Deadline> {
+            ("[0-9]{4}-[0-9]{2}-[0-9]{2}", "[a-z]{2,5}")
+                .prop_map(|(date, lang)| Deadline { date, lang })
+        }
+
+        fn arb_date_info() -> impl Strategy<Value = DateInfo> {
+            (
+                "[0-9T:+-]{10,25}",
+                proptest::bool::ANY,
+                "\\PC{1,30}",
+                "[a-z]{2,5}",
+                proptest::option::of("[A-Za-z_/]{3,20}"),
+            )
+                .prop_map(|(date, is_recurring, string, lang, timezone)| DateInfo {
+                    date,
+                    is_recurring,
+                    string,
+                    lang,
+                    timezone,
+                })
+        }
+
+        fn arb_priority() -> impl Strategy<Value = Priority> {
+            prop_oneof![
+                Just(Priority::None),
+                Just(Priority::Low),
+                Just(Priority::Medium),
+                Just(Priority::High),
+            ]
+        }
+
+        // ── Task strategy (split across three tuples to stay under 10-element cap) ──
+
+        fn arb_task() -> impl Strategy<Value = Task> {
+            let g1 = (
+                "[0-9a-f]{5,20}",
+                "[0-9]{3,10}",
+                "[0-9]{5,15}",
+                proptest::option::of("[0-9]{5,15}"),
+                proptest::option::of("[0-9]{5,15}"),
+                proptest::option::of("[0-9]{3,10}"),
+                proptest::option::of("[0-9]{3,10}"),
+                proptest::option::of("[0-9]{3,10}"),
+                proptest::collection::vec("[a-z_]{2,15}", 0..5),
+            );
+            let g2 = (
+                proptest::option::of(arb_deadline()),
+                proptest::option::of(arb_duration()),
+                proptest::option::of(arb_date_info()),
+                proptest::bool::ANY,
+                proptest::bool::ANY,
+                proptest::bool::ANY,
+                proptest::option::of("[0-9T:+-]{10,25}"),
+                proptest::option::of("[0-9T:+-]{10,25}"),
+                proptest::option::of("[0-9T:+-]{10,25}"),
+            );
+            let g3 = (
+                arb_priority(),
+                -100i16..1000i16,
+                "\\PC{0,60}",
+                "\\PC{0,100}",
+                0u32..100u32,
+                -100i16..1000i16,
+            );
+            (g1, g2, g3).prop_map(
+                |(
+                    (
+                        id,
+                        user_id,
+                        project_id,
+                        section_id,
+                        parent_id,
+                        added_by_uid,
+                        assigned_by_uid,
+                        responsible_uid,
+                        labels,
+                    ),
+                    (
+                        deadline,
+                        duration,
+                        due,
+                        checked,
+                        is_deleted,
+                        is_collapsed,
+                        added_at,
+                        completed_at,
+                        updated_at,
+                    ),
+                    (priority, child_order, content, description, note_count, day_order),
+                )| Task {
+                    id,
+                    user_id,
+                    project_id,
+                    section_id,
+                    parent_id,
+                    added_by_uid,
+                    assigned_by_uid,
+                    responsible_uid,
+                    labels,
+                    deadline,
+                    duration,
+                    due,
+                    checked,
+                    is_deleted,
+                    is_collapsed,
+                    added_at,
+                    completed_at,
+                    updated_at,
+                    priority,
+                    child_order,
+                    content,
+                    description,
+                    note_count,
+                    day_order,
+                },
+            )
+        }
+
+        // ── properties ─────────────────────────────────────────────
+
+        proptest! {
+            #[test]
+            fn priority_serde_roundtrip(priority in arb_priority()) {
+                let json = serde_json::to_string(&priority).unwrap();
+                let roundtripped: Priority = serde_json::from_str(&json).unwrap();
+                assert_eq!(priority, roundtripped);
+            }
+
+            #[test]
+            fn unit_serde_roundtrip(unit in arb_unit()) {
+                let json = serde_json::to_string(&unit).unwrap();
+                let roundtripped: Unit = serde_json::from_str(&json).unwrap();
+                assert_eq!(unit, roundtripped);
+            }
+
+            #[test]
+            fn duration_serde_roundtrip(dur in arb_duration()) {
+                let json = serde_json::to_string(&dur).unwrap();
+                let roundtripped: Duration = serde_json::from_str(&json).unwrap();
+                assert_eq!(dur, roundtripped);
+            }
+
+            #[test]
+            fn deadline_serde_roundtrip(deadline in arb_deadline()) {
+                let json = serde_json::to_string(&deadline).unwrap();
+                let roundtripped: Deadline = serde_json::from_str(&json).unwrap();
+                assert_eq!(deadline, roundtripped);
+            }
+
+            #[test]
+            fn date_info_serde_roundtrip(di in arb_date_info()) {
+                let json = serde_json::to_string(&di).unwrap();
+                let roundtripped: DateInfo = serde_json::from_str(&json).unwrap();
+                assert_eq!(di, roundtripped);
+            }
+
+            #[test]
+            fn task_serde_roundtrip(task in arb_task()) {
+                let json = serde_json::to_string(&task).unwrap();
+                let roundtripped: Task = serde_json::from_str(&json).unwrap();
+                assert_eq!(task, roundtripped);
+            }
+
+            #[test]
+            fn task_response_serde_roundtrip(
+                tasks in proptest::collection::vec(arb_task(), 0..10),
+                next_cursor in proptest::option::of("[a-zA-Z0-9]{5,20}"),
+            ) {
+                let response = TaskResponse {
+                    results: tasks,
+                    next_cursor,
+                };
+                let json = serde_json::to_string(&response).unwrap();
+                let roundtripped: TaskResponse = serde_json::from_str(&json).unwrap();
+                assert_eq!(response, roundtripped);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Adds property-based serde roundtrip tests using [proptest](https://docs.rs/proptest) for the core JSON-backed types.

## Changes

- **\`Cargo.toml\`** — add \`proptest = "1.5"\` to dev-dependencies
- **\`src/labels.rs\`** — \`Label\` roundtrip + \`LabelResponse\` deserialization
- **\`src/projects.rs\`** — \`Project\` roundtrip + \`ProjectResponse\` roundtrip
- **\`src/tasks/mod.rs\`** — \`Priority\`, \`Unit\`, \`Duration\`, \`Deadline\`, \`DateInfo\`, \`Task\`, and \`TaskResponse\` roundtrips

## Design decisions

- Strategies for large structs (\`Task\` has 24 fields, \`Project\` has 18) are split across multiple sub-tuples since proptest's \`Strategy\` trait caps at 10-element tuples
- Each proptest module uses \`use pretty_assertions::assert_eq\` to avoid ambiguity with \`proptest::prelude::*\`
- All 11 new tests run in ~1 second; filterable with \`cargo test proptests\`