### PR TITLE
design: label CRUD research questions for #1768

### DIFF
--- a/.pi/qrspi/TOD-1768-label-crud/design.md
+++ b/.pi/qrspi/TOD-1768-label-crud/design.md
@@ -1,0 +1,648 @@
+# Design: Label CRUD (create, update, delete labels)
+
+## Overview
+
+Add `tod label create`, `tod label update`, and `tod label delete` CLI commands, backed by API functions in `src/todoist/mod.rs` and business-logic wrappers in `src/labels.rs`. The existing `all_labels` GET endpoint and `Label` struct already exist — this adds the mutation side.
+
+## Files to change
+
+| File | Type | What |
+|------|------|------|
+| `src/labels.rs` | Modify | Add `Label::from_json()`, `create()`, `update()`, `delete()` |
+| `src/todoist/mod.rs` | Modify | Add `create_label()`, `update_label()`, `delete_label()` |
+| `src/commands/label_commands.rs` | **New** | CLI arg structs, handler functions, tests |
+| `src/commands/mod.rs` | Modify | Register `LabelCommands`, dispatch, handler |
+| `docs/usage.md` | Modify | Add label command examples |
+
+`tests/responses/Label.json` and `src/test/fixtures.rs::label()` already exist — no new fixtures needed.
+
+## 1. `src/labels.rs` — business logic layer
+
+### 1.1 Add `Label::from_json()`
+
+Follow the pattern in `src/projects.rs:92` / `src/sections.rs` (exact line TBD). The struct already derives `Deserialize`, so the method is a one-liner:
+
+```rust
+impl Label {
+    pub fn from_json(json: &str) -> Result<Label, Error> {
+        let label: Label = serde_json::from_str(json)?;
+        Ok(label)
+    }
+}
+```
+
+Place after the existing `impl LabelResponse` block and before `impl Display for Label`.
+
+### 1.2 Add business-logic functions
+
+After the existing `get_labels()` function at line 33:
+
+```rust
+pub async fn create(
+    config: &Config,
+    name: &str,
+    color: Option<&str>,
+    order: Option<u32>,
+    is_favorite: bool,
+) -> Result<Label, Error> {
+    todoist::create_label(config, name, color, order, is_favorite, true).await
+}
+
+pub async fn update(
+    config: &Config,
+    label_id: &str,
+    name: Option<&str>,
+    color: Option<&str>,
+    order: Option<u32>,
+    is_favorite: Option<bool>,
+) -> Result<Label, Error> {
+    todoist::update_label(config, label_id, name, color, order, is_favorite, true).await
+}
+
+pub async fn delete(config: &Config, label_id: &str) -> Result<String, Error> {
+    todoist::delete_label(config, label_id, true).await
+}
+```
+
+These are thin wrappers that always pass `spinner: true`, matching the pattern of `get_labels()` and `projects::create()`.
+
+### 1.3 Add unit tests for `from_json`
+
+Add to the existing `mod tests` block:
+
+```rust
+#[test]
+fn test_label_from_json_valid() {
+    let json = r#"{"id":"1","name":"work","color":"red","order":1,"is_favorite":false}"#;
+    let label = Label::from_json(json).expect("should parse label");
+    assert_eq!(label.id, "1");
+    assert_eq!(label.name, "work");
+    assert_eq!(label.color, "red");
+    assert_eq!(label.order, Some(1));
+    assert!(!label.is_favorite);
+}
+
+#[test]
+fn test_label_from_json_invalid() {
+    let result = Label::from_json("not json");
+    assert!(result.is_err());
+}
+```
+
+## 2. `src/todoist/mod.rs` — API layer
+
+### 2.1 `create_label()`
+
+Place after `all_labels()` (after line ~463) and before `move_task_to_project`.
+
+```rust
+/// Create a personal label.
+pub async fn create_label(
+    config: &Config,
+    name: &str,
+    color: Option<&str>,
+    order: Option<u32>,
+    is_favorite: bool,
+    spinner: bool,
+) -> Result<Label, Error> {
+    let mut body = json!({"name": name, "is_favorite": is_favorite});
+    if let Some(c) = color {
+        body["color"] = json!(c);
+    }
+    if let Some(o) = order {
+        body["order"] = json!(o);
+    }
+
+    let response = request::post_todoist(config, LABELS_URL, body, spinner).await?;
+    Label::from_json(&response)
+}
+```
+
+**Design decisions:**
+- `name` is required (API requires it), `color`, `order`, `is_favorite` are optional
+- Only include optional fields in the body when `Some` — avoids sending `null` for unset values
+- URL constant: `LABELS_URL` already exists at line 42 (`"/api/v1/labels"`)
+- Returns `Label` (single object, not paginated — the Todoist API returns the created label inline)
+- Uses `post_todoist` (POST), matching the Todoist REST API
+
+### 2.2 `update_label()`
+
+```rust
+/// Update a personal label by ID.
+pub async fn update_label(
+    config: &Config,
+    label_id: &str,
+    name: Option<&str>,
+    color: Option<&str>,
+    order: Option<u32>,
+    is_favorite: Option<bool>,
+    spinner: bool,
+) -> Result<Label, Error> {
+    let mut body = json!({});
+    if let Some(n) = name {
+        body["name"] = json!(n);
+    }
+    if let Some(c) = color {
+        body["color"] = json!(c);
+    }
+    if let Some(o) = order {
+        body["order"] = json!(o);
+    }
+    if let Some(f) = is_favorite {
+        body["is_favorite"] = json!(f);
+    }
+
+    let url = format!("{}/{}", LABELS_URL, label_id);
+    let response = request::post_todoist(config, &url, body, spinner).await?;
+    Label::from_json(&response)
+}
+```
+
+**Design decisions:**
+- All fields optional — user can update just one field
+- URL format `{LABELS_URL}/{id}` — same pattern as `delete_project` uses `{PROJECTS_URL}/{id}`
+- Uses POST (Todoist REST API uses POST for mutations, not PUT/PATCH)
+- Returns `Label` — API returns the updated label object
+
+### 2.3 `delete_label()`
+
+```rust
+/// Delete a personal label by ID.
+pub async fn delete_label(
+    config: &Config,
+    label_id: &str,
+    spinner: bool,
+) -> Result<String, Error> {
+    let url = format!("{}/{}", LABELS_URL, label_id);
+    request::delete_todoist(config, &url, json!({}), spinner).await?;
+    Ok("✓".into())
+}
+```
+
+**Design decisions:**
+- URL format `{LABELS_URL}/{id}`
+- Passes `json!({})` as body (empty object) — consistent with `delete_project` and `delete_section` callers
+- Ignores response body (204 No Content from API; `handle_response` returns `""`)
+- Returns `Ok("✓".into())` — matching `delete_project`, `delete_section`, `archive_project`
+
+### 2.4 API tests
+
+Add to the tests module in `src/todoist/mod.rs` (find the section tests and add after them):
+
+```rust
+#[tokio::test]
+async fn test_create_label() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/api/v1/labels")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(ResponseFromFile::Label.read().await)
+        .create_async()
+        .await;
+
+    let config = test::fixtures::config().await.with_mock_url(server.url());
+
+    let result = create_label(&config, "test-label", Some("red"), None, false, false).await;
+    assert_eq!(result, Ok(test::fixtures::label()));
+    mock.assert();
+}
+
+#[tokio::test]
+async fn test_update_label() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/api/v1/labels/123")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(ResponseFromFile::Label.read().await)
+        .create_async()
+        .await;
+
+    let config = test::fixtures::config().await.with_mock_url(server.url());
+
+    let result =
+        update_label(&config, "123", Some("new-name"), Some("blue"), None, None, false).await;
+    assert_eq!(result, Ok(test::fixtures::label()));
+    mock.assert();
+}
+
+#[tokio::test]
+async fn test_delete_label() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("DELETE", "/api/v1/labels/123")
+        .with_status(204)
+        .create_async()
+        .await;
+
+    let config = test::fixtures::config().await.with_mock_url(server.url());
+
+    let result = delete_label(&config, "123", false).await;
+    assert_eq!(result, Ok("✓".into()));
+    mock.assert();
+}
+```
+
+Note: `ResponseFromFile::Label` currently has `#[allow(dead_code)]` at `src/test/responses.rs:27-28`. Remove that attribute when the test file uses it.
+
+## 3. `src/commands/label_commands.rs` — CLI layer (new file)
+
+### 3.1 Subcommand enum and arg structs
+
+```rust
+use crate::{config::Config, errors::Error, format, input, labels};
+use clap::{Parser, Subcommand};
+
+/// Label subcommands.
+#[derive(Subcommand, Debug, Clone)]
+pub enum LabelCommands {
+    #[clap(alias = "c")]
+    /// (c) Create a new personal label
+    Create(Create),
+    #[clap(alias = "u")]
+    /// (u) Update an existing personal label
+    Update(Update),
+    #[clap(alias = "d")]
+    /// (d) Delete a personal label
+    Delete(Delete),
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct Create {
+    #[arg(short, long)]
+    /// Label name
+    name: Option<String>,
+
+    #[arg(short, long)]
+    /// Color for the label (e.g. "red", "blue", "green")
+    color: Option<String>,
+
+    #[arg(short, long)]
+    /// Display order (1-based)
+    order: Option<u32>,
+
+    #[arg(short = 'f', long, default_value_t = false)]
+    /// Mark label as a favorite
+    is_favorite: bool,
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct Update {
+    #[arg(short, long)]
+    /// Label to update (name or ID)
+    label: Option<String>,
+
+    #[arg(short, long)]
+    /// New name for the label
+    name: Option<String>,
+
+    #[arg(short, long)]
+    /// New color for the label
+    color: Option<String>,
+
+    #[arg(short, long)]
+    /// New display order
+    order: Option<u32>,
+
+    #[arg(short = 'f', long)]
+    /// Toggle favorite status (true or false)
+    favorite: Option<bool>,
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct Delete {
+    #[arg(short, long)]
+    /// Label to delete (name or ID)
+    label: Option<String>,
+
+    #[arg(short = 'f', long, default_value_t = false)]
+    /// Skip deletion confirmation
+    force: bool,
+}
+```
+
+### 3.2 Handler functions
+
+```rust
+/// Creates a personal label.
+pub async fn create(config: &Config, args: &Create, json: bool) -> Result<String, Error> {
+    let Create {
+        name,
+        color,
+        order,
+        is_favorite,
+    } = args;
+    let name = super::fetch_string(name.as_deref(), config, input::NAME)?;
+
+    let label = labels::create(config, &name, color.as_deref(), *order, *is_favorite).await?;
+    if json {
+        Ok(serde_json::to_string(&label)?)
+    } else {
+        Ok(format::green_string(&format!(
+            "Label \"{}\" created",
+            label.name
+        )))
+    }
+}
+
+/// Updates a personal label.
+pub async fn update(config: &Config, args: &Update, json: bool) -> Result<String, Error> {
+    let Update {
+        label,
+        name,
+        color,
+        order,
+        favorite,
+    } = args;
+
+    // Fetch all labels and resolve the target by name or ID
+    let labels_list = labels::get_labels(config, true).await?;
+    let target = super::fetch_label(label.as_deref(), config, &labels_list)?;
+
+    // Require at least one field to update
+    if name.is_none() && color.is_none() && order.is_none() && favorite.is_none() {
+        return Err(Error::new(
+            "update_label",
+            "At least one of --name, --color, --order, or --favorite is required",
+        ));
+    }
+
+    let updated =
+        labels::update(config, &target.id, name.as_deref(), color.as_deref(), *order, *favorite)
+            .await?;
+    if json {
+        Ok(serde_json::to_string(&updated)?)
+    } else {
+        Ok(format::green_string(&format!(
+            "Label \"{}\" updated",
+            updated.name
+        )))
+    }
+}
+
+/// Deletes a personal label.
+pub async fn delete(config: &Config, args: &Delete, json: bool) -> Result<String, Error> {
+    let Delete { label, force } = args;
+
+    let labels_list = labels::get_labels(config, true).await?;
+    if labels_list.is_empty() {
+        return Ok("No labels found".into());
+    }
+
+    let target = super::fetch_label(label.as_deref(), config, &labels_list)?;
+
+    if !force {
+        if json {
+            return Err(Error::new("json_mode", super::JSON_INTERACTIVE_ERROR));
+        }
+        let options = vec![input::CANCEL, input::DELETE];
+        let desc = format!("Delete label \"{}\"?", target.name);
+        let result = input::select(&desc, options, config.mock_select)?;
+        if result == input::CANCEL {
+            return Ok("Cancelled".into());
+        }
+    }
+
+    labels::delete(config, &target.id).await?;
+    if json {
+        Ok(serde_json::to_string(&target)?)
+    } else {
+        Ok(format::green_string(&format!(
+            "Label \"{}\" deleted",
+            target.name
+        )))
+    }
+}
+```
+
+Note: `fetch_label()` is a new helper function (see §4.2 below) placed in `src/commands/mod.rs`. It resolves a label by ID or name from the labels list, with JSON-mode guard for interactive selection.
+
+### 3.3 Tests
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test;
+    use crate::test::responses::ResponseFromFile;
+
+    #[tokio::test]
+    async fn create_fails_in_json_mode_without_name() {
+        let mut config = Config::default_test();
+        config.args.json = true;
+        let args = Create {
+            name: None,
+            color: None,
+            order: None,
+            is_favorite: false,
+        };
+
+        let error = create(&config, &args, true)
+            .await
+            .expect_err("creating a label without name in JSON mode should fail");
+
+        assert_eq!(error.source, "json_mode");
+    }
+
+    #[tokio::test]
+    async fn delete_fails_when_label_not_found() {
+        let mut server = mockito::Server::new_async().await;
+
+        let labels_mock = server
+            .mock("GET", "/api/v1/labels?limit=200")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(ResponseFromFile::Labels.read().await)
+            .create_async()
+            .await;
+
+        let config = test::fixtures::config().await.with_mock_url(server.url());
+
+        let args = Delete {
+            label: Some("nonexistent".to_string()),
+            force: false,
+        };
+
+        let error = delete(&config, &args, false)
+            .await
+            .expect_err("deleting a nonexistent label should fail");
+
+        assert_eq!(error.source, "fetch_label");
+        assert!(error.message.contains("not found"));
+        labels_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn delete_force_skips_confirmation() {
+        let mut server = mockito::Server::new_async().await;
+
+        let labels_mock = server
+            .mock("GET", "/api/v1/labels?limit=200")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(ResponseFromFile::Labels.read().await)
+            .create_async()
+            .await;
+
+        let delete_mock = server
+            .mock("DELETE", "/api/v1/labels/123")
+            .with_status(204)
+            .create_async()
+            .await;
+
+        let config = test::fixtures::config().await.with_mock_url(server.url());
+
+        let args = Delete {
+            label: Some("345".to_string()), // matches name in Label.json fixture
+            force: true,
+        };
+
+        let result = delete(&config, &args, false)
+            .await
+            .expect("force delete should succeed");
+
+        assert!(result.contains("deleted"));
+        labels_mock.assert_async().await;
+        delete_mock.assert_async().await;
+    }
+}
+```
+
+## 4. `src/commands/mod.rs` — dispatch wiring
+
+### 4.1 Add module and import
+
+Add `mod label_commands;` to the module declarations (after `mod list_commands;` at line 20):
+
+```rust
+mod label_commands;
+```
+
+Add `use label_commands::LabelCommands;` to the imports (after `use list_commands::ListCommands;`):
+
+```rust
+use label_commands::LabelCommands;
+```
+
+### 4.2 Add `fetch_label()` helper
+
+After the existing `fetch_string()` / `fetch_project()` functions, add a new helper. Labels differ from projects because they don't live in config — they're fetched from the API. The helper resolves by ID first, then name:
+
+```rust
+pub fn fetch_label<'a>(
+    arg: Option<&str>,
+    config: &Config,
+    labels: &'a [labels::Label],
+) -> Result<&'a labels::Label, Error> {
+    if let Some(input) = arg {
+        // Try exact ID match first, then name match
+        labels
+            .iter()
+            .find(|l| l.id == input || l.name == input)
+            .ok_or_else(|| {
+                Error::new(
+                    "fetch_label",
+                    &format!("Label \"{input}\" not found"),
+                )
+            })
+    } else if config.args.json {
+        Err(Error::new("json_mode", JSON_INTERACTIVE_ERROR))
+    } else {
+        let label_names: Vec<String> = labels.iter().map(|l| l.name.clone()).collect();
+        let selected = input::select(input::LABEL, label_names, config.mock_select)?;
+        Ok(labels.iter().find(|l| l.name == selected).unwrap())
+    }
+}
+```
+
+Note: This requires `input::LABEL` to exist. Check `src/input.rs` for the prompt constants — if it doesn't exist, add `pub const LABEL: &str = "Label:";` alongside the existing `SECTION`, `NAME`, etc. constants.
+
+### 4.3 Add `Label` variant to `Commands` enum
+
+After the `Section(SectionCommands)` variant (after line 90), add:
+
+```rust
+    #[command(subcommand)]
+    #[clap(alias = "b")]
+    /// (b) Commands for managing personal labels
+    Label(LabelCommands),
+```
+
+Aliases: `p`, `n`, `t`, `l`, `r`, `c`, `a`, `s`, `e` are taken. Use `b` for la**b**el, or `L` if uppercase aliases work (check clap behavior).
+
+### 4.4 Add match arm in `select_command()`
+
+After `Commands::Section(command) => ...` (after line 143):
+
+```rust
+        Commands::Label(command) => label_command(command, &cli, &tx).await,
+```
+
+### 4.5 Add handler function
+
+After `section_command()` (around line 220), add:
+
+```rust
+async fn label_command(
+    command: &LabelCommands,
+    cli: &Cli,
+    tx: &UnboundedSender<Error>,
+) -> Result<CommandResult, Error> {
+    match command {
+        LabelCommands::Create(args) => {
+            let config = fetch_config(cli, tx).await?;
+            let result = label_commands::create(&config, args, cli.json).await;
+            Ok(build_command_result(result, &config))
+        }
+        LabelCommands::Update(args) => {
+            let config = fetch_config(cli, tx).await?;
+            let result = label_commands::update(&config, args, cli.json).await;
+            Ok(build_command_result(result, &config))
+        }
+        LabelCommands::Delete(args) => {
+            let config = fetch_config(cli, tx).await?;
+            let result = label_commands::delete(&config, args, cli.json).await;
+            Ok(build_command_result(result, &config))
+        }
+    }
+}
+```
+
+## 5. `src/input.rs` — add prompt constant
+
+If `LABEL` doesn't already exist in `src/input.rs`, add it alongside the other prompt constants:
+
+```rust
+pub const LABEL: &str = "Label:";
+```
+
+## 6. `src/test/responses.rs` — remove dead_code attribute
+
+Change line 27-28 from:
+
+```rust
+    #[allow(dead_code)]
+    Label,
+```
+
+to:
+
+```rust
+    Label,
+```
+
+## 7. `docs/usage.md` — add label examples
+
+Add a new "Labels" section after the existing "Sections" examples.
+
+## Implementation order
+
+1. **`src/labels.rs`** — Add `from_json()`, business-logic wrappers, unit tests
+2. **`src/todoist/mod.rs`** — Add `create_label()`, `update_label()`, `delete_label()`, API tests
+3. **`src/input.rs`** — Add `LABEL` prompt constant (if missing)
+4. **`src/commands/label_commands.rs`** — Create file with CLI arg structs, handlers, tests
+5. **`src/commands/mod.rs`** — Wire dispatch: module, import, enum variant, match arm, handler, `fetch_label()` helper
+6. **`src/test/responses.rs`** — Remove `#[allow(dead_code)]` on `Label` variant
+7. **`docs/usage.md`** — Add label command examples
+8. Run `scripts/test.sh` — verify formatting, compilation, clippy, tests, forbidden strings

--- a/.pi/qrspi/TOD-1768-label-crud/plan.md
+++ b/.pi/qrspi/TOD-1768-label-crud/plan.md
@@ -779,16 +779,16 @@ Note: Read the existing `docs/usage.md` to find the exact "Sections" section loc
 ### Verification
 
 #### Automated
-- [ ] `scripts/test.sh` passes clean (fmt, build, clippy, tests, forbidden strings)
-- [ ] No `dbg!`, `TODO`, `FIXME`, `DEBUG:`, or `FIXTURE:` strings in any `.rs` file
+- [x] `scripts/test.sh` passes clean (fmt, build, clippy, tests, forbidden strings)
+- [x] No `dbg!`, `TODO`, `FIXME`, `DEBUG:`, or `FIXTURE:` strings in any `.rs` file
 
 #### Manual
-- [ ] `tod -h` shows `label` / `b` in the command list
-- [ ] `tod label -h` shows all three subcommands with correct aliases:
+- [x] `tod -h` shows `label` / `b` in the command list
+- [x] `tod label -h` shows all three subcommands with correct aliases:
   - `create` / `c`
   - `update` / `u`
   - `delete` / `d`
-- [ ] `docs/usage.md` renders correctly (check in editor)
+- [x] `docs/usage.md` renders correctly (check in editor)
 
 ---
 

--- a/.pi/qrspi/TOD-1768-label-crud/plan.md
+++ b/.pi/qrspi/TOD-1768-label-crud/plan.md
@@ -280,10 +280,10 @@ Note: `labels::Label` is already available via `use crate::{..., labels};` on li
 - [x] `#[allow(dead_code)]` is removed from `ResponseFromFile::Label` (verify with `grep dead_code src/test/responses.rs` — should not appear on the `Label` line)
 
 #### Manual
-- [ ] `tod label -h` shows `Create` subcommand with alias `c`
-- [ ] `tod label create --name "test-label" --color red` creates a real label (visible in Todoist UI)
-- [ ] `tod label create --name "test-label" --json` returns JSON with `id`, `name`, `color`, `order`, `is_favorite` fields
-- [ ] `tod -h` shows `label` command with alias `b` in the command list
+- [x] `tod label -h` shows `Create` subcommand with alias `c`
+- [x] `tod label create --name "test-label" --color red` creates a real label (visible in Todoist UI)
+- [x] `tod label create --name "test-label" --json` returns JSON with `id`, `name`, `color`, `order`, `is_favorite` fields
+- [x] `tod -h` shows `label` command with alias `b` in the command list
 
 ---
 
@@ -714,7 +714,7 @@ Replace the Phase 1 version of `label_command()` (which only had the `Create` ar
 ### Verification
 
 #### Automated
-- [ ] `cargo test` passes all Phase 1 + Phase 2 tests (8 total new tests across both phases):
+- [x] `cargo test` passes all Phase 1 + Phase 2 tests (8 total new tests across both phases):
   - `labels::tests::test_label_from_json_valid`
   - `labels::tests::test_label_from_json_invalid`
   - `todoist::tests::test_create_label`
@@ -724,13 +724,13 @@ Replace the Phase 1 version of `label_command()` (which only had the `Create` ar
   - `label_commands::tests::update_fails_without_any_fields`
   - `label_commands::tests::delete_fails_when_label_not_found`
   - `label_commands::tests::delete_force_skips_confirmation`
-- [ ] `cargo build` compiles without warnings
+- [x] `cargo build` compiles without warnings
 
 #### Manual
-- [ ] `tod label update --label "test-label" --name "renamed"` renames a label
-- [ ] `tod label delete --label "renamed" --force` deletes without confirmation
-- [ ] `tod label delete --label "renamed"` (interactive, no `--force`) shows confirmation prompt with Cancel/Delete options
-- [ ] `tod label -h` shows all three subcommands with aliases: `c` (create), `u` (update), `d` (delete)
+- [x] `tod label update --label "test-label" --name "renamed"` renames a label
+- [x] `tod label delete --label "renamed" --force` deletes without confirmation
+- [x] `tod label delete --label "renamed"` (interactive, no `--force`) shows confirmation prompt with Cancel/Delete options
+- [x] `tod label -h` shows all three subcommands with aliases: `c` (create), `u` (update), `d` (delete)
 
 ---
 

--- a/.pi/qrspi/TOD-1768-label-crud/plan.md
+++ b/.pi/qrspi/TOD-1768-label-crud/plan.md
@@ -1,0 +1,805 @@
+# Implementation Plan
+
+## Overview
+
+Add `tod label create`, `tod label update`, and `tod label delete` CLI commands by following the existing patterns in `project_commands` / `section_commands`. Each phase delivers a complete, testable vertical slice.
+
+---
+
+## Phase 1: `tod label create` — first vertical slice
+
+Delivers `tod label create` end-to-end: API call, business-logic wrapper, CLI handler, dispatch wiring, and tests at every layer. Establishes the `label_commands` module, `LabelCommands` enum, and dispatch infrastructure.
+
+### Changes
+
+#### 1. Add `Label::from_json()` standalone method
+**File**: `src/labels.rs`
+**Action**: modify
+
+After the `impl LabelResponse` block (after line 27), before `impl Display for Label` (line 28):
+
+```rust
+impl Label {
+    pub fn from_json(json: &str) -> Result<Label, Error> {
+        let label: Label = serde_json::from_str(json)?;
+        Ok(label)
+    }
+}
+```
+
+#### 2. Add `labels::create()` business-logic wrapper
+**File**: `src/labels.rs`
+**Action**: modify
+
+After the existing `get_labels()` function (after line 33):
+
+```rust
+pub async fn create(
+    config: &Config,
+    name: &str,
+    color: Option<&str>,
+    order: Option<u32>,
+    is_favorite: bool,
+) -> Result<Label, Error> {
+    todoist::create_label(config, name, color, order, is_favorite, true).await
+}
+```
+
+#### 3. Add unit tests for `from_json` and `create`
+**File**: `src/labels.rs`
+**Action**: modify
+
+Add to the existing `mod tests` block (after line ~108, before the `mod proptests` block):
+
+```rust
+    #[test]
+    fn test_label_from_json_valid() {
+        let json =
+            r#"{"id":"1","name":"work","color":"red","order":1,"is_favorite":false}"#;
+        let label = Label::from_json(json).expect("should parse label");
+        assert_eq!(label.id, "1");
+        assert_eq!(label.name, "work");
+        assert_eq!(label.color, "red");
+        assert_eq!(label.order, Some(1));
+        assert!(!label.is_favorite);
+    }
+
+    #[test]
+    fn test_label_from_json_invalid() {
+        let result = Label::from_json("not json");
+        assert!(result.is_err());
+    }
+```
+
+#### 4. Add `todoist::create_label()` API function
+**File**: `src/todoist/mod.rs`
+**Action**: modify
+
+Place after `all_labels()` (after line ~465 of the `all_labels` function), before `move_task_to_project`:
+
+```rust
+/// Create a personal label.
+pub async fn create_label(
+    config: &Config,
+    name: &str,
+    color: Option<&str>,
+    order: Option<u32>,
+    is_favorite: bool,
+    spinner: bool,
+) -> Result<Label, Error> {
+    let mut body = json!({"name": name, "is_favorite": is_favorite});
+    if let Some(c) = color {
+        body["color"] = json!(c);
+    }
+    if let Some(o) = order {
+        body["order"] = json!(o);
+    }
+
+    let response = request::post_todoist(config, LABELS_URL, body, spinner).await?;
+    Label::from_json(&response)
+}
+```
+
+#### 5. Add API test for `create_label`
+**File**: `src/todoist/mod.rs`
+**Action**: modify
+
+Add to the tests module. Find the section tests (around line 1068) and add after `test_create_section`:
+
+```rust
+    #[tokio::test]
+    async fn test_create_label() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/api/v1/labels")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(ResponseFromFile::Label.read().await)
+            .create_async()
+            .await;
+
+        let config = test::fixtures::config().await.with_mock_url(server.url());
+
+        let result = create_label(&config, "test-label", Some("red"), None, false, false).await;
+        assert_eq!(result, Ok(test::fixtures::label()));
+        mock.assert();
+    }
+```
+
+#### 6. Remove `#[allow(dead_code)]` from `ResponseFromFile::Label`
+**File**: `src/test/responses.rs`
+**Action**: modify
+
+Change line 27 from:
+```rust
+    #[allow(dead_code)]
+    Label,
+```
+to:
+```rust
+    Label,
+```
+
+#### 7. Create `src/commands/label_commands.rs`
+**File**: `src/commands/label_commands.rs`
+**Action**: create
+
+```rust
+use crate::{config::Config, errors::Error, format, input, labels};
+use clap::{Parser, Subcommand};
+
+/// Label subcommands.
+#[derive(Subcommand, Debug, Clone)]
+pub enum LabelCommands {
+    #[clap(alias = "c")]
+    /// (c) Create a new personal label
+    Create(Create),
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct Create {
+    #[arg(short, long)]
+    /// Label name
+    name: Option<String>,
+
+    #[arg(short, long)]
+    /// Color for the label (e.g. "red", "blue", "green")
+    color: Option<String>,
+
+    #[arg(short, long)]
+    /// Display order (1-based)
+    order: Option<u32>,
+
+    #[arg(short = 'f', long, default_value_t = false)]
+    /// Mark label as a favorite
+    is_favorite: bool,
+}
+
+/// Creates a personal label.
+pub async fn create(config: &Config, args: &Create, json: bool) -> Result<String, Error> {
+    let Create {
+        name,
+        color,
+        order,
+        is_favorite,
+    } = args;
+    let name = super::fetch_string(name.as_deref(), config, input::NAME)?;
+
+    let label = labels::create(config, &name, color.as_deref(), *order, *is_favorite).await?;
+    if json {
+        Ok(serde_json::to_string(&label)?)
+    } else {
+        Ok(format::green_string(&format!(
+            "Label \"{}\" created",
+            label.name
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test;
+
+    #[tokio::test]
+    async fn create_fails_in_json_mode_without_name() {
+        let mut config = Config::default_test();
+        config.args.json = true;
+        let args = Create {
+            name: None,
+            color: None,
+            order: None,
+            is_favorite: false,
+        };
+
+        let error = create(&config, &args, true)
+            .await
+            .expect_err("creating a label without name in JSON mode should fail");
+
+        assert_eq!(error.source, "json_mode");
+    }
+}
+```
+
+#### 8. Register `label_commands` module and wire dispatch
+**File**: `src/commands/mod.rs`
+**Action**: modify
+
+**a.** Add module declaration after `mod list_commands;` (line 18):
+```rust
+mod label_commands;
+```
+
+**b.** Add import after `use list_commands::ListCommands;` (line 15):
+```rust
+use label_commands::LabelCommands;
+```
+
+**c.** Add `Label` variant to `Commands` enum after the `Section(SectionCommands)` variant (after line 87):
+```rust
+    #[command(subcommand)]
+    #[clap(alias = "b")]
+    /// (b) Commands for managing personal labels
+    Label(LabelCommands),
+```
+
+**d.** Add match arm in `select_command()` after `Commands::Section(command) => ...` (after line 139):
+```rust
+        Commands::Label(command) => label_command(command, &cli, &tx).await,
+```
+
+**e.** Add `label_command()` handler function after `section_command()` (after line ~218):
+
+```rust
+async fn label_command(
+    command: &LabelCommands,
+    cli: &Cli,
+    tx: &UnboundedSender<Error>,
+) -> Result<CommandResult, Error> {
+    match command {
+        LabelCommands::Create(args) => {
+            let config = fetch_config(cli, tx).await?;
+            let result = label_commands::create(&config, args, cli.json).await;
+            Ok(build_command_result(result, &config))
+        }
+    }
+}
+```
+
+Note: `labels::Label` is already available via `use crate::{..., labels};` on line 6 — no new import needed for the label type.
+
+### Verification
+
+#### Automated
+- [x] `cargo test` passes all existing tests plus 4 new tests:
+  - `labels::tests::test_label_from_json_valid`
+  - `labels::tests::test_label_from_json_invalid`
+  - `todoist::tests::test_create_label`
+  - `label_commands::tests::create_fails_in_json_mode_without_name`
+- [x] `cargo build` compiles without warnings
+- [x] `#[allow(dead_code)]` is removed from `ResponseFromFile::Label` (verify with `grep dead_code src/test/responses.rs` — should not appear on the `Label` line)
+
+#### Manual
+- [ ] `tod label -h` shows `Create` subcommand with alias `c`
+- [ ] `tod label create --name "test-label" --color red` creates a real label (visible in Todoist UI)
+- [ ] `tod label create --name "test-label" --json` returns JSON with `id`, `name`, `color`, `order`, `is_favorite` fields
+- [ ] `tod -h` shows `label` command with alias `b` in the command list
+
+---
+
+## Phase 2: `tod label update` and `tod label delete`
+
+Adds the remaining two commands on top of Phase 1's infrastructure. The `LabelCommands` enum grows from one variant to three.
+
+### Changes
+
+#### 1. Add `todoist::update_label()` API function
+**File**: `src/todoist/mod.rs`
+**Action**: modify
+
+Place after `create_label()` (added in Phase 1):
+
+```rust
+/// Update a personal label by ID.
+pub async fn update_label(
+    config: &Config,
+    label_id: &str,
+    name: Option<&str>,
+    color: Option<&str>,
+    order: Option<u32>,
+    is_favorite: Option<bool>,
+    spinner: bool,
+) -> Result<Label, Error> {
+    let mut body = json!({});
+    if let Some(n) = name {
+        body["name"] = json!(n);
+    }
+    if let Some(c) = color {
+        body["color"] = json!(c);
+    }
+    if let Some(o) = order {
+        body["order"] = json!(o);
+    }
+    if let Some(f) = is_favorite {
+        body["is_favorite"] = json!(f);
+    }
+
+    let url = format!("{}/{}", LABELS_URL, label_id);
+    let response = request::post_todoist(config, &url, body, spinner).await?;
+    Label::from_json(&response)
+}
+```
+
+#### 2. Add `todoist::delete_label()` API function
+**File**: `src/todoist/mod.rs`
+**Action**: modify
+
+Place after `update_label()`:
+
+```rust
+/// Delete a personal label by ID.
+pub async fn delete_label(
+    config: &Config,
+    label_id: &str,
+    spinner: bool,
+) -> Result<String, Error> {
+    let url = format!("{}/{}", LABELS_URL, label_id);
+    request::delete_todoist(config, &url, json!({}), spinner).await?;
+    Ok("✓".into())
+}
+```
+
+#### 3. Add API tests for update and delete
+**File**: `src/todoist/mod.rs`
+**Action**: modify
+
+Add after `test_create_label` (added in Phase 1):
+
+```rust
+    #[tokio::test]
+    async fn test_update_label() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/api/v1/labels/123")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(ResponseFromFile::Label.read().await)
+            .create_async()
+            .await;
+
+        let config = test::fixtures::config().await.with_mock_url(server.url());
+
+        let result =
+            update_label(&config, "123", Some("new-name"), Some("blue"), None, None, false).await;
+        assert_eq!(result, Ok(test::fixtures::label()));
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_delete_label() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("DELETE", "/api/v1/labels/123")
+            .with_status(204)
+            .create_async()
+            .await;
+
+        let config = test::fixtures::config().await.with_mock_url(server.url());
+
+        let result = delete_label(&config, "123", false).await;
+        assert_eq!(result, Ok("✓".into()));
+        mock.assert();
+    }
+```
+
+#### 4. Add `labels::update()` and `labels::delete()` business-logic wrappers
+**File**: `src/labels.rs`
+**Action**: modify
+
+Add after `create()` (added in Phase 1):
+
+```rust
+pub async fn update(
+    config: &Config,
+    label_id: &str,
+    name: Option<&str>,
+    color: Option<&str>,
+    order: Option<u32>,
+    is_favorite: Option<bool>,
+) -> Result<Label, Error> {
+    todoist::update_label(config, label_id, name, color, order, is_favorite, true).await
+}
+
+pub async fn delete(config: &Config, label_id: &str) -> Result<String, Error> {
+    todoist::delete_label(config, label_id, true).await
+}
+```
+
+#### 5. Add `LABEL` prompt constant
+**File**: `src/input.rs`
+**Action**: modify
+
+Add after `pub const LABELS: &str = "Select labels";` (line 33):
+
+```rust
+/// Prompt label for single label selection.
+pub const LABEL: &str = "Label:";
+```
+
+#### 6. Add `fetch_label()` helper to `commands/mod.rs`
+**File**: `src/commands/mod.rs`
+**Action**: modify
+
+Add after `fetch_project_or_filter()` (after line ~460). This helper resolves a label by ID or name from a pre-fetched list:
+
+```rust
+/// Resolves a label by ID or name from a list, or prompts interactively.
+pub fn fetch_label<'a>(
+    arg: Option<&str>,
+    config: &Config,
+    labels: &'a [labels::Label],
+) -> Result<&'a labels::Label, Error> {
+    if let Some(input) = arg {
+        labels
+            .iter()
+            .find(|l| l.id == input || l.name == input)
+            .ok_or_else(|| Error::new("fetch_label", &format!("Label \"{input}\" not found")))
+    } else if config.args.json {
+        Err(Error::new("json_mode", JSON_INTERACTIVE_ERROR))
+    } else {
+        let label_names: Vec<String> = labels.iter().map(|l| l.name.clone()).collect();
+        let selected = input::select(input::LABEL, label_names, config.mock_select)?;
+        Ok(labels.iter().find(|l| l.name == selected).unwrap())
+    }
+}
+```
+
+Note: `labels::Label` is already in scope via `use crate::{..., labels};` on line 6.
+
+#### 7. Add `Update` and `Delete` to `LabelCommands` + handlers + tests
+**File**: `src/commands/label_commands.rs`
+**Action**: modify
+
+**a.** Add `Update` and `Delete` variants to the `LabelCommands` enum:
+
+```rust
+    #[clap(alias = "u")]
+    /// (u) Update an existing personal label
+    Update(Update),
+    #[clap(alias = "d")]
+    /// (d) Delete a personal label
+    Delete(Delete),
+```
+
+**b.** Add new arg structs after `Create`:
+
+```rust
+#[derive(Parser, Debug, Clone)]
+pub struct Update {
+    #[arg(short, long)]
+    /// Label to update (name or ID)
+    label: Option<String>,
+
+    #[arg(short, long)]
+    /// New name for the label
+    name: Option<String>,
+
+    #[arg(short, long)]
+    /// New color for the label
+    color: Option<String>,
+
+    #[arg(short, long)]
+    /// New display order
+    order: Option<u32>,
+
+    #[arg(short = 'f', long)]
+    /// Toggle favorite status (true or false)
+    favorite: Option<bool>,
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct Delete {
+    #[arg(short, long)]
+    /// Label to delete (name or ID)
+    label: Option<String>,
+
+    #[arg(short = 'f', long, default_value_t = false)]
+    /// Skip deletion confirmation
+    force: bool,
+}
+```
+
+**c.** Add handler functions after the `create()` handler:
+
+```rust
+/// Updates a personal label.
+pub async fn update(config: &Config, args: &Update, json: bool) -> Result<String, Error> {
+    let Update {
+        label,
+        name,
+        color,
+        order,
+        favorite,
+    } = args;
+
+    let labels_list = labels::get_labels(config, true).await?;
+    let target = super::fetch_label(label.as_deref(), config, &labels_list)?;
+
+    if name.is_none() && color.is_none() && order.is_none() && favorite.is_none() {
+        return Err(Error::new(
+            "update_label",
+            "At least one of --name, --color, --order, or --favorite is required",
+        ));
+    }
+
+    let updated = labels::update(
+        config,
+        &target.id,
+        name.as_deref(),
+        color.as_deref(),
+        *order,
+        *favorite,
+    )
+    .await?;
+    if json {
+        Ok(serde_json::to_string(&updated)?)
+    } else {
+        Ok(format::green_string(&format!(
+            "Label \"{}\" updated",
+            updated.name
+        )))
+    }
+}
+
+/// Deletes a personal label.
+pub async fn delete(config: &Config, args: &Delete, json: bool) -> Result<String, Error> {
+    let Delete { label, force } = args;
+
+    let labels_list = labels::get_labels(config, true).await?;
+    if labels_list.is_empty() {
+        return Ok("No labels found".into());
+    }
+
+    let target = super::fetch_label(label.as_deref(), config, &labels_list)?;
+
+    if !force {
+        if json {
+            return Err(Error::new("json_mode", super::JSON_INTERACTIVE_ERROR));
+        }
+        let options = vec![input::CANCEL, input::DELETE];
+        let desc = format!("Delete label \"{}\"?", target.name);
+        let result = input::select(&desc, options, config.mock_select)?;
+        if result == input::CANCEL {
+            return Ok("Cancelled".into());
+        }
+    }
+
+    labels::delete(config, &target.id).await?;
+    if json {
+        Ok(serde_json::to_string(&target)?)
+    } else {
+        Ok(format::green_string(&format!(
+            "Label \"{}\" deleted",
+            target.name
+        )))
+    }
+}
+```
+
+**d.** Add command-level tests to the existing `mod tests` block:
+
+```rust
+    #[tokio::test]
+    async fn update_fails_without_any_fields() {
+        let config = Config::default_test();
+        let args = Update {
+            label: Some("my-label".to_string()),
+            name: None,
+            color: None,
+            order: None,
+            favorite: None,
+        };
+
+        let error = update(&config, &args, false)
+            .await
+            .expect_err("update with no fields should fail");
+
+        assert_eq!(error.source, "update_label");
+        assert!(error.message.contains("At least one"));
+    }
+
+    #[tokio::test]
+    async fn delete_fails_when_label_not_found() {
+        let mut server = mockito::Server::new_async().await;
+
+        let labels_mock = server
+            .mock("GET", "/api/v1/labels?limit=200")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(ResponseFromFile::Labels.read().await)
+            .create_async()
+            .await;
+
+        let config = test::fixtures::config().await.with_mock_url(server.url());
+
+        let args = Delete {
+            label: Some("nonexistent".to_string()),
+            force: false,
+        };
+
+        let error = delete(&config, &args, false)
+            .await
+            .expect_err("deleting a nonexistent label should fail");
+
+        assert_eq!(error.source, "fetch_label");
+        assert!(error.message.contains("not found"));
+        labels_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn delete_force_skips_confirmation() {
+        let mut server = mockito::Server::new_async().await;
+
+        let labels_mock = server
+            .mock("GET", "/api/v1/labels?limit=200")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(ResponseFromFile::Labels.read().await)
+            .create_async()
+            .await;
+
+        let delete_mock = server
+            .mock("DELETE", "/api/v1/labels/123")
+            .with_status(204)
+            .create_async()
+            .await;
+
+        let config = test::fixtures::config().await.with_mock_url(server.url());
+
+        let args = Delete {
+            label: Some("345".to_string()),
+            force: true,
+        };
+
+        let result = delete(&config, &args, false)
+            .await
+            .expect("force delete should succeed");
+
+        assert!(result.contains("deleted"));
+        labels_mock.assert_async().await;
+        delete_mock.assert_async().await;
+    }
+```
+
+Note: The test module needs these additional imports added at the top of the `mod tests` block:
+```rust
+    use crate::test::responses::ResponseFromFile;
+```
+(already present from Phase 1 if `create_fails_in_json_mode_without_name` uses it — it doesn't, so add it now for the delete tests that need it.)
+
+#### 8. Add `Update` and `Delete` arms to `label_command()` dispatch
+**File**: `src/commands/mod.rs`
+**Action**: modify
+
+Expand the `label_command()` function (added in Phase 1) to handle the new variants:
+
+```rust
+async fn label_command(
+    command: &LabelCommands,
+    cli: &Cli,
+    tx: &UnboundedSender<Error>,
+) -> Result<CommandResult, Error> {
+    match command {
+        LabelCommands::Create(args) => {
+            let config = fetch_config(cli, tx).await?;
+            let result = label_commands::create(&config, args, cli.json).await;
+            Ok(build_command_result(result, &config))
+        }
+        LabelCommands::Update(args) => {
+            let config = fetch_config(cli, tx).await?;
+            let result = label_commands::update(&config, args, cli.json).await;
+            Ok(build_command_result(result, &config))
+        }
+        LabelCommands::Delete(args) => {
+            let config = fetch_config(cli, tx).await?;
+            let result = label_commands::delete(&config, args, cli.json).await;
+            Ok(build_command_result(result, &config))
+        }
+    }
+}
+```
+
+Replace the Phase 1 version of `label_command()` (which only had the `Create` arm) with this expanded one.
+
+### Verification
+
+#### Automated
+- [ ] `cargo test` passes all Phase 1 + Phase 2 tests (8 total new tests across both phases):
+  - `labels::tests::test_label_from_json_valid`
+  - `labels::tests::test_label_from_json_invalid`
+  - `todoist::tests::test_create_label`
+  - `todoist::tests::test_update_label`
+  - `todoist::tests::test_delete_label`
+  - `label_commands::tests::create_fails_in_json_mode_without_name`
+  - `label_commands::tests::update_fails_without_any_fields`
+  - `label_commands::tests::delete_fails_when_label_not_found`
+  - `label_commands::tests::delete_force_skips_confirmation`
+- [ ] `cargo build` compiles without warnings
+
+#### Manual
+- [ ] `tod label update --label "test-label" --name "renamed"` renames a label
+- [ ] `tod label delete --label "renamed" --force` deletes without confirmation
+- [ ] `tod label delete --label "renamed"` (interactive, no `--force`) shows confirmation prompt with Cancel/Delete options
+- [ ] `tod label -h` shows all three subcommands with aliases: `c` (create), `u` (update), `d` (delete)
+
+---
+
+## Phase 3: Docs and final verification
+
+Updates `docs/usage.md` with label command examples and runs the full pre-commit checklist.
+
+### Changes
+
+#### 1. Add label command examples to docs
+**File**: `docs/usage.md`
+**Action**: modify
+
+Add a new "Labels" section after the existing "Sections" examples. The format should match existing sections — a `### Labels` heading with code-fenced bash examples:
+
+```markdown
+### Labels
+
+Create a label:
+```bash
+tod label create --name "Urgent" --color red
+tod label create -n "Personal" --color blue --favorite
+tod label create -n "Weekend" -c green -o 2
+```
+
+Update a label:
+```bash
+tod label update --label "Urgent" --name "Critical"
+tod label update -l "Personal" --color purple
+```
+
+Delete a label:
+```bash
+tod label delete --label "Weekend" --force
+tod label delete -l "Critical"
+```
+
+View all labels:
+```bash
+tod label -h
+```
+```
+
+Note: Read the existing `docs/usage.md` to find the exact "Sections" section location and follow its heading level and code fence conventions exactly.
+
+### Verification
+
+#### Automated
+- [ ] `scripts/test.sh` passes clean (fmt, build, clippy, tests, forbidden strings)
+- [ ] No `dbg!`, `TODO`, `FIXME`, `DEBUG:`, or `FIXTURE:` strings in any `.rs` file
+
+#### Manual
+- [ ] `tod -h` shows `label` / `b` in the command list
+- [ ] `tod label -h` shows all three subcommands with correct aliases:
+  - `create` / `c`
+  - `update` / `u`
+  - `delete` / `d`
+- [ ] `docs/usage.md` renders correctly (check in editor)
+
+---
+
+## Summary of all files touched
+
+| File | Phase | Action |
+|------|-------|--------|
+| `src/labels.rs` | 1, 2 | Add `Label::from_json()`, `create()`, `update()`, `delete()`, 2 unit tests |
+| `src/todoist/mod.rs` | 1, 2 | Add `create_label()`, `update_label()`, `delete_label()`, 3 API tests |
+| `src/input.rs` | 1 | Add `pub const LABEL: &str = "Label:";` |
+| `src/commands/label_commands.rs` | 1, 2 | **New file**: `LabelCommands` enum, `Create`/`Update`/`Delete` arg structs, 3 handlers, 4 tests |
+| `src/commands/mod.rs` | 1, 2 | Module + import, `Commands::Label` variant, `select_command` arm, `label_command()` handler, `fetch_label()` helper |
+| `src/test/responses.rs` | 1 | Remove `#[allow(dead_code)]` from `Label` variant |
+| `docs/usage.md` | 3 | Add "Labels" section with examples |

--- a/.pi/qrspi/TOD-1768-label-crud/questions.md
+++ b/.pi/qrspi/TOD-1768-label-crud/questions.md
@@ -1,0 +1,21 @@
+# Research Questions
+
+## Context
+
+This codebase is a Todoist CLI client written in Rust. Labels have an existing data model (`src/labels.rs`), a GET endpoint (`all_labels` in `src/todoist/mod.rs`), and a JSON response fixture (`tests/responses/Label.json`). The codebase uses clap for CLI parsing, mockito for HTTP mocking in tests, and has established patterns for CRUD operations on other resources like projects, sections, and tasks. Focus on the API layer (`src/todoist/`), the CLI command dispatch (`src/commands/`), the business logic layer (`src/projects.rs` as a model), and the test infrastructure (`src/test/`).
+
+## Questions
+
+1. What is the full set of fields on the `Label` struct in `src/labels.rs`, and how does the Todoist API label response JSON (from `tests/responses/Label.json`) map to those fields? Which fields are optional vs required in the API?
+
+2. Trace the flow of `create_project` from CLI to API: how does `src/commands/project_commands.rs` parse arguments, dispatch to `src/projects.rs`, and call `src/todoist/mod.rs`? What does the `request::post_todoist` function expect for URL construction, body format, and response handling?
+
+3. How does `src/commands/mod.rs` register and dispatch command groups (like `ProjectCommands`, `SectionCommands`)? What would need to happen in the `Commands` enum, the `select_command` match block, and the `Cli` struct to add a new top-level command group?
+
+4. How does the `delete_project` flow work end-to-end — specifically, how does `delete_todoist` in `src/todoist/request.rs` handle the DELETE HTTP method, what status codes does it treat as success, and how does the caller (`projects::delete` → `project_commands::delete`) handle the response?
+
+5. What is the existing `all_labels` function's pagination pattern in `src/todoist/mod.rs`, and how does the `LabelResponse::from_json` method deserialize the paginated API response? Are label create/update/delete responses paginated or do they return a single object?
+
+6. How are HTTP 204 No Content responses handled in `src/todoist/request.rs`'s `handle_response` function? Look at how `archive_project` and `unarchive_project` deal with 204 responses, since `DELETE /labels/{id}` also returns 204.
+
+7. What test patterns exist for resource creation and deletion — specifically, how do `test_create_section` and `test_delete_section` in `src/todoist/mod.rs` set up mockito mocks, construct test configs, and assert results? What fixtures and response files would a label create/delete test need?

--- a/.pi/qrspi/TOD-1768-label-crud/research.md
+++ b/.pi/qrspi/TOD-1768-label-crud/research.md
@@ -1,0 +1,111 @@
+# Research Findings
+
+## Q1: What is the full set of fields on the `Label` struct in `src/labels.rs`, and how does the Todoist API label response JSON (from `tests/responses/Label.json`) map to those fields? Which fields are optional vs required in the API?
+
+### Findings
+- The `Label` struct has five fields (`src/labels.rs:9-13`): `id: String`, `name: String`, `color: String`, `order: Option<u32>`, `is_favorite: bool`.
+- `tests/responses/Label.json` contains: `"id": "123"`, `"name": "345"`, `"is_favorite": false`, `"order": null`, `"color": "red"`. All five keys match the struct fields exactly via serde field-name matching.
+- `Label.json` represents a single label object (no pagination wrapper). The paginated version is `tests/responses/Labels.json` which wraps the same label object in `{"results": [...], "next_cursor": null}`.
+- Based on the struct definition: `id`, `name`, and `color` are required (`String`, no `Option`). `order` is optional (`Option<u32>`, API sends `null` when unset). `is_favorite` is required (`bool`, API always sends it).
+- The test fixture at `src/test/fixtures.rs:16-23` (`label()`) constructs a Label with the same values as `Label.json`: `id: "123"`, `name: "345"`, `color: "red"`, `order: None`, `is_favorite: false`.
+- `Label` derives `Serialize`, `Deserialize`, `Debug`, `PartialEq`, `Eq` (`src/labels.rs:8`). `LabelResponse` derives only `Deserialize` (`src/labels.rs:17`).
+- `Label` implements `Display` (`src/labels.rs:28-31`): outputs just the label name.
+- Serde roundtrip tests exist via proptest at `src/labels.rs:100-108` asserting `label_serde_roundtrip`.
+
+## Q2: Trace the flow of `create_project` from CLI to API: how does `src/commands/project_commands.rs` parse arguments, dispatch to `src/projects.rs`, and call `src/todoist/mod.rs`? What does the `request::post_todoist` function expect for URL construction, body format, and response handling?
+
+### Findings
+- **CLI parsing** (`src/commands/project_commands.rs:28-37`): `Create` derives `Parser`. Fields: `name: Option<String>` (`-n`), `description: Option<String>` (`-d`), `is_favorite: bool` (`-f`, defaults false).
+- **Command handler** (`src/commands/project_commands.rs:167-178`): `create()` destructures args, resolves `name` via `super::fetch_string()` (argument or interactive prompt, with JSON-mode guard), defaults description to `""`, then delegates to `projects::create(config, name, description, *is_favorite, json)`.
+- **Dispatch** (`src/commands/mod.rs:220-224`): `project_command()` matches `ProjectCommands::Create(args)` → calls `project_commands::create()`. Returns `CommandResult` via `build_command_result()` which attaches bell settings and json flag from config.
+- **Business logic** (`src/projects.rs:98-108`): `create()` calls `todoist::create_project(config, &name, description, is_favorite, true)` (spinner always true), then `add(config, &project)` to save to config. If json, returns `serde_json::to_string(&project)`; otherwise a human-readable message.
+- **API call** (`src/todoist/mod.rs:432-441`): `create_project()` sets URL to `PROJECTS_URL` (`"/api/v1/projects"` constant at line 39). Body is `json!({"name": name, "description": description, "is_favorite": is_favorite})`. Calls `request::post_todoist(config, &url, body, spinner)`.
+- **HTTP layer** (`src/todoist/request.rs:33-68`): `post_todoist()` constructs full URL via `get_base_url(config)` — returns `TODOIST_URL` (`"https://api.todoist.com"`) or `mock_url` in tests (`src/todoist/request.rs:168-173`). Sends POST with headers: `Content-Type: application/json`, `Authorization: Bearer {token}`, `X-Request-Id: {uuid}`. Timeout via `get_timeout()` defaults to `DEFAULT_TIMEOUT_SECONDS` (30s). When body is `Value::Null`, uses `client.send()` instead of `client.json(&body)`. On success returns the response text; on 401/403 returns re-login error; on other errors returns diagnostic Error with method/url/body/response.
+
+## Q3: How does `src/commands/mod.rs` register and dispatch command groups (like `ProjectCommands`, `SectionCommands`)? What would need to happen in the `Commands` enum, the `select_command` match block, and the `Cli` struct to add a new top-level command group?
+
+### Findings
+- **`Cli` struct** (`src/commands/mod.rs:48-67`): Holds `command: Commands` as a `#[command(subcommand)]`. Also has global flags: `verbose`, `config`, `timeout`, `json`. No changes needed in `Cli` to add a new command group.
+- **`Commands` enum** (`src/commands/mod.rs:70-113`): Uses `#[derive(Subcommand, Debug, Clone)]`. Each variant wraps a sub-enum: e.g., `Project(ProjectCommands)`, `Section(SectionCommands)`, etc. Each variant has `#[command(subcommand)]` and `#[clap(alias = "X")]` with a doc comment. Currently 9 variants: Project, Section, Task, List, Reminder, Config, Auth, Shell, Test.
+- **Module declarations** (`src/commands/mod.rs:15-27`): Each sub-enum has a corresponding `mod` (e.g., `mod project_commands`, `mod section_commands`) with a `use` import for the type.
+- **`select_command()` dispatch** (`src/commands/mod.rs:130-142`): Matches on `cli.command` and dispatches to handler functions: `project_command()`, `section_command()`, `task_command()`, etc. Adding a new group requires a new arm `Commands::Label(command) => label_command(command, &cli, &tx).await` and a corresponding `async fn label_command(...)` that matches the sub-enum variants.
+- **Handler pattern** (`src/commands/mod.rs:197-218` for `section_command()`): Each handler matches on sub-enum variants, calls `fetch_config(cli, tx)` (loads config, checks auth, applies CLI context), delegates to the sub-command module (e.g., `section_commands::create()`), wraps result with `build_command_result()`.
+- **`fetch_config()`** (`src/commands/mod.rs:460-465`): Always called before business logic. Loads config, applies CLI context (`with_cli_context`), checks version, sets timezone.
+- **Sub-enum and arg struct pattern**: Each command group file (e.g., `src/commands/section_commands.rs`) defines: (1) a `#[derive(Subcommand)]` enum with variants, (2) `#[derive(Parser)]` arg structs for each variant, (3) public async fn handlers.
+
+## Q4: How does the `delete_project` flow work end-to-end — specifically, how does `delete_todoist` in `src/todoist/request.rs` handle the DELETE HTTP method, what status codes does it treat as success, and how does the caller (`projects::delete` → `project_commands::delete`) handle the response?
+
+### Findings
+- **CLI** (`src/commands/project_commands.rs:222-250`): `delete()` fetches project via `fetch_project()`, then calls `todoist::all_tasks_by_project()` to check if project has tasks. If it has tasks and `!force`, shows a confirmation prompt (CANCEL/DELETE options). If user cancels, returns "Cancelled". Otherwise calls `projects::delete()`.
+- **Business logic** (`src/projects.rs:133-137`): `delete()` calls `todoist::delete_project(config, project, true)`, then `config.remove_project(project)`, then `config.save()`. Returns `Ok("✓".into())` on success.
+- **API call** (`src/todoist/mod.rs:425-431`): `delete_project()` builds URL `format!("{}/{}", PROJECTS_URL, project.id)` (e.g., `/api/v1/projects/123`), body `json!({})`, calls `request::delete_todoist()`.
+- **HTTP layer** (`src/todoist/request.rs:82-109`): `delete_todoist()` constructs full URL, sends DELETE with `Authorization: Bearer`, `Content-Type: application/json`, `X-Request-Id`. Always sends `.json(&body)`. Calls `handle_response()`.
+- **`handle_response()`** (`src/todoist/request.rs:149-170`): Treats `status.is_success()` as success (HTTP 200-299 range). On success, returns `response.text().await?` which is an empty string for 204. On 401/403: returns a "run 'tod auth login'" error, unless URL matches a pro-plan URL (`REMINDERS_URL`), then returns pro-plan error. On any other status: returns a diagnostic error with method, URL, body, and response text.
+- **Caller handling**: `delete_project` at `src/todoist/mod.rs:431` ignores the response body string, returns `Ok("✓".into())`. `projects::delete` also returns `Ok("✓".into())` after config cleanup. The CLI handler wraps this via `build_command_result()` and sends to `output_result()` in main.
+
+## Q5: What is the existing `all_labels` function's pagination pattern in `src/todoist/mod.rs`, and how does the `LabelResponse::from_json` method deserialize the paginated API response? Are label create/update/delete responses paginated or do they return a single object?
+
+### Findings
+- **`all_labels()` pagination** (`src/todoist/mod.rs:359-374`): Uses a `loop` with cursor-based pagination. Default limit is `QUERY_LIMIT` (200, defined at line 44). Initial URL: `format!("{LABELS_URL}?limit={limit}")` where `LABELS_URL = "/api/v1/labels"`. Subsequent: `format!("{LABELS_URL}?limit={limit}&cursor={string}")`. Calls `request::get_todoist()` then `LabelResponse::from_json()`. Extends `labels` vec with `results`, breaks when `next_cursor` is `None`.
+- **`LabelResponse`** (`src/labels.rs:17-27`): Derives `Deserialize`. Has two fields: `results: Vec<Label>` and `next_cursor: Option<String>`. `from_json()` calls `serde_json::from_str(json)` and wraps the error in the `Error` type via `From` impl.
+- **Pattern consistency**: Identical pagination pattern used by `all_projects`, `all_sections_by_project`, `all_reminders`, `all_comments`, `all_tasks_by_project`, `all_tasks_by_filter`, `all_tasks_by_ids` — all use `Response::from_json()` → extend results → check `next_cursor`.
+- **Create/update/delete responses**: The Todoist REST API returns a **single object** for create and update (not paginated). This is the pattern used by `create_project` (`src/todoist/mod.rs:440` calls `Project::from_json(&json)`) and `create_section` (`src/todoist/mod.rs:476` calls `Section::from_json(&json)`). Delete returns 204 No Content (empty body). There is no existing label create/update/delete in the codebase.
+- **`Label` already has `from_json`** via serde Deserialize, but it's used on the individual label objects within `LabelResponse.results`. There is no standalone `Label::from_json()` method — but the `Project` and `Section` types do have such methods (`src/projects.rs:92`, `src/sections.rs`).
+
+## Q6: How are HTTP 204 No Content responses handled in `src/todoist/request.rs`'s `handle_response` function? Look at how `archive_project` and `unarchive_project` deal with 204 responses, since `DELETE /labels/{id}` also returns 204.
+
+### Findings
+- **`handle_response()`** (`src/todoist/request.rs:149-170`): The check is `status.is_success()`. For HTTP 204, `reqwest::StatusCode::is_success()` returns `true` (204 is in the 200-299 range). The function then calls `response.text().await?` which returns an empty string `""` for 204 responses. No special branching for 204 vs 200.
+- **`archive_project()`** (`src/todoist/mod.rs:459-468`): POST to `/api/v1/projects/{id}/archive`. Calls `post_todoist()`, ignores response body, returns `Ok("✓".into())`.
+- **`unarchive_project()`** (`src/todoist/mod.rs:471-480`): POST to `/api/v1/projects/{id}/unarchive`. Same pattern: ignores response, returns `Ok("✓".into())`.
+- **Test pattern for 204** (`src/todoist/mod.rs` tests, lines ~1080-1097): `test_archive_project_hits_api` and `test_unarchive_project_hits_api` use `.with_status(204)` with **no** `.with_body()` call — mockito returns an empty body by default. The test asserts `Ok("✓".to_string())`.
+- **`update_task_priority`** (`src/todoist/mod.rs:315-324`): Also handles 204 responses — POST returns 204 and the function ignores the body, returns `Ok("✓".into())`. Test at `src/todoist/mod.rs` uses `.with_status(204)` with a body provided (ignored by code).
+- **Contrast with `delete_section`** (`src/todoist/mod.rs:482-489`): Uses `delete_todoist()` (DELETE method), ignores body, returns `Ok("✓".into())`. Test mocks 200 with `.with_body("null")`, but the actual API returns 204. The code would work identically with either status since both are `is_success()`.
+- **Key insight**: The codebase already handles 204 transparently. Any DELETE function can use `delete_todoist()` and ignore the response body (empty string), returning `Ok("✓".into())` — exactly the pattern for `DELETE /labels/{id}`.
+
+## Q7: What test patterns exist for resource creation and deletion — specifically, how do `test_create_section` and `test_delete_section` in `src/todoist/mod.rs` set up mockito mocks, construct test configs, and assert results? What fixtures and response files would a label create/delete test need?
+
+### Findings
+- **`test_create_section`** (`src/todoist/mod.rs`, lines ~660-676):
+  1. Create mockito server: `let mut server = mockito::Server::new_async().await`
+  2. Mock POST: `.mock("POST", "/api/v1/sections")` with `.with_status(200)`, `.with_header("content-type", "application/json")`, `.with_body(ResponseFromFile::Section.read().await)`, `.create_async().await`
+  3. Build config: `test::fixtures::config().await.with_mock_url(server.url())`
+  4. Get fixture project: `test::fixtures::project()`
+  5. Call API: `create_section(&config, "New task", &project, false).await`
+  6. Assert: `assert_eq!(result, Ok(test::fixtures::section()))` — exact struct match
+  7. Verify: `mock.assert()` — ensures the mock was hit exactly once
+
+- **`test_delete_section`** (`src/todoist/mod.rs`, lines ~702-717):
+  1. Mock DELETE: `.mock("DELETE", "/api/v1/sections/1234")` with `.with_status(200)`, `.with_body("null")`
+  2. Config via `with_mock_url(server.url())`
+  3. Call: `delete_section(&config, "1234", false).await`
+  4. Assert: `assert_eq!(result, Ok("✓".into()))` — deletion returns checkmark string
+  5. Verify: `mock.assert()`
+
+- **Common test infrastructure**:
+  - `test::fixtures::config()` (`src/test/fixtures.rs:92-102`): Creates a Config with token, a project fixture, fixed time provider, and America/Vancouver timezone
+  - `.with_mock_url(url)` chains on Config to set the mockito server URL. This is defined on Config (likely `src/config/mod.rs`) and causes `get_base_url()` to return the mock URL.
+  - `ResponseFromFile` enum (`src/test/responses.rs:12-37`): Maps variants to `tests/responses/{variant}.json` files. Has `Label` and `Labels` variants already defined (though `Label` is `#[allow(dead_code)]` at line 27-28).
+  - `Label.json` (`tests/responses/Label.json`): Single label object, usable for create/update mock responses.
+  - `Labels.json` (`tests/responses/Labels.json`): Paginated wrapper `{"results": [...], "next_cursor": null}`, used by `test_all_labels` mock.
+  - `test::fixtures::label()` (`src/test/fixtures.rs:16-23`): Returns `Label { id: "123", name: "345", color: "red", order: None, is_favorite: false }` — already exists.
+
+- **What label create/delete tests would need**:
+  - **Create**: Mock POST `/api/v1/labels` with status 200 and body from `ResponseFromFile::Label`. Assert result equals `test::fixtures::label()`.
+  - **Delete**: Mock DELETE `/api/v1/labels/{id}` — the Todoist API returns 204. Pattern from `archive_project`: `.with_status(204)` without `.with_body()`. Assert result equals `Ok("✓".into())`.
+  - **Update**: Would need POST `/api/v1/labels/{id}` with status 200 and body from `ResponseFromFile::Label`. Assert result equals updated `test::fixtures::label()`.
+  - All fixtures (`Label.json`, `Labels.json`, `test::fixtures::label()`) already exist.
+
+## Cross-Cutting Observations
+- **Pagination pattern**: Every list endpoint uses identical cursor-based pagination: `loop { get → Response::from_json → extend results → match next_cursor }`. The `all_labels` function already implements this at `src/todoist/mod.rs:359-374`.
+- **POST for mutations**: The codebase uses POST (not PUT/PATCH) for all update operations (`update_project`, `archive_project`, `update_task_priority`, etc.) as the Todoist REST API uses POST for mutations.
+- **204 handling**: The `handle_response()` function has no special-casing for 204; empty body is returned as `""` and callers ignore it. Tests for 204 responses simply omit `.with_body()`.
+- **Config wiring**: All command handlers call `fetch_config()` which loads config, checks auth, applies CLI context, checks version, sets timezone. Config carries `args.json` and `mock_url` for test vs production routing.
+- **Error type convention**: `Error::new(source, message)` where source is a snake_case function name. The `?` operator works via `From` impls for reqwest, serde_json, io errors. Callers never pre-apply `format::*_string` coloring.
+- **JSON mode**: All interactive prompts are guarded with `if config.args.json { return Err(Error::new("json_mode", ...)) }` at the fetch_* call sites in `src/commands/mod.rs`. Commands that require user prompts (delete confirmation, import interactive) return errors in JSON mode unless `--force` or `--auto` flags bypass interaction.
+- **Spinner parameter**: API functions take a `spinner: bool` parameter. It's `true` in business-logic callers and sometimes `false` in test_all_endpoints or tests. The spinner is suppressed in test mode via `if cfg!(test)` in `maybe_start_spinner()`.
+
+## Open Areas
+- The `Label` variant in `ResponseFromFile` (`src/test/responses.rs:27-28`) is `#[allow(dead_code)]` — currently unused in tests. The enum and file already exist and are ready for use.
+- There is no `Label::from_json()` standalone method unlike `Project::from_json()` and `Section::from_json()`. For a label create API function, either a standalone `Label::from_json()` would need to be added or the deserialization handled inline (the struct already derives `Deserialize`).
+- The existing `all_labels` function at `src/todoist/mod.rs:359` takes `limit: Option<u8>` as the third parameter while `get_labels` at `src/labels.rs:33` takes only `config` and `spinner` (passes `None` for limit). There is no CLI command that currently invokes either.

--- a/.pi/qrspi/TOD-1768-label-crud/structure.md
+++ b/.pi/qrspi/TOD-1768-label-crud/structure.md
@@ -1,0 +1,97 @@
+# Structure Outline
+
+## Approach
+
+Add `tod label create`, `tod label update`, and `tod label delete` CLI commands by following the existing patterns in `project_commands`/`section_commands`. Each phase delivers a complete, testable vertical slice — from API call to CLI output — rather than building all database/API/service layers before touching the UI.
+
+---
+
+## Phase 1: `tod label create` — first vertical slice
+
+Delivers the `tod label create` command end-to-end: API call, business-logic wrapper, CLI handler, dispatch wiring, and tests at every layer. Establishes the `label_commands` module, `LabelCommands` enum, and dispatch infrastructure that Phases 2–3 build on.
+
+**Files**: `src/labels.rs`, `src/todoist/mod.rs`, `src/commands/label_commands.rs` (new), `src/commands/mod.rs`, `src/test/responses.rs`
+
+**Key changes**:
+
+- `Label::from_json(json: &str) -> Result<Label, Error>` — new standalone method on `Label`
+- `labels::create(config: &Config, name: &str, color: Option<&str>, order: Option<u32>, is_favorite: bool) -> Result<Label, Error>` — new business-logic wrapper (thin pass-through to `todoist::create_label`, spinner always `true`)
+- `todoist::create_label(config: &Config, name: &str, color: Option<&str>, order: Option<u32>, is_favorite: bool, spinner: bool) -> Result<Label, Error>` — new API function, POST to `/api/v1/labels`, returns `Label` from single-object response
+- `LabelCommands { Create(Create) }` — new subcommand enum in `label_commands.rs` (only `Create` variant in this phase)
+- `Create { name: Option<String>, color: Option<String>, order: Option<u32>, is_favorite: bool }` — new arg struct (clap `Parser`)
+- `label_commands::create(config: &Config, args: &Create, json: bool) -> Result<String, Error>` — new handler, resolves `name` via `fetch_string`, calls `labels::create`, formats output
+- `Commands::Label(LabelCommands)` — new variant with `#[clap(alias = "b")]`
+- `select_command()` match arm — `Commands::Label(command) => label_command(command, &cli, &tx).await`
+- `label_command()` — new dispatch function matching `LabelCommands::Create`
+- `mod label_commands;` + `use label_commands::LabelCommands;` — module registration
+- Remove `#[allow(dead_code)]` from `ResponseFromFile::Label` (line 27 of `src/test/responses.rs`)
+
+**Tests**:
+
+| Layer | Test | What it verifies |
+|-------|------|------------------|
+| `src/labels.rs` | `test_label_from_json_valid` | Parses single label JSON |
+| `src/labels.rs` | `test_label_from_json_invalid` | Returns error on bad JSON |
+| `src/todoist/mod.rs` | `test_create_label` | POST hits `/api/v1/labels`, returns `Label` |
+| `src/commands/label_commands.rs` | `create_fails_in_json_mode_without_name` | JSON mode + no `--name` → error |
+
+**Verify**: `cargo test` passes all four new tests. Manually: `tod label create --name "test-label" --color red` creates a real label (visible in Todoist UI), `tod label create --name "test-label" --json` returns JSON with `id`/`name`/`color`/`order`/`is_favorite`.
+
+---
+
+## Phase 2: `tod label update` and `tod label delete`
+
+Adds the remaining two commands on top of Phase 1's infrastructure. Introduces `fetch_label()` for label resolution by name/ID and the `LABEL` prompt constant. The `LabelCommands` enum grows from one variant to three.
+
+**Files**: `src/todoist/mod.rs`, `src/labels.rs`, `src/commands/label_commands.rs`, `src/commands/mod.rs`, `src/input.rs`
+
+**Key changes**:
+
+- `todoist::update_label(config: &Config, label_id: &str, name: Option<&str>, color: Option<&str>, order: Option<u32>, is_favorite: Option<bool>, spinner: bool) -> Result<Label, Error>` — POST to `/api/v1/labels/{id}`, all fields optional, returns updated `Label`
+- `todoist::delete_label(config: &Config, label_id: &str, spinner: bool) -> Result<String, Error>` — DELETE `/api/v1/labels/{id}`, returns `Ok("✓".into())`
+- `labels::update(config: &Config, label_id: &str, name: Option<&str>, color: Option<&str>, order: Option<u32>, is_favorite: Option<bool>) -> Result<Label, Error>` — thin wrapper, spinner always `true`
+- `labels::delete(config: &Config, label_id: &str) -> Result<String, Error>` — thin wrapper, spinner always `true`
+- `LabelCommands` gains `Update(Update)` and `Delete(Delete)` variants
+- `Update { label: Option<String>, name: Option<String>, color: Option<String>, order: Option<u32>, favorite: Option<bool> }` — new arg struct, at least one update field required
+- `Delete { label: Option<String>, force: bool }` — new arg struct, `--force` skips confirmation
+- `label_commands::update(config, args, json)` — fetches labels, resolves target via `fetch_label`, validates at least one update field, calls `labels::update`
+- `label_commands::delete(config, args, json)` — fetches labels, resolves target, confirmation prompt (canceled in `--force` or `--json` mode), calls `labels::delete`
+- `commands::fetch_label<'a>(arg: &str, config, labels: &[Label]) -> Result<&Label, Error>` — resolves by ID first, then name; falls back to interactive select (with JSON-mode guard)
+- `input::LABEL: &str = "Label:"` — new prompt constant in `src/input.rs`
+- `label_command()` gains `Update` and `Delete` match arms
+
+**Tests**:
+
+| Layer | Test | What it verifies |
+|-------|------|------------------|
+| `src/todoist/mod.rs` | `test_update_label` | POST hits `/api/v1/labels/123`, returns `Label` |
+| `src/todoist/mod.rs` | `test_delete_label` | DELETE hits `/api/v1/labels/123`, returns `"✓"` |
+| `src/commands/label_commands.rs` | `delete_fails_when_label_not_found` | Unknown label → `fetch_label` error |
+| `src/commands/label_commands.rs` | `delete_force_skips_confirmation` | `--force` bypasses prompt, label deleted |
+
+**Verify**: `cargo test` passes all Phase 1 + Phase 2 tests. Manually: `tod label update --label "test-label" --name "renamed"` renames a label. `tod label delete --label "renamed" --force` deletes it without confirmation. `tod label delete --label "renamed"` (interactive) shows a confirmation prompt.
+
+---
+
+## Phase 3: Docs and final verification
+
+Updates `docs/usage.md` with label command examples, runs the full pre-commit checklist, and ensures all dead-code annotations are cleaned up.
+
+**Files**: `docs/usage.md`
+
+**Key changes**:
+- New "Labels" section in `docs/usage.md`, placed after the existing "Sections" examples, following the same format with `tod label create`, `tod label update`, and `tod label delete` examples
+
+**Verify**: `scripts/test.sh` passes (fmt, build, clippy, tests, forbidden strings). `tod -h` shows `label`/`b` in command list. `tod label -h` shows all three subcommands with correct aliases.
+
+---
+
+## Testing Checkpoints
+
+After each phase, the following should be true:
+
+| Phase | Checkpoint |
+|-------|-----------|
+| 1 | `tod label create --name "test" --json` succeeds; `cargo test` passes with 4 new tests; `#[allow(dead_code)]` gone from `ResponseFromFile::Label` |
+| 2 | All three label subcommands work end-to-end; `cargo test` passes with 8 total new tests; `LABEL` constant exists in `input.rs` |
+| 3 | `scripts/test.sh` passes clean; `docs/usage.md` has label examples; `tod -h` lists the `b` alias |

--- a/.pi/qrspi/TOD-1768-label-crud/task.md
+++ b/.pi/qrspi/TOD-1768-label-crud/task.md
@@ -1,0 +1,5 @@
+# Task: Label CRUD (create, update, delete labels)
+
+Add API functions and CLI commands for creating, updating, and deleting personal labels in Todoist. Currently only label listing (`all_labels` / `GET /labels`) is supported. The Todoist REST API also supports `POST /labels` (create), `POST /labels/{id}` (update name, color, order, is_favorite), and `DELETE /labels/{id}`. The goal is to expose these operations both as internal API functions in `src/todoist/mod.rs` and as CLI subcommands (e.g. `tod label create`, `tod label update`, `tod label delete`).
+
+Ref: https://github.com/tod-org/tod/issues/1768

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -137,6 +137,22 @@ tod section delete -s "Groceries" -p "Shopping" --force
 
 # Repeat mode — keep deleting sections until Ctrl+C
 tod section delete -r
+
+# Create a label
+tod label create --name "Urgent" --color red
+
+# Create a label with favorite and order
+tod label create -n "Personal" -c blue -f -o 1
+
+# Update a label
+tod label update --label "Urgent" --name "Critical"
+tod label update -l "Personal" --color purple
+
+# Delete a label (skip confirmation)
+tod label delete --label "Critical" --force
+
+# Delete a label (interactive prompt)
+tod label delete -l "Purple"
 # Get the next task for a project
 tod task next
 

--- a/src/commands/label_commands.rs
+++ b/src/commands/label_commands.rs
@@ -7,6 +7,12 @@ pub enum LabelCommands {
     #[clap(alias = "c")]
     /// (c) Create a new personal label
     Create(Create),
+    #[clap(alias = "u")]
+    /// (u) Update an existing personal label
+    Update(Update),
+    #[clap(alias = "d")]
+    /// (d) Delete a personal label
+    Delete(Delete),
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -26,6 +32,40 @@ pub struct Create {
     #[arg(short = 'f', long, default_value_t = false)]
     /// Mark label as a favorite
     is_favorite: bool,
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct Update {
+    #[arg(short, long)]
+    /// Label to update (name or ID)
+    label: Option<String>,
+
+    #[arg(short, long)]
+    /// New name for the label
+    name: Option<String>,
+
+    #[arg(short, long)]
+    /// New color for the label
+    color: Option<String>,
+
+    #[arg(short, long)]
+    /// New display order
+    order: Option<u32>,
+
+    #[arg(short = 'f', long)]
+    /// Toggle favorite status (true or false)
+    favorite: Option<bool>,
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct Delete {
+    #[arg(short, long)]
+    /// Label to delete (name or ID)
+    label: Option<String>,
+
+    #[arg(short = 'f', long, default_value_t = false)]
+    /// Skip deletion confirmation
+    force: bool,
 }
 
 /// Creates a personal label.
@@ -49,9 +89,83 @@ pub async fn create(config: &Config, args: &Create, json: bool) -> Result<String
     }
 }
 
+/// Updates a personal label.
+pub async fn update(config: &Config, args: &Update, json: bool) -> Result<String, Error> {
+    let Update {
+        label,
+        name,
+        color,
+        order,
+        favorite,
+    } = args;
+
+    if name.is_none() && color.is_none() && order.is_none() && favorite.is_none() {
+        return Err(Error::new(
+            "update_label",
+            "At least one of --name, --color, --order, or --favorite is required",
+        ));
+    }
+
+    let labels_list = labels::get_labels(config, true).await?;
+    let target = super::fetch_label(label.as_deref(), config, &labels_list)?;
+
+    let updated = labels::update(
+        config,
+        &target.id,
+        name.as_deref(),
+        color.as_deref(),
+        *order,
+        *favorite,
+    )
+    .await?;
+    if json {
+        Ok(serde_json::to_string(&updated)?)
+    } else {
+        Ok(format::green_string(&format!(
+            "Label \"{}\" updated",
+            updated.name
+        )))
+    }
+}
+
+/// Deletes a personal label.
+pub async fn delete(config: &Config, args: &Delete, json: bool) -> Result<String, Error> {
+    let Delete { label, force } = args;
+
+    let labels_list = labels::get_labels(config, true).await?;
+    if labels_list.is_empty() {
+        return Ok("No labels found".into());
+    }
+
+    let target = super::fetch_label(label.as_deref(), config, &labels_list)?;
+
+    if !force {
+        if json {
+            return Err(Error::new("json_mode", super::JSON_INTERACTIVE_ERROR));
+        }
+        let options = vec![input::CANCEL, input::DELETE];
+        let desc = format!("Delete label \"{}\"?", target.name);
+        let result = input::select(&desc, options, config.mock_select)?;
+        if result == input::CANCEL {
+            return Ok("Cancelled".into());
+        }
+    }
+
+    labels::delete(config, &target.id).await?;
+    if json {
+        Ok(serde_json::to_string(&target)?)
+    } else {
+        Ok(format::green_string(&format!(
+            "Label \"{}\" deleted",
+            target.name
+        )))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test::responses::ResponseFromFile;
 
     #[tokio::test]
     async fn create_fails_in_json_mode_without_name() {
@@ -69,5 +183,86 @@ mod tests {
             .expect_err("creating a label without name in JSON mode should fail");
 
         assert_eq!(error.source, "json_mode");
+    }
+
+    #[tokio::test]
+    async fn update_fails_without_any_fields() {
+        let config = Config::default_test();
+        let args = Update {
+            label: Some("my-label".to_string()),
+            name: None,
+            color: None,
+            order: None,
+            favorite: None,
+        };
+
+        let error = update(&config, &args, false)
+            .await
+            .expect_err("update with no fields should fail");
+
+        assert_eq!(error.source, "update_label");
+        assert!(error.message.contains("At least one"));
+    }
+
+    #[tokio::test]
+    async fn delete_fails_when_label_not_found() {
+        let mut server = mockito::Server::new_async().await;
+
+        let labels_mock = server
+            .mock("GET", "/api/v1/labels?limit=200")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(ResponseFromFile::Labels.read().await)
+            .create_async()
+            .await;
+
+        let config = crate::test::fixtures::config().await.with_mock_url(server.url());
+
+        let args = Delete {
+            label: Some("nonexistent".to_string()),
+            force: false,
+        };
+
+        let error = delete(&config, &args, false)
+            .await
+            .expect_err("deleting a nonexistent label should fail");
+
+        assert_eq!(error.source, "fetch_label");
+        assert!(error.message.contains("not found"));
+        labels_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn delete_force_skips_confirmation() {
+        let mut server = mockito::Server::new_async().await;
+
+        let labels_mock = server
+            .mock("GET", "/api/v1/labels?limit=200")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(ResponseFromFile::Labels.read().await)
+            .create_async()
+            .await;
+
+        let delete_mock = server
+            .mock("DELETE", "/api/v1/labels/123")
+            .with_status(204)
+            .create_async()
+            .await;
+
+        let config = crate::test::fixtures::config().await.with_mock_url(server.url());
+
+        let args = Delete {
+            label: Some("345".to_string()),
+            force: true,
+        };
+
+        let result = delete(&config, &args, false)
+            .await
+            .expect("force delete should succeed");
+
+        assert!(result.contains("deleted"));
+        labels_mock.assert_async().await;
+        delete_mock.assert_async().await;
     }
 }

--- a/src/commands/label_commands.rs
+++ b/src/commands/label_commands.rs
@@ -216,7 +216,9 @@ mod tests {
             .create_async()
             .await;
 
-        let config = crate::test::fixtures::config().await.with_mock_url(server.url());
+        let config = crate::test::fixtures::config()
+            .await
+            .with_mock_url(server.url());
 
         let args = Delete {
             label: Some("nonexistent".to_string()),
@@ -250,7 +252,9 @@ mod tests {
             .create_async()
             .await;
 
-        let config = crate::test::fixtures::config().await.with_mock_url(server.url());
+        let config = crate::test::fixtures::config()
+            .await
+            .with_mock_url(server.url());
 
         let args = Delete {
             label: Some("345".to_string()),

--- a/src/commands/label_commands.rs
+++ b/src/commands/label_commands.rs
@@ -1,0 +1,73 @@
+use crate::{config::Config, errors::Error, format, input, labels};
+use clap::{Parser, Subcommand};
+
+/// Label subcommands.
+#[derive(Subcommand, Debug, Clone)]
+pub enum LabelCommands {
+    #[clap(alias = "c")]
+    /// (c) Create a new personal label
+    Create(Create),
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct Create {
+    #[arg(short, long)]
+    /// Label name
+    name: Option<String>,
+
+    #[arg(short, long)]
+    /// Color for the label (e.g. "red", "blue", "green")
+    color: Option<String>,
+
+    #[arg(short, long)]
+    /// Display order (1-based)
+    order: Option<u32>,
+
+    #[arg(short = 'f', long, default_value_t = false)]
+    /// Mark label as a favorite
+    is_favorite: bool,
+}
+
+/// Creates a personal label.
+pub async fn create(config: &Config, args: &Create, json: bool) -> Result<String, Error> {
+    let Create {
+        name,
+        color,
+        order,
+        is_favorite,
+    } = args;
+    let name = super::fetch_string(name.as_deref(), config, input::NAME)?;
+
+    let label = labels::create(config, &name, color.as_deref(), *order, *is_favorite).await?;
+    if json {
+        Ok(serde_json::to_string(&label)?)
+    } else {
+        Ok(format::green_string(&format!(
+            "Label \"{}\" created",
+            label.name
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn create_fails_in_json_mode_without_name() {
+        let mut config = Config::default_test();
+        config.args.json = true;
+        let args = Create {
+            name: None,
+            color: None,
+            order: None,
+            is_favorite: false,
+        };
+
+        let error = create(&config, &args, true)
+            .await
+            .expect_err("creating a label without name in JSON mode should fail");
+
+        assert_eq!(error.source, "json_mode");
+    }
+}

--- a/src/commands/label_commands.rs
+++ b/src/commands/label_commands.rs
@@ -54,7 +54,7 @@ pub struct Update {
 
     #[arg(short = 'f', long)]
     /// Toggle favorite status (true or false)
-    favorite: Option<bool>,
+    is_favorite: Option<bool>,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -96,17 +96,20 @@ pub async fn update(config: &Config, args: &Update, json: bool) -> Result<String
         name,
         color,
         order,
-        favorite,
+        is_favorite,
     } = args;
 
-    if name.is_none() && color.is_none() && order.is_none() && favorite.is_none() {
+    if name.is_none() && color.is_none() && order.is_none() && is_favorite.is_none() {
         return Err(Error::new(
             "update_label",
-            "At least one of --name, --color, --order, or --favorite is required",
+            "At least one of --name, --color, --order, or --is-favorite is required",
         ));
     }
 
     let labels_list = labels::get_labels(config, true).await?;
+    if labels_list.is_empty() {
+        return Ok("No labels found".into());
+    }
     let target = super::fetch_label(label.as_deref(), config, &labels_list)?;
 
     let updated = labels::update(
@@ -115,7 +118,7 @@ pub async fn update(config: &Config, args: &Update, json: bool) -> Result<String
         name.as_deref(),
         color.as_deref(),
         *order,
-        *favorite,
+        *is_favorite,
     )
     .await?;
     if json {
@@ -193,7 +196,7 @@ mod tests {
             name: None,
             color: None,
             order: None,
-            favorite: None,
+            is_favorite: None,
         };
 
         let error = update(&config, &args, false)

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -620,7 +620,10 @@ pub fn fetch_label<'a>(
     } else {
         let label_names: Vec<String> = labels.iter().map(|l| l.name.clone()).collect();
         let selected = input::select(input::LABEL, label_names, config.mock_select)?;
-        Ok(labels.iter().find(|l| l.name == selected).unwrap())
+        Ok(labels
+            .iter()
+            .find(|l| l.name == selected)
+            .expect("selected label must exist in labels slice"))
     }
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -213,6 +213,16 @@ async fn label_command(
             let result = label_commands::create(&config, args, cli.json).await;
             Ok(build_command_result(result, &config))
         }
+        LabelCommands::Update(args) => {
+            let config = fetch_config(cli, tx).await?;
+            let result = label_commands::update(&config, args, cli.json).await;
+            Ok(build_command_result(result, &config))
+        }
+        LabelCommands::Delete(args) => {
+            let config = fetch_config(cli, tx).await?;
+            let result = label_commands::delete(&config, args, cli.json).await;
+            Ok(build_command_result(result, &config))
+        }
     }
 }
 
@@ -591,6 +601,26 @@ async fn fetch_project_or_filter(
                 FlagOptions::Filter => fetch_filter(filter, config),
             }
         }
+    }
+}
+
+/// Resolves a label by ID or name from a list, or prompts interactively.
+pub fn fetch_label<'a>(
+    arg: Option<&str>,
+    config: &Config,
+    labels: &'a [labels::Label],
+) -> Result<&'a labels::Label, Error> {
+    if let Some(input) = arg {
+        labels
+            .iter()
+            .find(|l| l.id == input || l.name == input)
+            .ok_or_else(|| Error::new("fetch_label", &format!("Label \"{input}\" not found")))
+    } else if config.args.json {
+        Err(Error::new("json_mode", JSON_INTERACTIVE_ERROR))
+    } else {
+        let label_names: Vec<String> = labels.iter().map(|l| l.name.clone()).collect();
+        let selected = input::select(input::LABEL, label_names, config.mock_select)?;
+        Ok(labels.iter().find(|l| l.name == selected).unwrap())
     }
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,6 +6,7 @@ use crate::{CommandResult, input, labels};
 use auth_commands::AuthCommands;
 use clap::{Parser, Subcommand};
 use config_commands::ConfigCommands;
+use label_commands::LabelCommands;
 use list_commands::ListCommands;
 use project_commands::ProjectCommands;
 use reminder_commands::ReminderCommands;
@@ -19,6 +20,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 mod auth_commands;
 mod config_commands;
+mod label_commands;
 mod list_commands;
 mod project_commands;
 mod reminder_commands;
@@ -84,6 +86,11 @@ pub enum Commands {
     Section(SectionCommands),
 
     #[command(subcommand)]
+    #[clap(alias = "b")]
+    /// (b) Commands for managing personal labels
+    Label(LabelCommands),
+
+    #[command(subcommand)]
     #[clap(alias = "t")]
     /// (t) Commands for individual tasks
     Task(TaskCommands),
@@ -146,6 +153,7 @@ pub async fn select_command(cli: Cli, tx: UnboundedSender<Error>) -> Result<Comm
         Commands::Project(command) => project_command(command, &cli, &tx).await,
         Commands::Reminder(command) => reminder_command(command, &cli, &tx).await,
         Commands::Section(command) => section_command(command, &cli, &tx).await,
+        Commands::Label(command) => label_command(command, &cli, &tx).await,
         Commands::Shell(command) => shell_command(command, cli.json).await,
         Commands::Task(command) => task_command(command, &cli, &tx).await,
         Commands::Test(command) => test_command(command, &cli, &tx).await,
@@ -189,6 +197,20 @@ async fn section_command(
         SectionCommands::Delete(args) => {
             let config = fetch_config(cli, tx).await?;
             let result = section_commands::delete(&config, args, cli.json).await;
+            Ok(build_command_result(result, &config))
+        }
+    }
+}
+
+async fn label_command(
+    command: &LabelCommands,
+    cli: &Cli,
+    tx: &UnboundedSender<Error>,
+) -> Result<CommandResult, Error> {
+    match command {
+        LabelCommands::Create(args) => {
+            let config = fetch_config(cli, tx).await?;
+            let result = label_commands::create(&config, args, cli.json).await;
             Ok(build_command_result(result, &config))
         }
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -36,6 +36,8 @@ pub const ATTRIBUTES: &str = "Select attributes";
 pub const PROJECT: &str = "Select a project";
 /// Prompt label for label selection.
 pub const LABELS: &str = "Select labels";
+/// Prompt label for single label selection.
+pub const LABEL: &str = "Label:";
 /// Prompt label for section selection.
 pub const SECTION: &str = "Select section";
 /// Prompt label for priority selection.

--- a/src/input.rs
+++ b/src/input.rs
@@ -37,7 +37,7 @@ pub const PROJECT: &str = "Select a project";
 /// Prompt label for label selection.
 pub const LABELS: &str = "Select labels";
 /// Prompt label for single label selection.
-pub const LABEL: &str = "Label:";
+pub const LABEL: &str = "Select a label";
 /// Prompt label for section selection.
 pub const SECTION: &str = "Select section";
 /// Prompt label for priority selection.

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -72,8 +72,7 @@ mod tests {
 
     #[test]
     fn test_label_from_json_valid() {
-        let json =
-            r#"{"id":"1","name":"work","color":"red","order":1,"is_favorite":false}"#;
+        let json = r#"{"id":"1","name":"work","color":"red","order":1,"is_favorite":false}"#;
         let label = Label::from_json(json).expect("should parse label");
         assert_eq!(label.id, "1");
         assert_eq!(label.name, "work");

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -50,6 +50,21 @@ pub async fn create(
     todoist::create_label(config, name, color, order, is_favorite, true).await
 }
 
+pub async fn update(
+    config: &Config,
+    label_id: &str,
+    name: Option<&str>,
+    color: Option<&str>,
+    order: Option<u32>,
+    is_favorite: Option<bool>,
+) -> Result<Label, Error> {
+    todoist::update_label(config, label_id, name, color, order, is_favorite, true).await
+}
+
+pub async fn delete(config: &Config, label_id: &str) -> Result<String, Error> {
+    todoist::delete_label(config, label_id, true).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -24,6 +24,12 @@ impl LabelResponse {
         Ok(response)
     }
 }
+impl Label {
+    pub fn from_json(json: &str) -> Result<Label, Error> {
+        let label: Label = serde_json::from_str(json)?;
+        Ok(label)
+    }
+}
 impl Display for Label {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let name = self.name.clone();
@@ -34,10 +40,38 @@ pub async fn get_labels(config: &Config, spinner: bool) -> Result<Vec<Label>, Er
     todoist::all_labels(config, spinner, None).await
 }
 
+pub async fn create(
+    config: &Config,
+    name: &str,
+    color: Option<&str>,
+    order: Option<u32>,
+    is_favorite: bool,
+) -> Result<Label, Error> {
+    todoist::create_label(config, name, color, order, is_favorite, true).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_label_from_json_valid() {
+        let json =
+            r#"{"id":"1","name":"work","color":"red","order":1,"is_favorite":false}"#;
+        let label = Label::from_json(json).expect("should parse label");
+        assert_eq!(label.id, "1");
+        assert_eq!(label.name, "work");
+        assert_eq!(label.color, "red");
+        assert_eq!(label.order, Some(1));
+        assert!(!label.is_favorite);
+    }
+
+    #[test]
+    fn test_label_from_json_invalid() {
+        let result = Label::from_json("not json");
+        assert!(result.is_err());
+    }
 
     #[test]
     fn test_label_fmt() {

--- a/src/test/responses.rs
+++ b/src/test/responses.rs
@@ -18,7 +18,6 @@ pub enum ResponseFromFile {
     TodayTask,
     TodayTasks,
     Comment,
-    #[allow(dead_code)]
     Label,
     Labels,
     Project,

--- a/src/todoist/mod.rs
+++ b/src/todoist/mod.rs
@@ -461,6 +461,27 @@ pub async fn all_labels(
     Ok(labels)
 }
 
+/// Create a personal label.
+pub async fn create_label(
+    config: &Config,
+    name: &str,
+    color: Option<&str>,
+    order: Option<u32>,
+    is_favorite: bool,
+    spinner: bool,
+) -> Result<Label, Error> {
+    let mut body = json!({"name": name, "is_favorite": is_favorite});
+    if let Some(c) = color {
+        body["color"] = json!(c);
+    }
+    if let Some(o) = order {
+        body["order"] = json!(o);
+    }
+
+    let response = request::post_todoist(config, LABELS_URL, body, spinner).await?;
+    Label::from_json(&response)
+}
+
 /// Move a task to a different project
 pub async fn move_task_to_project(
     config: &Config,
@@ -1083,6 +1104,24 @@ mod tests {
             create_section(&config, "New task", &project, false).await,
             Ok(test::fixtures::section())
         );
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_create_label() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/api/v1/labels")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(ResponseFromFile::Label.read().await)
+            .create_async()
+            .await;
+
+        let config = test::fixtures::config().await.with_mock_url(server.url());
+
+        let result = create_label(&config, "test-label", Some("red"), None, false, false).await;
+        assert_eq!(result, Ok(test::fixtures::label()));
         mock.assert();
     }
 

--- a/src/todoist/mod.rs
+++ b/src/todoist/mod.rs
@@ -512,11 +512,7 @@ pub async fn update_label(
 }
 
 /// Delete a personal label by ID.
-pub async fn delete_label(
-    config: &Config,
-    label_id: &str,
-    spinner: bool,
-) -> Result<String, Error> {
+pub async fn delete_label(config: &Config, label_id: &str, spinner: bool) -> Result<String, Error> {
     let url = format!("{}/{}", LABELS_URL, label_id);
     request::delete_todoist(config, &url, json!({}), spinner).await?;
     Ok("✓".into())
@@ -1178,8 +1174,16 @@ mod tests {
 
         let config = test::fixtures::config().await.with_mock_url(server.url());
 
-        let result =
-            update_label(&config, "123", Some("new-name"), Some("blue"), None, None, false).await;
+        let result = update_label(
+            &config,
+            "123",
+            Some("new-name"),
+            Some("blue"),
+            None,
+            None,
+            false,
+        )
+        .await;
         assert_eq!(result, Ok(test::fixtures::label()));
         mock.assert();
     }

--- a/src/todoist/mod.rs
+++ b/src/todoist/mod.rs
@@ -482,6 +482,46 @@ pub async fn create_label(
     Label::from_json(&response)
 }
 
+/// Update a personal label by ID.
+pub async fn update_label(
+    config: &Config,
+    label_id: &str,
+    name: Option<&str>,
+    color: Option<&str>,
+    order: Option<u32>,
+    is_favorite: Option<bool>,
+    spinner: bool,
+) -> Result<Label, Error> {
+    let mut body = json!({});
+    if let Some(n) = name {
+        body["name"] = json!(n);
+    }
+    if let Some(c) = color {
+        body["color"] = json!(c);
+    }
+    if let Some(o) = order {
+        body["order"] = json!(o);
+    }
+    if let Some(f) = is_favorite {
+        body["is_favorite"] = json!(f);
+    }
+
+    let url = format!("{}/{}", LABELS_URL, label_id);
+    let response = request::post_todoist(config, &url, body, spinner).await?;
+    Label::from_json(&response)
+}
+
+/// Delete a personal label by ID.
+pub async fn delete_label(
+    config: &Config,
+    label_id: &str,
+    spinner: bool,
+) -> Result<String, Error> {
+    let url = format!("{}/{}", LABELS_URL, label_id);
+    request::delete_todoist(config, &url, json!({}), spinner).await?;
+    Ok("✓".into())
+}
+
 /// Move a task to a different project
 pub async fn move_task_to_project(
     config: &Config,
@@ -1122,6 +1162,41 @@ mod tests {
 
         let result = create_label(&config, "test-label", Some("red"), None, false, false).await;
         assert_eq!(result, Ok(test::fixtures::label()));
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_update_label() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/api/v1/labels/123")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(ResponseFromFile::Label.read().await)
+            .create_async()
+            .await;
+
+        let config = test::fixtures::config().await.with_mock_url(server.url());
+
+        let result =
+            update_label(&config, "123", Some("new-name"), Some("blue"), None, None, false).await;
+        assert_eq!(result, Ok(test::fixtures::label()));
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_delete_label() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("DELETE", "/api/v1/labels/123")
+            .with_status(204)
+            .create_async()
+            .await;
+
+        let config = test::fixtures::config().await.with_mock_url(server.url());
+
+        let result = delete_label(&config, "123", false).await;
+        assert_eq!(result, Ok("✓".into()));
         mock.assert();
     }
 


### PR DESCRIPTION
## Research Plan for Label CRUD

Research questions to explore the codebase before implementing label create, update, and delete operations.

### Artifacts
- \`.pi/qrspi/TOD-1768-label-crud/task.md\` — task description
- \`.pi/qrspi/TOD-1768-label-crud/questions.md\` — 7 neutral research questions

### Next step
Run \`/2_research .pi/qrspi/TOD-1768-label-crud/\`

Ref: #1768