### PR TITLE
design: comment update and delete API research questions

### DIFF
--- a/.pi/qrspi/PROJ-1766-comment-update-delete/design.md
+++ b/.pi/qrspi/PROJ-1766-comment-update-delete/design.md
@@ -1,0 +1,88 @@
+# Design Discussion
+
+## Current State
+
+The comment system today is create-only. What exists (all refs from `research.md`):
+
+- **Data model**: `Comment` struct in `src/comments.rs:9-18` with `id`, `content`, `posted_uid`, `posted_at`, `item_id`, `is_deleted`, `reactions`, `file_attachment`. `from_json` at line 19 deserializes from API responses.
+- **API client**: `create_comment` at `src/todoist/mod.rs:525-536` (POST `/api/v1/comments/`) and `all_comments` at line 549-578 (GET with task_id filter). No update or delete functions exist.
+- **Interactive workflow**: `process_task` at `src/tasks/mod.rs:524-583` shows `[COMPLETE, SKIP, SCHEDULE, COMMENT, REMIND, DELETE, QUIT]`. COMMENT (lines 553-557) prompts for content and spawns a create. Comments are already fetched and passed in as `comments: Vec<Comment>`.
+- **Spawn pattern**: `spawn_comment_task` at `src/tasks/mod.rs:794-801` fires a `tokio::spawn` that calls `create_comment` with `spinner: false`, forwarding errors via `config.tx()`.
+- **CLI dispatch**: `TaskCommands::Comment` at `src/commands/task_commands.rs:14-47` with alias `"m"`. Handler at lines 329-344 requires a "next" task, fetches content, calls `create_comment`, returns JSON or green string.
+- **HTTP layer**: `delete_todoist` at `src/todoist/request.rs:108-138` exists and is used only by `delete_task`. `handle_response` at lines 197-231 treats all 2xx identically — 204 returns `Ok("")`.
+- **Tests**: `create_comment` test at `src/todoist/mod.rs:713-726` mocks POST with `ResponseFromFile::Comment`. Test fixtures: `tests/responses/Comment.json` (single), `tests/responses/CommentsAllTypes.json` (8 variants). No comment mutation test fixtures.
+
+## Desired End State
+
+Users can **edit** and **delete** comments both from the interactive task processing loop and from the CLI. Verification:
+
+1. **`update_comment`** in `src/todoist/mod.rs` — POST `/api/v1/comments/{id}` with new content, returns parsed `Comment`. Test covers happy path with mock fixture.
+2. **`delete_comment`** in `src/todoist/mod.rs` — DELETE `/api/v1/comments/{id}`, returns `Ok("✓")`. Test covers 204 No Content response.
+3. **Interactive submenu**: Selecting COMMENT in `process_task` shows existing comments (formatted one-liners) + "New comment" option. Selecting an existing comment shows Edit/Delete/Back.
+4. **Spawn functions**: `spawn_update_comment` and `spawn_delete_comment` follow the existing `spawn_*` pattern with error forwarding.
+5. **CLI commands**: `TaskCommands::EditComment` (alias TBD) and `TaskCommands::DeleteComment` (alias TBD) with args structs, handlers in `src/commands/task_commands.rs`, and dispatch arms in `src/commands/mod.rs`.
+6. **`docs/usage.md`** updated with new command examples.
+
+## Patterns to Follow
+
+### ✅ Good patterns (match these)
+
+| Pattern | Reference | Notes |
+|---|---|---|
+| Single-field POST body with `json!({...})` | `src/todoist/mod.rs:368` (`update_task_content`) | Use for `update_comment` body: `json!({"content": new_content})` |
+| Parse response into type | `src/todoist/mod.rs:528-536` (`create_comment`) | `update_comment` returns `Result<Comment, Error>` |
+| Discard response, return `"✓"` | `src/todoist/mod.rs:416-421` (`delete_task`) | `delete_comment` returns `Result<String, Error>` |
+| URL: `format!("{COMMENTS_URL}{id}")` | `src/todoist/mod.rs:370` (task pattern) | Simple resource URL, no sub-path |
+| `delete_todoist` for DELETE endpoints | `src/todoist/mod.rs:416` | Already wired through `handle_response`, handles 204 |
+| `spinner: bool` parameter | All API functions in `src/todoist/mod.rs` | `true` for CLI, `false` for spawned background ops |
+| Spawn with error channel | `src/tasks/mod.rs:794-801` (`spawn_comment_task`) | `tokio::spawn` + `config.tx().send(e)` on error |
+| `input::select` for picking from list | `src/tasks/mod.rs:548` (options menu) | Use for comment selection and edit/delete submenu |
+| `fetch_string` for CLI-or-prompt content | `src/commands/mod.rs:393-403` | `EditComment` handler uses this for new content |
+| `#[derive(Parser)]` args struct + handler fn | `src/commands/task_commands.rs:118-122, 329-344` | New `EditComment` and `DeleteComment` structs + handlers |
+| Mock with `mockito::Server`, `ResponseFromFile` | `src/todoist/mod.rs:713-726` | Tests for both new API functions |
+| `// Does not pass back a task` comment | `src/todoist/mod.rs:370` | Use `// Does not pass back a comment` for delete |
+
+### ❌ Patterns to avoid
+
+| Pattern | Reference | Why avoid |
+|---|---|---|
+| `HashMap<String, Value>` for single-field updates | `src/todoist/mod.rs:163-190` (`create_task`) | Over-engineered for single-field updates; use `json!({...})` |
+| Pre-applying `format::*_string` in error messages | `src/errors.rs` Display impl | The Display impl owns coloring; callers must not pre-color |
+
+## Design Decisions
+
+1. **COMMENT submenu UX**: When COMMENT is selected in `process_task`, show a submenu: existing comments (formatted as one-line summaries via `input::select`) + a "New comment" entry. If "New comment" → prompt for content → spawn create. If existing comment selected → sub-submenu with Edit / Delete / Back.
+
+2. **`update_comment` returns `Comment`**: Parse the API response into the `Comment` struct (Pattern A), matching `create_comment` at `src/todoist/mod.rs:528-536`. This enables JSON output in CLI mode. **Risk**: the Todoist API response shape for comment update is unconfirmed from the codebase — flag for manual live testing after implementation.
+
+3. **`delete_comment` uses `delete_todoist`, expects 204**: Follow the `delete_task` pattern at `src/todoist/mod.rs:416-421`. Call `delete_todoist`, discard the empty response, return `Ok("✓")`. `handle_response` at `src/todoist/request.rs:208-211` already handles 204 gracefully.
+
+4. **New `TaskCommands` variants**: Add `EditComment` (with `comment_id` and `content` args) and `DeleteComment` (with `comment_id` arg) to the `TaskCommands` enum at `src/commands/task_commands.rs:14-47`. Each gets a handler function and a dispatch arm in `task_command`. Single-letter aliases TBD that don't collide with existing: `c` (Create), `e` (Edit), `n` (Next), `o` (Complete), `m` (Comment).
+
+5. **Comment selection via `input::select`**: Format each comment as `"{content_truncated} — {posted_at}"` (first ~60 chars of content) and use the existing `input::select` pattern (`src/input.rs:37`). Consistent with how tasks, projects, and labels are selected throughout the interactive workflow. No ownership filtering.
+
+6. **No confirmation for delete**: Deleting a task in `process_task` (`src/tasks/mod.rs:552`) is immediate with no confirmation prompt. Delete comment follows the same pattern for consistency.
+
+7. **Content prompt for edit reuses `input::CONTENT`**: When editing a comment, prompt for new content using the existing `input::string(input::CONTENT, ...)` constant (`src/input.rs:11`), same as comment creation.
+
+8. **Spawn for interactive, direct for CLI**: In the interactive workflow, comment update/delete use `tokio::spawn` with error forwarding (matching `spawn_comment_task`). In CLI handlers, calls are awaited directly with `spinner: true` (matching the existing `comment` handler at `src/commands/task_commands.rs:334`).
+
+## What We're NOT Doing
+
+- **No comment reactions management** — the `reactions` field on `Comment` is read-only through this feature
+- **No file attachment editing** — attachments are immutable after creation
+- **No batch comment operations** — edit/delete one comment at a time
+- **No comment search or filtering** — selection is limited to the comments already fetched for the current task
+- **No ownership-based filtering** — the backend enforces authorization; we don't pre-filter by `posted_uid`
+- **No comment edit/delete in `timebox_task`** — `timebox_task` at `src/tasks/mod.rs:417-452` has its own menu; out of scope
+- **No comment edit via `update_task`** — the attribute editing loop at `src/tasks/mod.rs:445-492` doesn't handle comments
+
+## Open Risks
+
+- **`update_comment` response shape unconfirmed**: The codebase has no existing comment-update call to learn from. The Todoist REST API may return the full `Comment` object (assumed), a subset, or 204 with no body. Must be verified with a live API call after implementation. If the shape differs, the `from_json` deserialization will fail at runtime.
+
+- **Comment ownership enforcement**: The Todoist API may reject (403/404) attempts to edit or delete comments posted by other users. `handle_response` at `src/todoist/request.rs:212-216` treats 401/403 as auth errors and prompts re-login — if the API returns 403 for ownership failures, the error message will be misleading ("Run 'tod auth login' to reauthenticate").
+
+- **CLI alias collisions**: `TaskCommands` aliases are single letters. Existing: `q` (QuickAdd), `c` (Create), `e` (Edit), `n` (Next), `o` (Complete), `m` (Comment). Available single letters are limited. If no clean alias fits, skip the alias for the new commands.
+
+- **Empty comments list edge case**: If the task has no comments, the COMMENT submenu should skip straight to "New comment" prompt rather than showing an empty select list. This avoids an extra keystroke for the common case.

--- a/.pi/qrspi/PROJ-1766-comment-update-delete/plan.md
+++ b/.pi/qrspi/PROJ-1766-comment-update-delete/plan.md
@@ -104,9 +104,9 @@ async fn test_delete_comment() {
 
 ### Verification
 #### Automated
-- [ ] `cargo test update_comment delete_comment` passes
-- [ ] `cargo test test_update_comment -- --nocapture` — `update_comment` returns parsed `Comment` matching `Comment.json` fixture
-- [ ] `cargo test test_delete_comment -- --nocapture` — `delete_comment` returns `"✓"` on 204
+- [x] `cargo test update_comment delete_comment` passes
+- [x] `cargo test test_update_comment -- --nocapture` — `update_comment` returns parsed `Comment` matching `Comment.json` fixture
+- [x] `cargo test test_delete_comment -- --nocapture` — `delete_comment` returns `"✓"` on 204
 
 #### Manual
 - [ ] (After full implementation) `tod task edit-comment <real_id> "test"` against live API to confirm response shape

--- a/.pi/qrspi/PROJ-1766-comment-update-delete/plan.md
+++ b/.pi/qrspi/PROJ-1766-comment-update-delete/plan.md
@@ -385,14 +385,14 @@ Then use these constants in the COMMENT arm instead of string literals.
 
 ### Verification
 #### Automated
-- [ ] `cargo test process_task` passes — existing tests still green with upgraded mock_select infrastructure
-- [ ] `cargo test spawn_update_comment spawn_delete_comment` passes (if unit-testing spawn functions — note: they fire-and-forget so it's hard to assert; rely on integration-level process_task tests)
-- [ ] New tests for COMMENT submenu flows:
-  - [ ] Empty comments: `mock_selects(vec![3])` + `mock_string("test")` → spawns create (COMMENT at index 3 in process menu)
-  - [ ] One comment + "New comment" selected: `mock_selects(vec![3, 1])` + `mock_string("new")` → spawns create (index 1 = "New comment" in comment list)
-  - [ ] One comment → Edit: `mock_selects(vec![3, 0, 0])` + `mock_string("updated")` → spawns update (index 0 = existing comment, then index 0 = Edit)
-  - [ ] One comment → Delete: `mock_selects(vec![3, 0, 1])` → spawns delete (index 0 = existing comment, then index 1 = Delete)
-  - [ ] One comment → Back: `mock_selects(vec![3, 0, 2])` → returns no-op spawn (index 0 = existing comment, then index 2 = Back)
+- [x] `cargo test process_task` passes — existing tests still green with upgraded mock_select infrastructure
+- [x] `cargo test spawn_update_comment spawn_delete_comment` passes (if unit-testing spawn functions — note: they fire-and-forget so it's hard to assert; rely on integration-level process_task tests)
+- [x] New tests for COMMENT submenu flows:
+  - [x] Empty comments: `mock_selects(vec![3])` + `mock_string("test")` → spawns create (COMMENT at index 3 in process menu)
+  - [x] One comment + "New comment" selected: `mock_selects(vec![3, 1])` + `mock_string("new")` → spawns create (index 1 = "New comment" in comment list)
+  - [x] One comment → Edit: `mock_selects(vec![3, 0, 0])` + `mock_string("updated")` → spawns update (index 0 = existing comment, then index 0 = Edit)
+  - [x] One comment → Delete: `mock_selects(vec![3, 0, 1])` → spawns delete (index 0 = existing comment, then index 1 = Delete)
+  - [x] One comment → Back: `mock_selects(vec![3, 0, 2])` → returns no-op spawn (index 0 = existing comment, then index 2 = Back)
 
 #### Manual
 - [ ] `tod list process` → hit COMMENT on a task with comments → see formatted one-liners, select one, edit/delete it

--- a/.pi/qrspi/PROJ-1766-comment-update-delete/plan.md
+++ b/.pi/qrspi/PROJ-1766-comment-update-delete/plan.md
@@ -109,7 +109,7 @@ async fn test_delete_comment() {
 - [x] `cargo test test_delete_comment -- --nocapture` — `delete_comment` returns `"✓"` on 204
 
 #### Manual
-- [ ] (After full implementation) `tod task edit-comment <real_id> "test"` against live API to confirm response shape
+- [x] (After full implementation) `tod task edit-comment <real_id> "test"` against live API to confirm response shape
 
 ---
 
@@ -395,9 +395,9 @@ Then use these constants in the COMMENT arm instead of string literals.
   - [x] One comment → Back: `mock_selects(vec![3, 0, 2])` → returns no-op spawn (index 0 = existing comment, then index 2 = Back)
 
 #### Manual
-- [ ] `tod list process` → hit COMMENT on a task with comments → see formatted one-liners, select one, edit/delete it
-- [ ] Task with no comments → COMMENT → goes straight to content prompt
-- [ ] Select "Back" → returns to task process loop
+- [x] `tod list process` → hit COMMENT on a task with comments → see formatted one-liners, select one, edit/delete it
+- [x] Task with no comments → COMMENT → goes straight to content prompt
+- [x] Select "Back" → returns to task process loop
 
 ---
 
@@ -619,18 +619,18 @@ async fn delete_comment_json_output() {
 
 ### Verification
 #### Automated
-- [ ] `cargo test edit_comment delete_comment` passes — all 5 new tests green
-- [ ] `cargo test test_update_comment test_delete_comment` — Phase 1 tests still green
-- [ ] `cargo test process_task` — Phase 2 tests still green
-- [ ] `scripts/test.sh` passes (format, clippy, no forbidden strings)
+- [x] `cargo test edit_comment delete_comment` passes — all 5 new tests green
+- [x] `cargo test test_update_comment test_delete_comment` — Phase 1 tests still green
+- [x] `cargo test process_task` — Phase 2 tests still green
+- [x] `scripts/test.sh` passes (format, clippy, no forbidden strings)
 
 #### Manual
-- [ ] `tod task edit-comment <real_comment_id> "updated text"` → success message
-- [ ] `tod task delete-comment <real_comment_id>` → success message
-- [ ] `tod task edit-comment <real_comment_id> --json "updated text"` → JSON output with comment object
-- [ ] `tod task delete-comment <real_comment_id> --json` → `"✓"`
-- [ ] `tod task edit-comment <real_comment_id> --json` (no content) → errors with `json_mode` source
-- [ ] `tod t ec <id> "text"` and `tod t dc <id>` — aliases work
+- [x] `tod task edit-comment <real_comment_id> "updated text"` → success message
+- [x] `tod task delete-comment <real_comment_id>` → success message
+- [x] `tod task edit-comment <real_comment_id> --json "updated text"` → JSON output with comment object
+- [x] `tod task delete-comment <real_comment_id> --json` → `"✓"`
+- [x] `tod task edit-comment <real_comment_id> --json` (no content) → errors with `json_mode` source
+- [x] `tod t ec <id> "text"` and `tod t dc <id>` — aliases work
 - [ ] Verify in Todoist UI that edited content appears / comment is deleted
 
 ---
@@ -672,11 +672,11 @@ Also update the `tod task -h` help output block earlier in the doc (around line 
 
 ### Verification
 #### Automated
-- [ ] `scripts/test.sh` passes — full pipeline (format, build, clippy, tests, forbidden strings)
-- [ ] `grep -A3 "edit-comment\|delete-comment" docs/usage.md` — confirms docs mention new commands
+- [x] `scripts/test.sh` passes — full pipeline (format, build, clippy, tests, forbidden strings)
+- [x] `grep -A3 "edit-comment\|delete-comment" docs/usage.md` — confirms docs mention new commands
 
 #### Manual
-- [ ] Review `docs/usage.md` for accuracy of examples
+- [x] Review `docs/usage.md` for accuracy of examples
 
 ---
 

--- a/.pi/qrspi/PROJ-1766-comment-update-delete/plan.md
+++ b/.pi/qrspi/PROJ-1766-comment-update-delete/plan.md
@@ -1,0 +1,707 @@
+# Implementation Plan
+
+## Overview
+
+Add `update_comment` and `delete_comment` to the Todoist API client, then expose them through the interactive `process_task` COMMENT submenu and new CLI subcommands (`edit-comment`, `delete-comment`).
+
+---
+
+## Phase 1: API client — `update_comment` and `delete_comment`
+
+### Changes
+
+#### 1. Add `update_comment` function
+**File**: `src/todoist/mod.rs`
+**Action**: modify — insert after `create_comment` (after line 536)
+
+```rust
+/// Updates the content of a comment by ID.
+pub async fn update_comment(
+    config: &Config,
+    comment_id: &str,
+    content: &str,
+    spinner: bool,
+) -> Result<Comment, Error> {
+    let body = json!({"content": content});
+    let url = format!("{COMMENTS_URL}{comment_id}");
+
+    let response = request::post_todoist(config, &url, body, spinner).await?;
+    Comment::from_json(&response)
+}
+```
+
+#### 2. Add `delete_comment` function
+**File**: `src/todoist/mod.rs`
+**Action**: modify — insert after `update_comment`
+
+```rust
+/// Deletes a comment by ID. The Todoist API returns 204 No Content.
+pub async fn delete_comment(
+    config: &Config,
+    comment_id: &str,
+    spinner: bool,
+) -> Result<String, Error> {
+    let url = format!("{COMMENTS_URL}{comment_id}");
+
+    request::delete_todoist(config, &url, json!({}), spinner).await?;
+    // Does not pass back a comment
+    Ok("✓".into())
+}
+```
+
+#### 3. Add tests for both functions
+**File**: `src/todoist/mod.rs`
+**Action**: modify — add tests in the `#[cfg(test)] mod tests` block
+
+Location: after the existing `test_create_comment` test (around line 726).
+
+```rust
+#[tokio::test]
+async fn test_update_comment() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/api/v1/comments/123")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(ResponseFromFile::Comment.read().await)
+        .create_async()
+        .await;
+
+    let config = test::fixtures::config()
+        .await
+        .with_mock_url(server.url());
+
+    let comment = update_comment(&config, "123", "updated content", false)
+        .await
+        .expect("expected value or result, got None or Err");
+
+    assert_eq!(comment.id, "2992679862");
+    assert_eq!(comment.content, "Need one bottle of milk");
+    mock.assert();
+}
+
+#[tokio::test]
+async fn test_delete_comment() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("DELETE", "/api/v1/comments/123")
+        .with_status(204)
+        .create_async()
+        .await;
+
+    let config = test::fixtures::config()
+        .await
+        .with_mock_url(server.url());
+
+    let result = delete_comment(&config, "123", false)
+        .await
+        .expect("expected value or result, got None or Err");
+
+    assert_eq!(result, "✓");
+    mock.assert();
+}
+```
+
+### Verification
+#### Automated
+- [ ] `cargo test update_comment delete_comment` passes
+- [ ] `cargo test test_update_comment -- --nocapture` — `update_comment` returns parsed `Comment` matching `Comment.json` fixture
+- [ ] `cargo test test_delete_comment -- --nocapture` — `delete_comment` returns `"✓"` on 204
+
+#### Manual
+- [ ] (After full implementation) `tod task edit-comment <real_id> "test"` against live API to confirm response shape
+
+---
+
+## Phase 2: Interactive comment submenu in `process_task`
+
+### Changes
+
+#### 1. Upgrade `mock_select` to support sequences
+**File**: `src/config/mod.rs`
+**Action**: modify
+
+Change the `mock_select` field from `Option<usize>` to `RefCell<Vec<usize>>` so tests can drive multiple sequential `input::select` calls. Skip serialization since this is test-only.
+
+**Struct field change** (line 91):
+```rust
+// Before:
+pub mock_select: Option<usize>,
+// After:
+#[serde(skip)]
+pub mock_select: RefCell<Vec<usize>>,
+```
+
+Add `use std::cell::RefCell;` to imports at top of file.
+
+**Default value change** (line 456, in `Default` impl):
+```rust
+// Before:
+mock_select: None,
+// After:
+mock_select: RefCell::new(Vec::new()),
+```
+
+**Test Config builder change** (lines 732-736, in test `Config::default_test`):
+```rust
+// Before:
+mock_select: None,
+// After:
+mock_select: RefCell::new(Vec::new()),
+```
+
+**Test Config builder change** (lines 788-789, in test `Config::default_test` no-config variant):
+```rust
+// Before:
+mock_select: None,
+// After:
+mock_select: RefCell::new(Vec::new()),
+```
+
+**Builder method** (lines 814-817): change to accept `Vec<usize>`:
+```rust
+pub fn mock_selects(self, selects: Vec<usize>) -> Config {
+    Config {
+        mock_select: RefCell::new(selects),
+        ..self
+    }
+}
+```
+
+Also add a single-value convenience:
+```rust
+pub fn mock_select(self, index: usize) -> Config {
+    Config {
+        mock_select: RefCell::new(vec![index]),
+        ..self
+    }
+}
+```
+
+**`mock_select` field omission** in struct destructuring patterns throughout config/mod.rs — wherever `mock_select` appears in a destructure (like line 551), replace usage with `&self.mock_select`.
+
+**File**: `src/input.rs`
+**Action**: modify
+
+Change `select` and `select_with_cursor_index` to accept `&RefCell<Vec<usize>>` instead of `Option<usize>`. Add `use std::cell::RefCell;` to imports.
+
+```rust
+pub fn select<T: Display>(
+    desc: &str,
+    options: Vec<T>,
+    mock_selects: &RefCell<Vec<usize>>,
+) -> Result<T, Error> {
+    select_with_cursor_index(desc, options, 0, mock_selects)
+}
+
+pub fn select_with_cursor_index<T: Display>(
+    desc: &str,
+    options: Vec<T>,
+    cursor_index: usize,
+    mock_selects: &RefCell<Vec<usize>>,
+) -> Result<T, Error> {
+    if cfg!(test) {
+        let mut selects = mock_selects.borrow_mut();
+        if selects.is_empty() {
+            panic!("mock_select ran out of values — need more entries for this test");
+        }
+        let index = selects.remove(0);
+        Ok(options
+            .into_iter()
+            .nth(index)
+            .expect("Must provide a vector of options"))
+    } else {
+        Select::new(desc, options)
+            .with_page_size(page_size() / 2)
+            .with_starting_cursor(cursor_index)
+            .prompt()
+            .map_err(Error::from)
+    }
+}
+```
+
+**File**: `src/input.rs` — `multi_select`
+**Action**: modify — same signature change from `Option<usize>` to `&RefCell<Vec<usize>>`, pop one value.
+
+**All callers** of `input::select`, `input::select_with_cursor_index`, `input::multi_select`:
+**Action**: modify — change argument from `config.mock_select` to `&config.mock_select`. Affected files:
+- `src/tasks/mod.rs` (8 call sites)
+- `src/lists.rs` (8 call sites)
+- `src/sections.rs` (2 call sites)
+- `src/config/mod.rs` (internal `input::bool` calls also use mock_select — these need updating too)
+
+For `input::bool` (in `src/input.rs`): change `mock_select: Option<usize>` param to `mock_selects: &RefCell<Vec<usize>>`, pop one value.
+
+**Test code** using `.mock_select(N)` — these continue to work because `.mock_select(3)` now wraps as `RefCell::new(vec![3])`. For tests needing multiple selects, use `.mock_selects(vec![3, 0, 1])`.
+
+#### 2. Add `format_comment_option` helper
+**File**: `src/tasks/mod.rs`
+**Action**: modify — add function near `spawn_comment_task`
+
+```rust
+/// Formats a comment as a one-line summary for display in select menus.
+fn format_comment_option(comment: &Comment, config: &Config) -> String {
+    let truncated = if comment.content.len() > 60 {
+        format!("{}…", &comment.content[..60])
+    } else {
+        comment.content.clone()
+    };
+    // Use a simple date parse (timezone not critical for a selection label)
+    match time::parse_and_format_posted_at(&comment.posted_at, config) {
+        Ok(formatted) => format!("{truncated} — {formatted}"),
+        Err(_) => format!("{truncated} — {}", &comment.posted_at[..10]),
+    }
+}
+```
+
+Note: check what `time::` functions are available for formatting `posted_at`. The `Comment::fmt` method uses `time::datetime_from_str` + `time::datetime_to_string`. Use `time::naive_datetime_from_str` (or equivalent) for a simpler parse. If no simple function exists, inline: parse the date portion `&comment.posted_at[..10]` and use that directly.
+
+**Adjustment**: look at how `Comment::fmt` in `src/comments.rs:105+` formats the date. Use the same pattern:
+```rust
+fn format_comment_option(comment: &Comment, config: &Config) -> String {
+    let truncated = if comment.content.len() > 60 {
+        format!("{}…", &comment.content[..60])
+    } else {
+        comment.content.clone()
+    };
+    let formatted_date = time::datetime_from_str(&comment.posted_at, time::timezone_from_str("UTC").unwrap())
+        .map(|dt| time::datetime_to_string(&dt, config).unwrap_or_default())
+        .unwrap_or_else(|_| comment.posted_at[..10].to_string());
+    format!("{truncated} — {formatted_date}")
+}
+```
+
+#### 3. Add `spawn_update_comment` and `spawn_delete_comment`
+**File**: `src/tasks/mod.rs`
+**Action**: modify — add after `spawn_comment_task` (line 801)
+
+```rust
+/// Updates a comment inside another thread
+pub fn spawn_update_comment(config: Config, comment_id: String, content: String) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        if let Err(e) = todoist::update_comment(&config, &comment_id, &content, false).await {
+            let _ = config.tx().send(e);
+        }
+    })
+}
+
+/// Deletes a comment inside another thread
+pub fn spawn_delete_comment(config: Config, comment_id: String) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        if let Err(e) = todoist::delete_comment(&config, &comment_id, false).await {
+            let _ = config.tx().send(e);
+        }
+    })
+}
+```
+
+#### 4. Rewrite COMMENT arm in `process_task`
+**File**: `src/tasks/mod.rs`
+**Action**: modify — replace lines 553-557 (the current COMMENT match arm) with the full submenu logic:
+
+```rust
+input::COMMENT => {
+    if comments.is_empty() {
+        // No existing comments — go straight to new comment prompt
+        let content = input::string(CONTENT, config.mock_string.clone())?;
+        return Ok(Some(spawn_comment_task(config.clone(), task.id, content)));
+    }
+
+    // Build options: each existing comment + "New comment"
+    let mut comment_options: Vec<String> = comments
+        .iter()
+        .map(|c| format_comment_option(c, config))
+        .collect();
+    comment_options.push("New comment".to_string());
+
+    let selected = input::select(
+        "Select a comment",
+        comment_options,
+        &config.mock_select,
+    )?;
+
+    if selected == "New comment" {
+        let content = input::string(CONTENT, config.mock_string.clone())?;
+        return Ok(Some(spawn_comment_task(config.clone(), task.id, content)));
+    }
+
+    // User picked an existing comment — find it by matching the formatted string
+    let comment_index = comment_options
+        .iter()
+        .position(|opt| *opt == selected)
+        .expect("selected option must exist");
+    let comment = &comments[comment_index];
+
+    // Sub-submenu: Edit / Delete / Back
+    let action_options = vec!["Edit", "Delete", "Back"];
+    let action = input::select(
+        "Choose an action",
+        action_options,
+        &config.mock_select,
+    )?;
+
+    match action {
+        "Edit" => {
+            let content = input::string(CONTENT, config.mock_string.clone())?;
+            Ok(Some(spawn_update_comment(
+                config.clone(),
+                comment.id.clone(),
+                content,
+            )))
+        }
+        "Delete" => Ok(Some(spawn_delete_comment(
+            config.clone(),
+            comment.id.clone(),
+        ))),
+        "Back" => {
+            // Recurse to show comment list again (loop)
+            // Use a simple approach: return a skip handle to avoid nesting
+            Ok(Some(tokio::spawn(async move {})))
+        }
+        _ => unreachable!(),
+    }
+}
+```
+
+Note: The "Back" option returns a no-op spawn handle rather than recursively calling `process_task` to keep the control flow simple. The caller (`process` in `src/lists.rs`) continues iterating, and the user can select COMMENT again on the next iteration.
+
+#### 5. Add comment option constants
+**File**: `src/input.rs`
+**Action**: modify — add comment submenu constants (optional; strings can be inline since they're only used once):
+
+If adding constants, insert near line 43-63 alongside existing option constants:
+```rust
+/// Comment submenu option: edit.
+pub const EDIT_COMMENT: &str = "Edit";
+/// Comment submenu option: delete.
+pub const DELETE_COMMENT: &str = "Delete";
+/// Comment submenu option: go back.
+pub const BACK: &str = "Back";
+/// Comment submenu option: create new comment.
+pub const NEW_COMMENT: &str = "New comment";
+```
+
+Then use these constants in the COMMENT arm instead of string literals.
+
+### Verification
+#### Automated
+- [ ] `cargo test process_task` passes — existing tests still green with upgraded mock_select infrastructure
+- [ ] `cargo test spawn_update_comment spawn_delete_comment` passes (if unit-testing spawn functions — note: they fire-and-forget so it's hard to assert; rely on integration-level process_task tests)
+- [ ] New tests for COMMENT submenu flows:
+  - [ ] Empty comments: `mock_selects(vec![3])` + `mock_string("test")` → spawns create (COMMENT at index 3 in process menu)
+  - [ ] One comment + "New comment" selected: `mock_selects(vec![3, 1])` + `mock_string("new")` → spawns create (index 1 = "New comment" in comment list)
+  - [ ] One comment → Edit: `mock_selects(vec![3, 0, 0])` + `mock_string("updated")` → spawns update (index 0 = existing comment, then index 0 = Edit)
+  - [ ] One comment → Delete: `mock_selects(vec![3, 0, 1])` → spawns delete (index 0 = existing comment, then index 1 = Delete)
+  - [ ] One comment → Back: `mock_selects(vec![3, 0, 2])` → returns no-op spawn (index 0 = existing comment, then index 2 = Back)
+
+#### Manual
+- [ ] `tod list process` → hit COMMENT on a task with comments → see formatted one-liners, select one, edit/delete it
+- [ ] Task with no comments → COMMENT → goes straight to content prompt
+- [ ] Select "Back" → returns to task process loop
+
+---
+
+## Phase 3: CLI subcommands — `edit-comment` and `delete-comment`
+
+### Changes
+
+#### 1. Add `EditComment` and `DeleteComment` args structs
+**File**: `src/commands/task_commands.rs`
+**Action**: modify — add after existing `Comment` struct (line 47)
+
+```rust
+#[derive(Parser, Debug, Clone)]
+/// (ec) Edit an existing comment's content
+pub struct EditComment {
+    /// ID of the comment to edit
+    comment_id: String,
+
+    /// New content for the comment
+    content: Option<String>,
+}
+
+#[derive(Parser, Debug, Clone)]
+/// (dc) Delete a comment by ID
+pub struct DeleteComment {
+    /// ID of the comment to delete
+    comment_id: String,
+}
+```
+
+#### 2. Add variants to `TaskCommands` enum
+**File**: `src/commands/task_commands.rs`
+**Action**: modify — add before the closing `}` of `TaskCommands` enum (line 47):
+
+```rust
+#[clap(alias = "ec")]
+/// (ec) Edit an existing comment's content
+EditComment(EditComment),
+
+#[clap(alias = "dc")]
+/// (dc) Delete a comment by ID
+DeleteComment(DeleteComment),
+```
+
+#### 3. Add handler functions
+**File**: `src/commands/task_commands.rs`
+**Action**: modify — add after the `comment` handler function (line 344):
+
+```rust
+/// Edits the content of an existing comment by ID.
+pub async fn edit_comment(
+    config: Config,
+    args: &EditComment,
+    json: bool,
+) -> Result<String, Error> {
+    let EditComment {
+        comment_id,
+        content,
+    } = args;
+
+    let content = super::fetch_string(content.as_deref(), &config, input::CONTENT)?;
+    let comment = todoist::update_comment(&config, comment_id, &content, true).await?;
+
+    if json {
+        Ok(serde_json::to_string(&comment)?)
+    } else {
+        Ok(format::green_string("Comment updated successfully"))
+    }
+}
+
+/// Deletes a comment by ID.
+pub async fn delete_comment(
+    config: Config,
+    args: &DeleteComment,
+    json: bool,
+) -> Result<String, Error> {
+    let result = todoist::delete_comment(&config, &args.comment_id, true).await?;
+
+    if json {
+        Ok(serde_json::to_string(&result)?)
+    } else {
+        Ok(format::green_string("Comment deleted successfully"))
+    }
+}
+```
+
+#### 4. Add dispatch arms in `task_command`
+**File**: `src/commands/mod.rs`
+**Action**: modify — add after the `TaskCommands::Comment` arm (lines 287-291):
+
+```rust
+TaskCommands::EditComment(args) => {
+    let config = fetch_config(cli, tx).await?;
+    let result = task_commands::edit_comment(config.clone(), args, cli.json).await;
+    Ok(build_command_result(result, &config))
+}
+TaskCommands::DeleteComment(args) => {
+    let config = fetch_config(cli, tx).await?;
+    let result = task_commands::delete_comment(config.clone(), args, cli.json).await;
+    Ok(build_command_result(result, &config))
+}
+```
+
+#### 5. Add tests
+**File**: `src/commands/task_commands.rs`
+**Action**: modify — add tests in the `#[cfg(test)] mod tests` block, after existing tests:
+
+```rust
+#[tokio::test]
+async fn edit_comment_happy_path() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/api/v1/comments/123")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(ResponseFromFile::Comment.read().await)
+        .create_async()
+        .await;
+
+    let config = test::fixtures::config()
+        .await
+        .with_mock_url(server.url());
+
+    let args = EditComment {
+        comment_id: "123".to_string(),
+        content: Some("new content".to_string()),
+    };
+    let result = edit_comment(config, &args, false).await;
+    assert!(result.is_ok(), "edit_comment should succeed; got: {result:?}");
+    assert!(result.unwrap().contains("Comment updated successfully"));
+    mock.assert();
+}
+
+#[tokio::test]
+async fn edit_comment_json_output() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/api/v1/comments/123")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(ResponseFromFile::Comment.read().await)
+        .create_async()
+        .await;
+
+    let config = test::fixtures::config()
+        .await
+        .with_mock_url(server.url());
+
+    let args = EditComment {
+        comment_id: "123".to_string(),
+        content: Some("new content".to_string()),
+    };
+    let result = edit_comment(config, &args, true).await;
+    assert!(result.is_ok());
+    let json = result.unwrap();
+    assert!(json.contains("\"id\""));
+    assert!(json.contains("2992679862"));
+    mock.assert();
+}
+
+#[tokio::test]
+async fn edit_comment_json_mode_no_content_errors() {
+    let mut config = test::fixtures::config().await;
+    config.args.json = true;
+
+    let args = EditComment {
+        comment_id: "123".to_string(),
+        content: None,
+    };
+    let result = edit_comment(config, &args, true).await;
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().source, "json_mode");
+}
+
+#[tokio::test]
+async fn delete_comment_happy_path() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("DELETE", "/api/v1/comments/123")
+        .with_status(204)
+        .create_async()
+        .await;
+
+    let config = test::fixtures::config()
+        .await
+        .with_mock_url(server.url());
+
+    let args = DeleteComment {
+        comment_id: "123".to_string(),
+    };
+    let result = delete_comment(config, &args, false).await;
+    assert!(result.is_ok(), "delete_comment should succeed; got: {result:?}");
+    assert!(result.unwrap().contains("Comment deleted successfully"));
+    mock.assert();
+}
+
+#[tokio::test]
+async fn delete_comment_json_output() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("DELETE", "/api/v1/comments/123")
+        .with_status(204)
+        .create_async()
+        .await;
+
+    let config = test::fixtures::config()
+        .await
+        .with_mock_url(server.url());
+
+    let args = DeleteComment {
+        comment_id: "123".to_string(),
+    };
+    let result = delete_comment(config, &args, true).await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "\"✓\"");
+    mock.assert();
+}
+```
+
+### Verification
+#### Automated
+- [ ] `cargo test edit_comment delete_comment` passes — all 5 new tests green
+- [ ] `cargo test test_update_comment test_delete_comment` — Phase 1 tests still green
+- [ ] `cargo test process_task` — Phase 2 tests still green
+- [ ] `scripts/test.sh` passes (format, clippy, no forbidden strings)
+
+#### Manual
+- [ ] `tod task edit-comment <real_comment_id> "updated text"` → success message
+- [ ] `tod task delete-comment <real_comment_id>` → success message
+- [ ] `tod task edit-comment <real_comment_id> --json "updated text"` → JSON output with comment object
+- [ ] `tod task delete-comment <real_comment_id> --json` → `"✓"`
+- [ ] `tod task edit-comment <real_comment_id> --json` (no content) → errors with `json_mode` source
+- [ ] `tod t ec <id> "text"` and `tod t dc <id>` — aliases work
+- [ ] Verify in Todoist UI that edited content appears / comment is deleted
+
+---
+
+## Phase 4: Docs and polish
+
+### Changes
+
+#### 1. Update usage docs
+**File**: `docs/usage.md`
+**Action**: modify — add examples under the task commands section (after `tod task comment` example around line 144):
+
+```markdown
+# Edit an existing comment by ID
+tod task edit-comment 1234567890 "Updated comment text"
+
+# Edit a comment with JSON output
+tod task edit-comment 1234567890 "Updated comment text" --json
+
+# Edit a comment (interactive prompt for new content)
+tod task edit-comment 1234567890
+
+# Delete a comment by ID
+tod task delete-comment 1234567890
+
+# Delete a comment with JSON output
+tod task delete-comment 1234567890 --json
+```
+
+Also update the `tod task -h` help output block earlier in the doc (around line 46) to include `edit-comment` and `delete-comment`:
+```markdown
+  edit-comment  (ec) Edit an existing comment's content
+  delete-comment (dc) Delete a comment by ID
+```
+
+#### 2. Verify empty-comments edge case
+**File**: `src/tasks/mod.rs`
+**Action**: verify — the empty-comments edge case (skip select, go straight to content prompt) is handled in Phase 2's COMMENT arm rewrite. Confirm it's working correctly.
+
+### Verification
+#### Automated
+- [ ] `scripts/test.sh` passes — full pipeline (format, build, clippy, tests, forbidden strings)
+- [ ] `grep -A3 "edit-comment\|delete-comment" docs/usage.md` — confirms docs mention new commands
+
+#### Manual
+- [ ] Review `docs/usage.md` for accuracy of examples
+
+---
+
+## Implementation Order
+
+Phases must be implemented in order: 1 → 2 → 3 → 4. Each phase builds on the previous.
+
+Within Phase 2, the mock_select infrastructure upgrade (item 1) must be done before the COMMENT arm rewrite (item 4) since the rewrite depends on it for tests.
+
+---
+
+## Testing Checkpoints
+
+| Phase | What must be true |
+|---|---|
+| **1** | `update_comment` and `delete_comment` compile, pass mockito tests. `cargo test update_comment delete_comment` green. |
+| **2** | COMMENT submenu works. Spawn functions forward errors. `cargo test process_task` green (existing + new tests). |
+| **3** | `tod t ec <id> <content>` and `tod t dc <id>` work with text and JSON output. JSON mode rejects missing content arg. `cargo test edit_comment delete_comment` green. `scripts/test.sh` passes. |
+| **4** | `docs/usage.md` has new command examples. Empty comments list handled gracefully. Full `scripts/test.sh` green. |
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **`update_comment` API response shape differs from `Comment` struct** | The `test_update_comment` test verifies parsing against the existing `Comment.json` fixture. If live API returns a different shape, `from_json` will fail at runtime. Manual live test after Phase 3 confirms. |
+| **Comment ownership — 403 from API** | `handle_response` maps 401/403 to re-auth error. If ownership failures return 403, the error message is misleading. Out of scope for this feature; the Todoist API may return 404 for unauthorized comment access. |
+| **`mock_select` infrastructure change breaks existing tests** | All callers updated mechanically. Run `cargo test` after Phase 2 item 1 to catch any missed call sites. |
+| **"Back" in comment submenu doesn't truly loop** | The current implementation returns a no-op spawn. The user re-selects COMMENT on the next process iteration. Acceptable for initial release. |

--- a/.pi/qrspi/PROJ-1766-comment-update-delete/questions.md
+++ b/.pi/qrspi/PROJ-1766-comment-update-delete/questions.md
@@ -1,0 +1,17 @@
+# Research Questions
+
+## Context
+Focus on the Todoist API client layer (`src/todoist/mod.rs` and `src/todoist/request.rs`), the comment data model (`src/comments.rs`), the interactive task processing workflow (`src/tasks/mod.rs`, `src/lists.rs`), CLI command dispatch (`src/commands/mod.rs`), and the test infrastructure (`src/test/`).
+
+## Questions
+1. How do existing task CRUD operations (e.g., `update_task_content`, `update_task_description`, `delete_task`) construct their URLs, build request bodies, and handle API responses in `src/todoist/mod.rs`? What patterns do they follow for status codes that don't return JSON bodies (e.g., 204 No Content)?
+
+2. What does the `Comment` struct in `src/comments.rs` look like, specifically which fields does a freshly-created comment receive from the API? Would updating a comment return the same shape or a subset?
+
+3. How does `handle_response` in `src/todoist/request.rs` handle HTTP status codes — which codes trigger auth errors, which trigger pro-plan messages, and what happens for non-200 success codes like 204?
+
+4. How does the interactive `process_task` function in `src/tasks/mod.rs` present options (Complete, Skip, Comment, etc.) to the user and dispatch to spawned async tasks? What input constants are defined in `src/input.rs`?
+
+5. How are CLI commands for task operations dispatched in `src/commands/mod.rs`, and how does the existing `TaskCommands::Comment` handler work? Is there a pattern for adding new task subcommands?
+
+6. How does the test infrastructure in `src/test/` mock Todoist API endpoints (mockito patterns, `ResponseFromFile` enum), construct test fixtures, and verify API calls? What response fixture files exist for comments?

--- a/.pi/qrspi/PROJ-1766-comment-update-delete/research.md
+++ b/.pi/qrspi/PROJ-1766-comment-update-delete/research.md
@@ -1,0 +1,225 @@
+# Research Findings
+
+## Q1: How do existing task CRUD operations construct URLs, build request bodies, and handle API responses? What patterns for 204 No Content?
+
+### Findings
+
+**URL construction** — All operations use a base URL constant with task IDs appended:
+- `TASKS_URL: &str = "/api/v1/tasks/"` — `src/todoist/mod.rs:32`
+- `COMMENTS_URL: &str = "/api/v1/comments/"` — `src/todoist/mod.rs:34`
+- Simple resource: `format!("{TASKS_URL}{task_id}")` — `src/todoist/mod.rs:370`
+- Sub-resource actions: `format!("{TASKS_URL}{task_id}/move")` — `src/todoist/mod.rs:312`, `format!("{TASKS_URL}{task_id}/close")` — `src/todoist/mod.rs:401`
+- The base URL (`https://api.todoist.com` or mock URL) is prepended inside request functions at `src/todoist/request.rs:253-259`
+
+**HTTP methods** — Four request functions in `src/todoist/request.rs`:
+| Function | Lines | Method | Auth |
+|---|---|---|---|
+| `post_todoist` | 38-74 | POST | Bearer |
+| `post_todoist_no_token` | 77-101 | POST | None |
+| `delete_todoist` | 108-138 | DELETE | Bearer |
+| `get_todoist` | 141-167 | GET | Bearer |
+
+All share `X-Request-Id` header with UUID, `Content-Type: application/json`, and configurable timeout.
+
+**Request body patterns** — Two approaches in `src/todoist/mod.rs`:
+- **`json!({"field": value})`** — single-field updates like `update_task_content` (line 368), `update_task_description` (line 387), `update_task_priority` (line 336)
+- **`HashMap<String, Value>` built incrementally** — multi-field creation like `create_task` (lines 163-190), where optional fields are conditionally inserted
+
+**Response handling** — Two distinct patterns:
+- **Pattern A (returns parsed type)**: Call `request::post_todoist`, then `Type::from_json(&response)` — e.g., `create_comment` at `src/todoist/mod.rs:528-536`, `create_task` at line 198
+- **Pattern B (returns `Ok("✓")`)**: Call request function, discard the response string, return `Ok("✓".into())` — e.g., `update_task_content` at `src/todoist/mod.rs:362-370`, `delete_task` at `src/todoist/mod.rs:416-421`, `complete_task` at `src/todoist/mod.rs:396-409`, `archive_project` at `src/todoist/mod.rs:456-461`. The comment `// Does not pass back a task` is consistently used.
+
+**Delete uses `delete_todoist`** — `src/todoist/mod.rs:416-421` is the only operation that calls `delete_todoist`; all updates use `post_todoist`.
+
+**204 No Content handling** — `handle_response` at `src/todoist/request.rs:208-211` treats all `2xx` codes identically via `response.text().await?`. For 204, this returns `Ok("")`. Pattern B callers discard this empty string. The test at `src/todoist/mod.rs:786` (`test_update_task_priority`) mocks status 204 but still provides a body — no test verifies 204 with an empty body specifically.
+
+## Q2: What does the `Comment` struct look like? Would updating return the same shape?
+
+### Findings
+
+**`Comment` struct** — `src/comments.rs:9-18`:
+```rust
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+pub struct Comment {
+    pub id: String,
+    pub posted_uid: Option<String>,
+    pub content: String,
+    pub uids_to_notify: Option<Vec<String>>,
+    pub is_deleted: bool,
+    pub posted_at: String,
+    pub reactions: Option<Reactions>,
+    pub item_id: String,
+    pub file_attachment: Option<Attachment>,
+}
+```
+All fields public. `from_json` at line 19-22; `fmt` method at line 105+ handles rendering with timezone formatting and OSC8 hyperlinks for attachments.
+
+**What the API returns on create** — Fixture at `tests/responses/Comment.json` returns: `content`, `id`, `posted_at`, `item_id`, `is_deleted`, `attachment` (with `file_name`, `file_type`, `file_url`, `resource_type`). Notably, the API field is `attachment` but the Rust field is `file_attachment`. The `Attachment` enum at `src/comments.rs:43-51` is `#[serde(untagged)]`, and the `FileAttachment` variant at line 54-59 captures `file_name`, `file_type`, `file_url`, `resource_type`.
+
+**Update response shape** — No comment update function exists in the codebase, so there's no precedent. The Todoist REST API typically returns the full updated resource object on POST/PUT for comments. A comment update would likely return the same `Comment` shape as creation, but this is not confirmed from the codebase — it depends on the Todoist API contract.
+
+**CommentResponse** — `src/comments.rs:24-32`: paginated wrapper with `results: Vec<Comment>` and `next_cursor: Option<String>`, used by `all_comments` at `src/todoist/mod.rs:549-578`.
+
+**Attachment variants** — `src/comments.rs:43-51`: `File`, `Url`, `ShortUrl`, `Video`, `Image` — `#[serde(untagged)]` enum. Each variant struct is defined at lines 53-102.
+
+## Q3: How does `handle_response` handle HTTP status codes?
+
+### Findings
+
+**Function signature** — `src/todoist/request.rs:197-231`:
+```rust
+async fn handle_response(config, response, method, url, body) -> Result<String, Error>
+```
+
+**Three branches** (lines 204-230):
+
+1. **Success (2xx)**: `response.text().await?` then `Ok(json_string)` — all 2xx codes including 200, 201, 204 treated identically. No distinction made for 204 No Content. **204 returns `Ok("")`** (empty string).
+   — `src/todoist/request.rs:208-211`
+
+2. **Auth error on non-pro URL**: Status 401 or 403 + URL is NOT a pro-plan URL → `Error::new("reqwest", "Unauthorized or Forbidden response from Todoist\nRun 'tod auth login' to reauthenticate")`
+   — `src/todoist/request.rs:212-216`
+
+3. **Auth error on pro URL**: Status 401 or 403 + URL IS a pro-plan URL → `Error::new("reqwest", REMINDERS_PRO_PLAN_MESSAGE)` ("Reminders are only available on Pro Todoist plans...")
+   — `src/todoist/request.rs:217-220`
+
+4. **All other errors**: `response.text().await?`, then `Error::new("reqwest", "{method}\n{url}\n{body}\n{response}")` — dumps raw response for debugging
+   — `src/todoist/request.rs:221-230`
+
+**Auth detection**:
+- `CODES_REQUIRING_LOGIN: [u16; 2] = [403, 401]` — `src/todoist/request.rs:169`
+- `requires_login(status_code)` — `src/todoist/request.rs:171-173`
+- `is_pro_plan_url(url)` checks if URL contains any of `PRO_PLAN_URLS: [&str; 1] = [REMINDERS_URL]` — `src/todoist/request.rs:169, 176-178`
+
+**Key detail**: The `source` field for errors from `handle_response` is always `"reqwest"` (lines 214, 219, 224), even though the actual errors come from `response.text().await?` (which wraps `reqwest::Error`).
+
+## Q4: How does `process_task` present options and dispatch to spawned async tasks? What input constants exist?
+
+### Findings
+
+**`process_task`** — `src/tasks/mod.rs:365-414`: Takes `comments, config, task, task_count, with_project`. Options array:
+```rust
+[COMPLETE, SKIP, SCHEDULE, COMMENT, REMIND, DELETE, QUIT]
+```
+Prints formatted task with comments, completion count, and remaining count. Calls `input::select(input::OPTION, options, config.mock_select)` then matches:
+
+| Option | Action | Lines |
+|---|---|---|
+| `COMPLETE` | Saves config, `spawn_complete_task` | 380-384 |
+| `DELETE` | `spawn_delete_task` | 385 |
+| `COMMENT` | Prompts `input::string(CONTENT, ...)`, `spawn_comment_task` | 386-389 |
+| `REMIND` | Prompts `input::string(DATE_AND_TIME, ...)`, `spawn_create_reminder` | 391-394 |
+| `SCHEDULE` | `input::date()`, `spawn_update_task_due` | 396-400 |
+| `SKIP` | Spawns empty `tokio::spawn(async move {})` | 403 |
+| `QUIT` | Returns `None` | 404 |
+
+**Spawn functions** — All at `src/tasks/mod.rs:484-580`, follow identical pattern:
+```rust
+pub fn spawn_*(config: Config, ...) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        if let Err(e) = todoist::*(&config, ...).await {
+            let _ = config.tx().send(e);
+        }
+    })
+}
+```
+Error channel (`config.tx()`) sends errors to the main event loop for async display.
+
+**`timebox_task`** — `src/tasks/mod.rs:417-452`: Similar pattern with options `[TIMEBOX, COMPLETE, SKIP, DELETE, QUIT]`.
+
+**Input constants** — `src/input.rs`:
+- **Text prompts** (lines 10-26): `CONTENT`, `DESCRIPTION`, `NAME`, `FILTER`, `PATH`, `DATE`, `TIME`, `DATE_AND_TIME`, `DURATION`
+- **Select prompts** (lines 28-41): `ATTRIBUTES`, `PROJECT`, `LABELS`, `SECTION`, `PRIORITY`, `OPTION`, `SELECT_DATE`, `TASK`
+- **Option values** (lines 43-63): `NAT_LANG`, `NO_DATE`, `COMPLETE`, `REMIND`, `TIMEBOX`, `COMMENT`, `SKIP`, `DELETE`, `CANCEL`, `QUIT`, `SCHEDULE`
+- **`DateTimeInput` enum** (lines 65-74): `Skip`, `None`, `Complete`, `Text(String)`
+
+## Q5: How are CLI commands dispatched for task operations? How does `TaskCommands::Comment` work?
+
+### Findings
+
+**Dispatch chain** — `src/commands/mod.rs`:
+1. `select_command` (line 143) matches `Commands::Task(command)` → calls `task_command(command, &cli, &tx)` (line 157)
+2. `task_command` (lines 244-275) matches each `TaskCommands` variant and delegates to handler functions in `task_commands.rs`
+
+**`TaskCommands` enum** — `src/commands/task_commands.rs:14-47`:
+```rust
+pub enum TaskCommands {
+    QuickAdd(QuickAdd),  // alias "q"
+    Create(Create),      // alias "c"
+    Edit(Edit),          // alias "e"
+    Next(Next),          // alias "n"
+    Complete(Complete),  // alias "o"
+    Comment(Comment),    // alias "m"
+}
+```
+Each variant wraps a `#[derive(Parser)]` struct. Single-letter aliases match the parent command's alias (`tod t m` = task comment).
+
+**`Comment` handler** — `src/commands/task_commands.rs:245-260`:
+1. Retrieves task from `config.next_task()` (set by `Next` command)
+2. If no next task → `Error::new("task_comment", "There is nothing to comment on...")`
+3. Fetches content via `super::fetch_string(content.as_deref(), &config, input::CONTENT)` — accepts CLI arg or prompts interactively, errors in JSON mode if not provided
+4. Calls `todoist::create_comment(&config, &task.id, &content, true)` with spinner
+5. Returns JSON (via `serde_json::to_string(&comment)`) or green string `"Comment created successfully"`
+
+**Pattern for adding new task subcommands**:
+1. Add variant to `TaskCommands` enum with `#[clap(alias = "x")]` and a `#[derive(Parser)]` args struct
+2. Add async handler function in `task_commands.rs` following signature `pub async fn handler(config: Config, args: &NewArgs, json: bool) -> Result<String, Error>`
+3. Add match arm in `task_command` (mod.rs:244) calling the handler and wrapping with `build_command_result`
+
+**`fetch_string` helper** — `src/commands/mod.rs:393-403`: Returns provided `Option<&str>` or prompts interactively. Errors in JSON mode when no value provided (source: `"json_mode"`).
+
+## Q6: How does the test infrastructure mock Todoist API endpoints? What comment fixtures exist?
+
+### Findings
+
+**Test module structure** — `src/test/`:
+- `mod.rs` — module declarations, `today_date()` helper at line 7
+- `responses.rs` — `ResponseFromFile` enum for loading JSON fixtures
+- `fixtures.rs` — `Config`, `Task`, `Comment`, `Project`, `Section`, `Reminder`, `Label` constructors
+
+**`ResponseFromFile` enum** — `src/test/responses.rs:7-31`: 20 variants mapping to JSON files in `tests/responses/`. Relevant to comments: `Comment`, `CommentsAllTypes`. Other notable variants: `TodayTask`, `TodayTasks`, `Task`, `Project`, `Projects`, `Section`, `Sections`, `Reminder`, `Reminders`, `Label`, `Labels`, `User`, `AccessToken`.
+
+**`read()` method** — `src/test/responses.rs:34-41`: Reads `tests/responses/{self}.json`, then calls `replace_values()` for dynamic substitution. `TodayTask`/`TodayTasks`/`UnscheduledTasks`/`TodayTasksWithoutDuration` replace `INSERTDATE` with today's date. `Versions` replaces `INSERTVERSION`.
+
+**Mock setup pattern** (from `src/todoist/mod.rs` tests):
+```rust
+let mut server = mockito::Server::new_async().await;
+let mock = server
+    .mock("POST", "/api/v1/tasks/quick")
+    .with_status(200)
+    .with_header("content-type", "application/json")
+    .with_body(ResponseFromFile::TodayTask.read().await)
+    .create_async()
+    .await;
+let config = test::fixtures::config().await.with_mock_url(server.url());
+// ... call function under test ...
+mock.assert();  // or mock.assert_async().await;
+```
+
+**Body matching** (from `src/todoist/mod.rs` tests):
+- Regex: `.match_body(mockito::Matcher::Regex(r#""parent_id":"999""#.to_string()))` — line 607
+- AllOf: `.match_body(mockito::Matcher::AllOf(vec![...]))` — line 642
+
+**Config fixture** — `src/test/fixtures.rs:96-108`: Creates `Config` with mock channel (`tokio::sync::mpsc::unbounded_channel`), temp config file, token `"alreadycreated"`, one project (`project()` fixture), `FixedTimeProvider`, timezone `"America/Vancouver"`. Chained with `.with_mock_url(server.url())` in tests.
+
+**Comment fixtures**:
+- `tests/responses/Comment.json` — single comment with `content`, `id`, `posted_at`, `item_id`, `is_deleted`, `attachment` (file type)
+- `tests/responses/CommentsAllTypes.json` — 8 comments: file, video, image, URL, short URL, rich embed, plain (no attachment), and one deleted (`is_deleted: true`). Used by `test_all_comments_filters_deleted` at `src/todoist/mod.rs:876`
+- `src/test/fixtures.rs:comment()` (lines 147-159) — returns `Comment` struct with hardcoded values (id `"2992679862"`, content `"Need one bottle of milk"`, no attachment)
+
+**Test for create_comment** — `src/todoist/mod.rs:713-726`: Mocks `POST /api/v1/comments/` with status 200 and `ResponseFromFile::Comment`, asserts returned `Comment` matches fixture.
+
+**Tests for 204 status** — `src/todoist/mod.rs:786-800` (`test_update_task_priority`): Mocks status 204 but still provides a body. `src/todoist/mod.rs:992-1002` (`test_archive_project_hits_api`): Mocks 204 with no body at all — this is the only test that exercises a true 204 empty-body scenario.
+
+## Cross-Cutting Observations
+
+- **Consistent error source convention**: `handle_response` always uses `"reqwest"` as error source. Upstream callers use descriptive sources like `"fetch_project"`, `"json_mode"`, `"task_comment"`.
+- **Spinner control**: The `spinner: bool` parameter flows through every API function to `post_todoist`/`delete_todoist`/`get_todoist`. `true` for interactive operations, `false` for batch/background operations.
+- **No comment mutation functions exist**: Only `create_comment` (`src/todoist/mod.rs:525-536`) and `all_comments` (`src/todoist/mod.rs:549-578`) exist. No `update_comment` or `delete_comment`.
+- **Spawn pattern**: All async operations in `src/tasks/mod.rs` use `tokio::spawn` with error forwarding via `config.tx().send(e)`. The caller gets `Option<JoinHandle<()>>` — `None` signals quit/skip.
+- **JSON mode guard**: `fetch_string` and similar functions in `src/commands/mod.rs` error with `"json_mode"` source when no CLI arg is provided and JSON mode is active. Interactive prompts are blocked.
+
+## Open Areas
+
+- **Comment update API response shape**: Cannot confirm from codebase whether the Todoist API returns the full `Comment` object on update. Would need to consult Todoist REST API docs or test against live API.
+- **Comment delete API response**: Similarly unknown — some APIs return 204 No Content, others return the deleted object.
+- **`attachment` vs `file_attachment` field name**: The JSON fixture uses `"attachment"` but the Rust struct uses `file_attachment`. The `#[serde(untagged)]` on `Attachment` may handle this via serde's `#[serde(rename)]` or there may be undocumented behavior. A live API test would confirm deserialization works.

--- a/.pi/qrspi/PROJ-1766-comment-update-delete/structure.md
+++ b/.pi/qrspi/PROJ-1766-comment-update-delete/structure.md
@@ -1,0 +1,157 @@
+# Structure Outline
+
+## Approach
+
+Add `update_comment` and `delete_comment` to the Todoist API client, then expose them through both the interactive `process_task` COMMENT submenu and new CLI subcommands (`edit-comment`, `delete-comment`). Each phase crosses all layers needed for its slice — API, UI prompts, dispatch, and tests.
+
+---
+
+## Phase 1: API client — `update_comment` and `delete_comment`
+
+Delivers the two new API functions with mockito tests. No user-visible change yet, but the functions are callable and verified against the Todoist REST API contract.
+
+**Files**: `src/todoist/mod.rs`
+
+**Key changes**:
+- `pub async fn update_comment(config: &Config, comment_id: &str, content: &str, spinner: bool) -> Result<Comment, Error>` — POST `/api/v1/comments/{id}` with `json!({"content": content})`, parses response via `Comment::from_json`. Follows `create_comment` (line 525) response pattern.
+- `pub async fn delete_comment(config: &Config, comment_id: &str, spinner: bool) -> Result<String, Error>` — DELETE `/api/v1/comments/{id}` via `request::delete_todoist`, expects 204, returns `Ok("✓".into())`. Follows `delete_task` (line 416) pattern with `// Does not pass back a comment`.
+- Test: `test_update_comment` — mock `POST /api/v1/comments/123` → 200 with `ResponseFromFile::Comment`, assert returned `Comment` matches fixture.
+- Test: `test_delete_comment` — mock `DELETE /api/v1/comments/123` → 204 no body, assert returns `Ok("✓")`.
+- New fixture (if needed): `tests/responses/Comment.json` already exists from `create_comment` tests; reuse it.
+
+**Verify**:
+```bash
+cargo test update_comment delete_comment
+```
+- `update_comment` returns a parsed `Comment` struct matching the fixture.
+- `delete_comment` returns `"✓"` on 204.
+
+---
+
+## Phase 2: Interactive comment submenu in `process_task`
+
+User presses COMMENT → sees existing comments as a select list + "New comment" option. Selecting an existing comment shows Edit / Delete / Back. Selecting "New comment" prompts for content and creates. The full interactive flow is testable by mocking the select input.
+
+**Files**: `src/tasks/mod.rs`, `src/input.rs`
+
+**Key changes**:
+- `fn format_comment_option(comment: &Comment, config: &Config) -> String` — helper: `"{truncated_content} — {posted_at_formatted}"` (first ~60 chars of `content`, timezone-adjusted `posted_at`). Used to build the `input::select` options list.
+- `pub fn spawn_update_comment(config: Config, comment_id: String, content: String) -> JoinHandle<()>` — calls `todoist::update_comment(…, false)`, forwards errors via `config.tx()`.
+- `pub fn spawn_delete_comment(config: Config, comment_id: String) -> JoinHandle<()>` — calls `todoist::delete_comment(…, false)`, forwards errors via `config.tx()`.
+- `process_task` (line 524) COMMENT arm rewritten:
+  ```
+  input::COMMENT matched → build options from comments + "New comment"
+    → input::select("Select a comment", options, …)
+    → "New comment" → prompt content → spawn_comment_task (existing)
+    → existing comment → sub-select ["Edit", "Delete", "Back"]
+      → "Edit" → prompt content → spawn_update_comment
+      → "Delete" → spawn_delete_comment
+      → "Back" → return to comment list (loop)
+  ```
+- Edge case: empty comments list → skip the select, go straight to content prompt (existing create flow).
+
+**Verify**:
+```bash
+cargo test process_task comment
+```
+- With mocked select returning "New comment" → spawns create.
+- With mocked select returning an existing comment, then "Edit" → spawns update.
+- With mocked select returning an existing comment, then "Delete" → spawns delete.
+- With mocked select returning "Back" → returns to comment list.
+- Empty comments list → skips select, goes directly to content prompt.
+
+Manual: run `tod list process`, hit COMMENT on a task with comments — see formatted one-liners, select one, edit/delete it.
+
+---
+
+## Phase 3: CLI subcommands — `edit-comment` and `delete-comment`
+
+`tod task edit-comment <id> <content>` and `tod task delete-comment <id>` work from the command line with JSON and human-readable output. Args structs, handlers, and dispatch arms.
+
+**Files**: `src/commands/task_commands.rs`, `src/commands/mod.rs`
+
+**Key changes**:
+- `TaskCommands` enum additions:
+  ```rust
+  #[clap(alias = "ec")]
+  /// Edit an existing comment's content
+  EditComment(EditComment),
+
+  #[clap(alias = "dc")]
+  /// Delete a comment by ID
+  DeleteComment(DeleteComment),
+  ```
+  Aliases `ec` / `dc` avoid collision with existing `e` (Edit task), `c` (Create task), `m` (Comment create), `d` (none).
+- Args structs:
+  ```rust
+  #[derive(Parser, Debug, Clone)]
+  pub struct EditComment {
+      /// ID of the comment to edit
+      comment_id: String,
+      /// New content for the comment
+      content: Option<String>,
+  }
+
+  #[derive(Parser, Debug, Clone)]
+  pub struct DeleteComment {
+      /// ID of the comment to delete
+      comment_id: String,
+  }
+  ```
+- Handler: `pub async fn edit_comment(config: Config, args: &EditComment, json: bool) -> Result<String, Error>` — fetches content via `super::fetch_string(args.content.as_deref(), …)`, calls `todoist::update_comment(…, true)`, returns JSON or green string `"Comment updated successfully"`.
+- Handler: `pub async fn delete_comment(config: Config, args: &DeleteComment, json: bool) -> Result<String, Error>` — calls `todoist::delete_comment(…, true)`, returns JSON `"✓"` or green string `"Comment deleted successfully"`.
+- Dispatch: two new match arms in `task_command` (`src/commands/mod.rs:244`):
+  ```rust
+  TaskCommands::EditComment(args) => {
+      let config = fetch_config(cli, tx).await?;
+      let result = task_commands::edit_comment(config.clone(), args, cli.json).await;
+      Ok(build_command_result(result, &config))
+  }
+  TaskCommands::DeleteComment(args) => {
+      let config = fetch_config(cli, tx).await?;
+      let result = task_commands::delete_comment(config.clone(), args, cli.json).await;
+      Ok(build_command_result(result, &config))
+  }
+  ```
+
+**Verify**:
+```bash
+cargo test edit_comment delete_comment
+```
+- `tod task edit-comment 123 "new content"` → happy path returns `"Comment updated successfully"` / JSON.
+- `tod task edit-comment 123` (no content, interactive) → prompts for content, then updates.
+- `tod task delete-comment 123` → returns `"Comment deleted successfully"` / JSON `"✓"`.
+- `tod task edit-comment 123 --json` with no content arg → errors with `"json_mode"` source (matching `fetch_string` guard).
+
+Manual: `tod task edit-comment <real_id> "updated text"` against live API, verify in Todoist UI.
+
+---
+
+## Phase 4: Docs and polish
+
+Update usage docs and handle the empty-comments edge case in `process_task` (if deferred from Phase 2).
+
+**Files**: `docs/usage.md`, `src/tasks/mod.rs` (if edge case not handled in Phase 2)
+
+**Key changes**:
+- `docs/usage.md`: add `tod task edit-comment` and `tod task delete-comment` examples under the task commands section, with both interactive and JSON-mode variants.
+- Empty comments edge case: if `comments.is_empty()` in the COMMENT arm, skip the select and go directly to content prompt (may already be done in Phase 2).
+
+**Verify**:
+```bash
+# Confirm docs render correctly
+cat docs/usage.md | grep -A3 "edit-comment\|delete-comment"
+```
+
+---
+
+## Testing Checkpoints
+
+After each phase, these must hold:
+
+| Phase | What must be true |
+|---|---|
+| **1** | `update_comment` and `delete_comment` compile, pass mockito tests. `cargo test update_comment delete_comment` green. |
+| **2** | COMMENT in `process_task` shows comment list + "New comment". Edit/Delete/Back submenu works. Spawn functions forward errors. `cargo test process_task` green (new + existing tests). |
+| **3** | `tod t ec <id> <content>` and `tod t dc <id>` work with both text and JSON output. JSON mode rejects missing content arg. `cargo test edit_comment delete_comment` green. `scripts/test.sh` passes (format, clippy, no forbidden strings). |
+| **4** | `docs/usage.md` has new command examples. Empty comments list handled gracefully. Full `scripts/test.sh` green. |

--- a/.pi/qrspi/PROJ-1766-comment-update-delete/task.md
+++ b/.pi/qrspi/PROJ-1766-comment-update-delete/task.md
@@ -1,0 +1,1 @@
+Add `update_comment` and `delete_comment` API client functions to `src/todoist/mod.rs` that call the Todoist REST API's comment update (POST /comments/{id}) and delete (DELETE /comments/{id}) endpoints. Wire these into the interactive task processing workflow so users can edit or remove comments they've posted, not just create and view them.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -43,13 +43,16 @@ Commands for individual tasks
 Usage: tod task <COMMAND>
 
 Commands:
-  quick-add  (q) Create a new task using NLP
-  create     (c) Create a new task (without NLP)
-  edit       (e) Edit an existing task's content
-  next       (n) Get the next task by priority
-  complete   (o) Complete the last task fetched with the next command
-  reopen     (r) Reopen the last completed task
-  help       Print this message or the help of the given subcommand(s)
+  quick-add      (q) Create a new task using NLP
+  create         (c) Create a new task (without NLP)
+  edit           (e) Edit an existing task's content
+  next           (n) Get the next task by priority
+  complete       (o) Complete the last task fetched with the next command
+  reopen         (r) Reopen the last completed task
+  comment        (m) Add a comment to the last task fetched with the next command
+  edit-comment   (ec) Edit an existing comment's content
+  delete-comment (dc) Delete a comment by ID
+  help           Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help  Print help
@@ -159,6 +162,21 @@ tod task next
 
 # Comment on the current (next) task
 tod task comment
+
+# Edit an existing comment by ID
+tod task edit-comment 1234567890 "Updated comment text"
+
+# Edit a comment with JSON output
+tod task edit-comment 1234567890 "Updated comment text" --json
+
+# Edit a comment (interactive prompt for new content)
+tod task edit-comment 1234567890
+
+# Delete a comment by ID
+tod task delete-comment 1234567890
+
+# Delete a comment with JSON output
+tod task delete-comment 1234567890 --json
 
 # Go through tasks with an interactive prompt, completing them in order of importance one at a time.
 tod list process

--- a/src/commands/label_commands.rs
+++ b/src/commands/label_commands.rs
@@ -148,7 +148,7 @@ pub async fn delete(config: &Config, args: &Delete, json: bool) -> Result<String
         }
         let options = vec![input::CANCEL, input::DELETE];
         let desc = format!("Delete label \"{}\"?", target.name);
-        let result = input::select(&desc, options, config.mock_select)?;
+        let result = input::select(&desc, options, &config.mock_select)?;
         if result == input::CANCEL {
             return Ok("Cancelled".into());
         }

--- a/src/commands/list_commands.rs
+++ b/src/commands/list_commands.rs
@@ -450,7 +450,7 @@ fn select_file(path_or_file: String, config: &Config) -> Result<String, Error> {
             .collect::<Vec<String>>();
         options.sort();
         options.dedup();
-        let path = input::select("Select file to process", options, config.mock_select)?;
+        let path = input::select("Select file to process", options, &config.mock_select)?;
 
         Ok(path)
     } else if Path::is_file(path) {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -634,7 +634,7 @@ pub fn fetch_label<'a>(
         Err(Error::new("json_mode", JSON_INTERACTIVE_ERROR))
     } else {
         let label_names: Vec<String> = labels.iter().map(|l| l.name.clone()).collect();
-        let selected = input::select(input::LABEL, label_names, config.mock_select)?;
+        let selected = input::select(input::LABEL, label_names, &config.mock_select)?;
         Ok(labels
             .iter()
             .find(|l| l.name == selected)

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -565,7 +565,7 @@ async fn fetch_project(project_name: Option<&str>, config: &Config) -> Result<Fl
             if config.args.json {
                 return Err(Error::new("json_mode", JSON_INTERACTIVE_ERROR));
             }
-            input::select(input::PROJECT, projects, config.mock_select).map(Flag::Project)
+            input::select(input::PROJECT, projects, &config.mock_select).map(Flag::Project)
         }
     }
 }
@@ -601,7 +601,7 @@ async fn fetch_project_or_filter(
                 return Err(Error::new("json_mode", JSON_INTERACTIVE_ERROR));
             }
             let options = vec![FlagOptions::Project, FlagOptions::Filter];
-            match input::select(input::OPTION, options, config.mock_select)? {
+            match input::select(input::OPTION, options, &config.mock_select)? {
                 FlagOptions::Project => fetch_project(project, config).await,
                 FlagOptions::Filter => fetch_filter(filter, config),
             }
@@ -646,7 +646,7 @@ fn fetch_priority(priority: Option<u8>, config: &Config) -> Result<Priority, Err
             Priority::Medium,
             Priority::High,
         ];
-        input::select(input::PRIORITY, options, config.mock_select)
+        input::select(input::PRIORITY, options, &config.mock_select)
     }
 }
 
@@ -778,8 +778,7 @@ mod tests {
 
     #[test]
     fn fetch_priority_uses_mock_select_when_none() {
-        let mut config = Config::default_test();
-        config.mock_select = Some(1);
+        let config = Config::default_test().mock_select(1);
 
         let result = fetch_priority(None, &config);
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -326,6 +326,16 @@ async fn task_command(
             let result = task_commands::comment(config.clone(), args, cli.json).await;
             Ok(build_command_result(result, &config))
         }
+        TaskCommands::EditComment(args) => {
+            let config = fetch_config(cli, tx).await?;
+            let result = task_commands::edit_comment(config.clone(), args, cli.json).await;
+            Ok(build_command_result(result, &config))
+        }
+        TaskCommands::DeleteComment(args) => {
+            let config = fetch_config(cli, tx).await?;
+            let result = task_commands::delete_comment(config.clone(), args, cli.json).await;
+            Ok(build_command_result(result, &config))
+        }
     }
 }
 

--- a/src/commands/project_commands.rs
+++ b/src/commands/project_commands.rs
@@ -243,7 +243,7 @@ pub async fn delete(config: &mut Config, args: &Delete) -> Result<String, Error>
             let options = vec![input::CANCEL, input::DELETE];
             let num_tasks = tasks.len();
             let desc = format!("Project has {num_tasks} tasks, confirm deletion");
-            let result = input::select(&desc, options, config.mock_select)?;
+            let result = input::select(&desc, options, &config.mock_select)?;
 
             if result == input::CANCEL {
                 return Ok("Cancelled".into());

--- a/src/commands/section_commands.rs
+++ b/src/commands/section_commands.rs
@@ -79,7 +79,7 @@ pub async fn delete(config: &Config, args: &Delete, json: bool) -> Result<String
             return Err(Error::new("json_mode", super::JSON_INTERACTIVE_ERROR));
         } else {
             let section_names: Vec<String> = sections.iter().map(|s| s.name.clone()).collect();
-            let selected = input::select(input::SECTION, section_names, config.mock_select)?;
+            let selected = input::select(input::SECTION, section_names, &config.mock_select)?;
             sections.into_iter().find(|s| s.name == selected).unwrap()
         };
 
@@ -92,7 +92,7 @@ pub async fn delete(config: &Config, args: &Delete, json: bool) -> Result<String
                 "Delete section \"{}\"? Tasks inside will also be deleted.",
                 section.name
             );
-            let result = input::select(&desc, options, config.mock_select)?;
+            let result = input::select(&desc, options, &config.mock_select)?;
             if result == input::CANCEL {
                 return Ok("Cancelled".into());
             }

--- a/src/commands/task_commands.rs
+++ b/src/commands/task_commands.rs
@@ -42,6 +42,14 @@ pub enum TaskCommands {
     #[clap(alias = "m")]
     /// (m) Add a comment to the last task fetched with the next command
     Comment(Comment),
+
+    #[clap(alias = "ec")]
+    /// (ec) Edit an existing comment's content
+    EditComment(EditComment),
+
+    #[clap(alias = "dc")]
+    /// (dc) Delete a comment by ID
+    DeleteComment(DeleteComment),
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -352,6 +360,54 @@ pub async fn reopen(config: Config, _args: &Reopen, json: bool) -> Result<String
     }
 }
 
+#[derive(Parser, Debug, Clone)]
+/// (ec) Edit an existing comment's content
+pub struct EditComment {
+    /// ID of the comment to edit
+    comment_id: String,
+
+    /// New content for the comment
+    content: Option<String>,
+}
+
+#[derive(Parser, Debug, Clone)]
+/// (dc) Delete a comment by ID
+pub struct DeleteComment {
+    /// ID of the comment to delete
+    comment_id: String,
+}
+
+/// Edits the content of an existing comment by ID.
+pub async fn edit_comment(config: Config, args: &EditComment, json: bool) -> Result<String, Error> {
+    let EditComment {
+        comment_id,
+        content,
+    } = args;
+
+    let content = super::fetch_string(content.as_deref(), &config, input::CONTENT)?;
+    let comment = todoist::update_comment(&config, comment_id, &content, true).await?;
+
+    if json {
+        Ok(serde_json::to_string(&comment)?)
+    } else {
+        Ok(format::green_string("Comment updated successfully"))
+    }
+}
+
+/// Deletes a comment by ID.
+pub async fn delete_comment(
+    config: Config,
+    args: &DeleteComment,
+    json: bool,
+) -> Result<String, Error> {
+    let result = todoist::delete_comment(&config, &args.comment_id, true).await?;
+
+    if json {
+        Ok(serde_json::to_string(&result)?)
+    } else {
+        Ok(format::green_string("Comment deleted successfully"))
+    }
+}
 /// Adds a comment to the stored next task.
 pub async fn comment(config: Config, args: &Comment, json: bool) -> Result<String, Error> {
     let Comment { content } = args;
@@ -525,5 +581,113 @@ mod tests {
         assert!(result.unwrap().contains("task(s) remaining"));
         tasks_mock.assert();
         comments_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn edit_comment_happy_path() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/api/v1/comments/123")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(ResponseFromFile::Comment.read().await)
+            .create_async()
+            .await;
+
+        let config = test::fixtures::config().await.with_mock_url(server.url());
+
+        let args = EditComment {
+            comment_id: "123".to_string(),
+            content: Some("new content".to_string()),
+        };
+        let result = edit_comment(config, &args, false).await;
+        assert!(
+            result.is_ok(),
+            "edit_comment should succeed; got: {result:?}"
+        );
+        assert!(result.unwrap().contains("Comment updated successfully"));
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn edit_comment_json_output() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/api/v1/comments/123")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(ResponseFromFile::Comment.read().await)
+            .create_async()
+            .await;
+
+        let config = test::fixtures::config().await.with_mock_url(server.url());
+
+        let args = EditComment {
+            comment_id: "123".to_string(),
+            content: Some("new content".to_string()),
+        };
+        let result = edit_comment(config, &args, true).await;
+        assert!(result.is_ok());
+        let json = result.unwrap();
+        assert!(json.contains("\"id\""));
+        assert!(json.contains("2992679862"));
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn edit_comment_json_mode_no_content_errors() {
+        let mut config = test::fixtures::config().await;
+        config.args.json = true;
+
+        let args = EditComment {
+            comment_id: "123".to_string(),
+            content: None,
+        };
+        let result = edit_comment(config, &args, true).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().source, "json_mode");
+    }
+
+    #[tokio::test]
+    async fn delete_comment_happy_path() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("DELETE", "/api/v1/comments/123")
+            .with_status(204)
+            .create_async()
+            .await;
+
+        let config = test::fixtures::config().await.with_mock_url(server.url());
+
+        let args = DeleteComment {
+            comment_id: "123".to_string(),
+        };
+        let result = delete_comment(config, &args, false).await;
+        assert!(
+            result.is_ok(),
+            "delete_comment should succeed; got: {result:?}"
+        );
+        assert!(result.unwrap().contains("Comment deleted successfully"));
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn delete_comment_json_output() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("DELETE", "/api/v1/comments/123")
+            .with_status(204)
+            .create_async()
+            .await;
+
+        let config = test::fixtures::config().await.with_mock_url(server.url());
+
+        let args = DeleteComment {
+            comment_id: "123".to_string(),
+        };
+        let result = delete_comment(config, &args, true).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "\"✓\"");
+        mock.assert();
     }
 }

--- a/src/commands/task_commands.rs
+++ b/src/commands/task_commands.rs
@@ -163,7 +163,7 @@ pub async fn create(config: Config, args: &Create, json: bool) -> Result<String,
             return Err(Error::new("json_mode", super::JSON_INTERACTIVE_ERROR));
         }
         let options = tasks::create_task_attributes();
-        let selections = input::multi_select(input::ATTRIBUTES, options, config.mock_select)?;
+        let selections = input::multi_select(input::ATTRIBUTES, options, &config.mock_select)?;
 
         let content = super::fetch_string(None, &config, input::CONTENT)?;
 
@@ -180,7 +180,7 @@ pub async fn create(config: Config, args: &Create, json: bool) -> Result<String,
         };
         let due = if selections.contains(&TaskAttribute::Due) {
             let datetime_input = input::datetime(
-                config.mock_select,
+                &config.mock_select,
                 config.mock_string.clone(),
                 config.natural_language_only,
                 false,
@@ -198,7 +198,7 @@ pub async fn create(config: Config, args: &Create, json: bool) -> Result<String,
 
         let labels = if selections.contains(&TaskAttribute::Labels) {
             let all_labels = labels::get_labels(&config, false).await?;
-            input::multi_select(input::LABELS, all_labels, config.mock_select)?
+            input::multi_select(input::LABELS, all_labels, &config.mock_select)?
         } else {
             Vec::new()
         }
@@ -461,11 +461,11 @@ mod tests {
             .create_async()
             .await;
 
-        let mut config = test::fixtures::config()
+        let config = test::fixtures::config()
             .await
             .with_mock_url(server.url())
-            .with_time_provider(TimeProviderEnum::Fixed(FixedTimeProvider));
-        config.mock_select = Some(0);
+            .with_time_provider(TimeProviderEnum::Fixed(FixedTimeProvider))
+            .mock_select(0);
 
         let args = Edit {
             project: None,

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -72,6 +72,7 @@ impl Config {
         Config::load(&self.path).await.map(|config| Config {
             internal: self.internal.clone(),
             time_provider: self.time_provider.clone(),
+            mock_select: self.mock_select.clone(),
             ..config
         })
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -51,6 +51,20 @@ where
     }
 }
 
+fn empty_mock_select() -> Arc<Mutex<Vec<usize>>> {
+    Arc::new(Mutex::new(Vec::new()))
+}
+
+fn deserialize_mock_select<'de, D>(deserializer: D) -> Result<Arc<Mutex<Vec<usize>>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    // Accept any value (including null, empty array, old values) and return default.
+    // This preserves backward compatibility with config files that saved mock_select.
+    let _ = serde_json::Value::deserialize(deserializer)?;
+    Ok(empty_mock_select())
+}
+
 /// App configuration, serialized as json in `$XDG_CONFIG_HOME/tod.cfg`
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(default, deny_unknown_fields)]
@@ -92,7 +106,11 @@ pub struct Config {
     pub last_version_check: Option<String>,
     pub mock_url: Option<String>,
     pub mock_string: Option<String>,
-    #[serde(skip)]
+    #[serde(
+        skip_serializing,
+        deserialize_with = "deserialize_mock_select",
+        default = "empty_mock_select"
+    )]
     pub mock_select: Arc<Mutex<Vec<usize>>>,
     /// Whether spinners are enabled
     pub spinners: Option<bool>,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -14,6 +14,7 @@ use regex::Regex;
 use serde::de::Error as DeError;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 use terminal_size::{Height, Width, terminal_size};
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -91,7 +92,8 @@ pub struct Config {
     pub last_version_check: Option<String>,
     pub mock_url: Option<String>,
     pub mock_string: Option<String>,
-    pub mock_select: Option<usize>,
+    #[serde(skip)]
+    pub mock_select: Arc<Mutex<Vec<usize>>>,
     /// Whether spinners are enabled
     pub spinners: Option<bool>,
     #[serde(default)]
@@ -482,7 +484,7 @@ impl Config {
             no_sections: None,
             natural_language_only: None,
             mock_string: None,
-            mock_select: None,
+            mock_select: Arc::new(Mutex::new(Vec::new())),
             max_comment_length: None,
             comment_exclude_regex: None,
             task_exclude_regex: None,
@@ -597,14 +599,14 @@ impl Config {
             bell_on_failure
             Ring terminal bell if a command fails
         ";
-        let bell_on_failure = input::bool(desc, bell_on_failure, mock_select)?;
+        let bell_on_failure = input::bool(desc, bell_on_failure, &mock_select)?;
 
         // --- bell_on_success
         let desc = "
             bell_on_success
             Ring terminal bell if a command succeeds
         ";
-        let bell_on_success = input::bool(desc, bell_on_success, mock_select)?;
+        let bell_on_success = input::bool(desc, bell_on_success, &mock_select)?;
 
         // --- spinners
         let desc = "
@@ -612,7 +614,7 @@ impl Config {
             Display a spinner in terminal while waiting for an API call to complete
         ";
         let default_value = spinners.unwrap_or(true);
-        let spinners = Some(input::bool(desc, default_value, mock_select)?);
+        let spinners = Some(input::bool(desc, default_value, &mock_select)?);
 
         // --- verbose
         let desc = "
@@ -620,7 +622,7 @@ impl Config {
             Output additional information to assist with debugging issues
         ";
         let default_value = verbose.unwrap_or(false);
-        let verbose = Some(input::bool(desc, default_value, mock_select)?);
+        let verbose = Some(input::bool(desc, default_value, &mock_select)?);
 
         // --- natural_language_only
         let desc = "
@@ -628,14 +630,14 @@ impl Config {
             Skip the date-picker menu and go straight to natural language input for datetime selection
         ";
         let default_value = natural_language_only.unwrap_or(false);
-        let natural_language_only = Some(input::bool(desc, default_value, mock_select)?);
+        let natural_language_only = Some(input::bool(desc, default_value, &mock_select)?);
 
         // --- disable_links
         let desc = "
             disable_links
             Disable terminal hyperlinks in output
         ";
-        let disable_links = input::bool(desc, disable_links, mock_select)?;
+        let disable_links = input::bool(desc, disable_links, &mock_select)?;
 
         // --- no_sections
         let desc = "
@@ -643,7 +645,7 @@ impl Config {
             Do not prompt a user to select a section when working with projects
         ";
         let default_value = no_sections.unwrap_or(false);
-        let no_sections = Some(input::bool(desc, default_value, mock_select)?);
+        let no_sections = Some(input::bool(desc, default_value, &mock_select)?);
 
         // --- token
         let desc = format!(
@@ -764,7 +766,7 @@ impl Default for Config {
             no_sections: None,
             natural_language_only: None,
             mock_string: None,
-            mock_select: None,
+            mock_select: Arc::new(Mutex::new(Vec::new())),
             max_comment_length: None,
             verbose: None,
             internal: Internal { tx: None },
@@ -818,7 +820,7 @@ mod tests {
                 last_version_check: None,
                 mock_url: None,
                 mock_string: None,
-                mock_select: None,
+                mock_select: Arc::new(Mutex::new(Vec::new())),
                 spinners: None,
                 disable_links: false,
                 completed: None,
@@ -845,7 +847,14 @@ mod tests {
 
         pub fn mock_select(self, index: usize) -> Config {
             Config {
-                mock_select: Some(index),
+                mock_select: Arc::new(Mutex::new(vec![index])),
+                ..self
+            }
+        }
+
+        pub fn mock_selects(self, selects: Vec<usize>) -> Config {
+            Config {
+                mock_select: Arc::new(Mutex::new(selects)),
                 ..self
             }
         }
@@ -1038,7 +1047,7 @@ mod tests {
         );
 
         let select_config = base_config.clone().mock_select(2);
-        assert_eq!(select_config.mock_select, Some(2));
+        assert_eq!(*select_config.mock_select.lock().unwrap(), vec![2]);
 
         let path_config = base_config.with_path(PathBuf::from("some/test/path.cfg"));
         assert_eq!(path_config.path, PathBuf::from("some/test/path.cfg"));

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -19,11 +19,11 @@ pub async fn edit_task(config: &Config, filter: String) -> Result<String, Error>
         .flat_map(|(_, tasks)| tasks)
         .collect::<Vec<Task>>();
 
-    let task = input::select(input::TASK, tasks, config.mock_select)?;
+    let task = input::select(input::TASK, tasks, &config.mock_select)?;
 
     let options = tasks::edit_task_attributes();
 
-    let selections = input::multi_select(input::ATTRIBUTES, options, config.mock_select)?;
+    let selections = input::multi_select(input::ATTRIBUTES, options, &config.mock_select)?;
 
     if selections.is_empty() {
         return Err(Error {

--- a/src/input.rs
+++ b/src/input.rs
@@ -75,6 +75,15 @@ pub const QUIT: &str = "Quit";
 /// Option: schedule the task.
 pub const SCHEDULE: &str = "Schedule";
 
+/// Comment submenu option: edit.
+pub const EDIT_COMMENT: &str = "Edit";
+/// Comment submenu option: delete.
+pub const DELETE_COMMENT: &str = "Delete";
+/// Comment submenu option: go back.
+pub const BACK: &str = "Back";
+/// Comment submenu option: create new comment.
+pub const NEW_COMMENT: &str = "New comment";
+
 /// Natural language date and time input.
 #[derive(Debug, PartialEq)]
 pub enum DateTimeInput {

--- a/src/input.rs
+++ b/src/input.rs
@@ -223,7 +223,11 @@ pub fn number_with_default(desc: &str, default_message: usize) -> Result<usize, 
 }
 
 /// Prompts the user for a boolean value.
-pub fn bool(desc: &str, default_value: bool, mock_selects: &Mutex<Vec<usize>>) -> Result<bool, Error> {
+pub fn bool(
+    desc: &str,
+    default_value: bool,
+    mock_selects: &Mutex<Vec<usize>>,
+) -> Result<bool, Error> {
     let options = vec![true, false];
     let cursor_index = usize::from(!default_value);
     select_with_cursor_index(desc, options, cursor_index, mock_selects)
@@ -311,11 +315,19 @@ mod tests {
 
     #[test]
     fn can_select() {
-        let result = select("type", vec!["there", "are", "words"], &Arc::new(Mutex::new(vec![0])));
+        let result = select(
+            "type",
+            vec!["there", "are", "words"],
+            &Arc::new(Mutex::new(vec![0])),
+        );
         let expected = Ok("there");
         assert_eq!(result, expected);
 
-        let result = select("type", vec!["there", "are", "words"], &Arc::new(Mutex::new(vec![1])));
+        let result = select(
+            "type",
+            vec!["there", "are", "words"],
+            &Arc::new(Mutex::new(vec![1])),
+        );
         let expected = Ok("are");
         assert_eq!(result, expected);
     }
@@ -352,43 +364,85 @@ mod tests {
 
     #[test]
     fn datetime_nat_lang_with_skip_complete_enter_none() {
-        let result = datetime(&Arc::new(Mutex::new(vec![1])), Some("none".into()), None, false, true);
+        let result = datetime(
+            &Arc::new(Mutex::new(vec![1])),
+            Some("none".into()),
+            None,
+            false,
+            true,
+        );
         assert_eq!(result, Ok(DateTimeInput::None));
     }
 
     #[test]
     fn datetime_nat_lang_with_skip_complete_enter_skip() {
-        let result = datetime(&Arc::new(Mutex::new(vec![1])), Some("skip".into()), None, false, true);
+        let result = datetime(
+            &Arc::new(Mutex::new(vec![1])),
+            Some("skip".into()),
+            None,
+            false,
+            true,
+        );
         assert_eq!(result, Ok(DateTimeInput::Skip));
     }
 
     #[test]
     fn datetime_nat_lang_with_skip_complete_enter_complete() {
-        let result = datetime(&Arc::new(Mutex::new(vec![1])), Some("complete".into()), None, false, true);
+        let result = datetime(
+            &Arc::new(Mutex::new(vec![1])),
+            Some("complete".into()),
+            None,
+            false,
+            true,
+        );
         assert_eq!(result, Ok(DateTimeInput::Complete));
     }
 
     #[test]
     fn datetime_nat_lang_with_skip_complete_enter_free_text() {
-        let result = datetime(&Arc::new(Mutex::new(vec![1])), Some("next Monday".into()), None, false, true);
+        let result = datetime(
+            &Arc::new(Mutex::new(vec![1])),
+            Some("next Monday".into()),
+            None,
+            false,
+            true,
+        );
         assert_eq!(result, Ok(DateTimeInput::Text("next Monday".into())));
     }
 
     #[test]
     fn datetime_nat_lang_without_skip_complete_enter_none() {
-        let result = datetime(&Arc::new(Mutex::new(vec![1])), Some("none".into()), None, false, false);
+        let result = datetime(
+            &Arc::new(Mutex::new(vec![1])),
+            Some("none".into()),
+            None,
+            false,
+            false,
+        );
         assert_eq!(result, Ok(DateTimeInput::None));
     }
 
     #[test]
     fn datetime_nat_lang_without_skip_complete_enter_short_n() {
-        let result = datetime(&Arc::new(Mutex::new(vec![1])), Some("n".into()), None, false, false);
+        let result = datetime(
+            &Arc::new(Mutex::new(vec![1])),
+            Some("n".into()),
+            None,
+            false,
+            false,
+        );
         assert_eq!(result, Ok(DateTimeInput::None));
     }
 
     #[test]
     fn datetime_nat_lang_without_skip_complete_enter_free_text() {
-        let result = datetime(&Arc::new(Mutex::new(vec![1])), Some("Friday".into()), None, false, false);
+        let result = datetime(
+            &Arc::new(Mutex::new(vec![1])),
+            Some("Friday".into()),
+            None,
+            false,
+            false,
+        );
         assert_eq!(result, Ok(DateTimeInput::Text("Friday".into())));
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -3,6 +3,7 @@
 use crate::errors::Error;
 use inquire::{Confirm, CustomType, DateSelect, MultiSelect, Select, Text};
 use std::fmt::Display;
+use std::sync::Mutex;
 use terminal_size::{Height, Width, terminal_size};
 
 // These constants are used throughout the app
@@ -91,7 +92,7 @@ pub enum DateTimeInput {
 /// `skip_or_complete` enables the skip and complete options;
 /// it is generally true when processing tasks.
 pub fn datetime(
-    mock_select: Option<usize>,
+    mock_selects: &Mutex<Vec<usize>>,
     mock_string: Option<String>,
     natural_language_only: Option<bool>,
     no_natural_language: bool,
@@ -102,15 +103,15 @@ pub fn datetime(
     } else if no_natural_language && skip_or_complete {
         let options = vec![SELECT_DATE, NO_DATE, SKIP, COMPLETE];
         let description = DATE;
-        select(description, options, mock_select)?
+        select(description, options, mock_selects)?
     } else if !no_natural_language && skip_or_complete {
         let options = vec![SELECT_DATE, NAT_LANG, NO_DATE, SKIP, COMPLETE];
         let description = DATE;
-        select(description, options, mock_select)?
+        select(description, options, mock_selects)?
     } else {
         let options = vec![SELECT_DATE, NAT_LANG, NO_DATE];
         let description = DATE;
-        select(description, options, mock_select)?
+        select(description, options, mock_selects)?
     };
 
     match selection {
@@ -213,19 +214,19 @@ pub fn number_with_default(desc: &str, default_message: usize) -> Result<usize, 
 }
 
 /// Prompts the user for a boolean value.
-pub fn bool(desc: &str, default_value: bool, mock_select: Option<usize>) -> Result<bool, Error> {
+pub fn bool(desc: &str, default_value: bool, mock_selects: &Mutex<Vec<usize>>) -> Result<bool, Error> {
     let options = vec![true, false];
     let cursor_index = usize::from(!default_value);
-    select_with_cursor_index(desc, options, cursor_index, mock_select)
+    select_with_cursor_index(desc, options, cursor_index, mock_selects)
 }
 
 /// Select an input from a list
 pub fn select<T: Display>(
     desc: &str,
     options: Vec<T>,
-    mock_select: Option<usize>,
+    mock_selects: &Mutex<Vec<usize>>,
 ) -> Result<T, Error> {
-    select_with_cursor_index(desc, options, 0, mock_select)
+    select_with_cursor_index(desc, options, 0, mock_selects)
 }
 
 /// Select an input from a list, with a cursor index
@@ -233,17 +234,21 @@ pub fn select_with_cursor_index<T: Display>(
     desc: &str,
     options: Vec<T>,
     cursor_index: usize,
-    mock_select: Option<usize>,
+    mock_selects: &Mutex<Vec<usize>>,
 ) -> Result<T, Error> {
     if cfg!(test) {
-        if let Some(index) = mock_select {
-            Ok(options
-                .into_iter()
-                .nth(index)
-                .expect("Must provide a vector of options"))
+        let mut selects = mock_selects.lock().unwrap();
+        let index = if selects.len() <= 1 {
+            // Singleton or empty: peek (backward-compatible, never consumes)
+            *selects.first().unwrap_or(&0)
         } else {
-            panic!("Must set mock_select in config")
-        }
+            // Multiple values: consume sequentially
+            selects.remove(0)
+        };
+        Ok(options
+            .into_iter()
+            .nth(index)
+            .expect("Must provide a vector of options"))
     } else {
         Select::new(desc, options)
             .with_page_size(page_size() / 2) //Fixing bug with page size
@@ -257,18 +262,20 @@ pub fn select_with_cursor_index<T: Display>(
 pub fn multi_select<T: Display>(
     desc: &str,
     options: Vec<T>,
-    mock_select: Option<usize>,
+    mock_selects: &Mutex<Vec<usize>>,
 ) -> Result<Vec<T>, Error> {
     if cfg!(test) {
-        if let Some(index) = mock_select {
-            let value = options
-                .into_iter()
-                .nth(index)
-                .expect("Must provide a vector of options");
-            Ok(vec![value])
+        let mut selects = mock_selects.lock().unwrap();
+        let index = if selects.len() <= 1 {
+            *selects.first().unwrap_or(&0)
         } else {
-            panic!("Must set mock_select in config")
-        }
+            selects.remove(0)
+        };
+        let value = options
+            .into_iter()
+            .nth(index)
+            .expect("Must provide a vector of options");
+        Ok(vec![value])
     } else {
         MultiSelect::new(desc, options)
             .with_page_size(page_size() / 2) //Fixing bug with page size
@@ -291,14 +298,15 @@ pub fn page_size() -> usize {
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
+    use std::sync::Arc;
 
     #[test]
     fn can_select() {
-        let result = select("type", vec!["there", "are", "words"], Some(0));
+        let result = select("type", vec!["there", "are", "words"], &Arc::new(Mutex::new(vec![0])));
         let expected = Ok("there");
         assert_eq!(result, expected);
 
-        let result = select("type", vec!["there", "are", "words"], Some(1));
+        let result = select("type", vec!["there", "are", "words"], &Arc::new(Mutex::new(vec![1])));
         let expected = Ok("are");
         assert_eq!(result, expected);
     }
@@ -306,7 +314,7 @@ mod tests {
     #[test]
     fn datetime_natural_language_only_returns_text() {
         let result = datetime(
-            None,
+            &Arc::new(Mutex::new(Vec::new())),
             Some("tomorrow at 3pm".into()),
             Some(true),
             false,
@@ -317,67 +325,67 @@ mod tests {
 
     #[test]
     fn datetime_no_natural_language_skip_complete_select_no_date() {
-        let result = datetime(Some(1), None, None, true, true);
+        let result = datetime(&Arc::new(Mutex::new(vec![1])), None, None, true, true);
         assert_eq!(result, Ok(DateTimeInput::None));
     }
 
     #[test]
     fn datetime_no_natural_language_skip_complete_select_skip() {
-        let result = datetime(Some(2), None, None, true, true);
+        let result = datetime(&Arc::new(Mutex::new(vec![2])), None, None, true, true);
         assert_eq!(result, Ok(DateTimeInput::Skip));
     }
 
     #[test]
     fn datetime_no_natural_language_skip_complete_select_complete() {
-        let result = datetime(Some(3), None, None, true, true);
+        let result = datetime(&Arc::new(Mutex::new(vec![3])), None, None, true, true);
         assert_eq!(result, Ok(DateTimeInput::Complete));
     }
 
     #[test]
     fn datetime_nat_lang_with_skip_complete_enter_none() {
-        let result = datetime(Some(1), Some("none".into()), None, false, true);
+        let result = datetime(&Arc::new(Mutex::new(vec![1])), Some("none".into()), None, false, true);
         assert_eq!(result, Ok(DateTimeInput::None));
     }
 
     #[test]
     fn datetime_nat_lang_with_skip_complete_enter_skip() {
-        let result = datetime(Some(1), Some("skip".into()), None, false, true);
+        let result = datetime(&Arc::new(Mutex::new(vec![1])), Some("skip".into()), None, false, true);
         assert_eq!(result, Ok(DateTimeInput::Skip));
     }
 
     #[test]
     fn datetime_nat_lang_with_skip_complete_enter_complete() {
-        let result = datetime(Some(1), Some("complete".into()), None, false, true);
+        let result = datetime(&Arc::new(Mutex::new(vec![1])), Some("complete".into()), None, false, true);
         assert_eq!(result, Ok(DateTimeInput::Complete));
     }
 
     #[test]
     fn datetime_nat_lang_with_skip_complete_enter_free_text() {
-        let result = datetime(Some(1), Some("next Monday".into()), None, false, true);
+        let result = datetime(&Arc::new(Mutex::new(vec![1])), Some("next Monday".into()), None, false, true);
         assert_eq!(result, Ok(DateTimeInput::Text("next Monday".into())));
     }
 
     #[test]
     fn datetime_nat_lang_without_skip_complete_enter_none() {
-        let result = datetime(Some(1), Some("none".into()), None, false, false);
+        let result = datetime(&Arc::new(Mutex::new(vec![1])), Some("none".into()), None, false, false);
         assert_eq!(result, Ok(DateTimeInput::None));
     }
 
     #[test]
     fn datetime_nat_lang_without_skip_complete_enter_short_n() {
-        let result = datetime(Some(1), Some("n".into()), None, false, false);
+        let result = datetime(&Arc::new(Mutex::new(vec![1])), Some("n".into()), None, false, false);
         assert_eq!(result, Ok(DateTimeInput::None));
     }
 
     #[test]
     fn datetime_nat_lang_without_skip_complete_enter_free_text() {
-        let result = datetime(Some(1), Some("Friday".into()), None, false, false);
+        let result = datetime(&Arc::new(Mutex::new(vec![1])), Some("Friday".into()), None, false, false);
         assert_eq!(result, Ok(DateTimeInput::Text("Friday".into())));
     }
 
     #[test]
     fn datetime_select_no_date_from_default_options() {
-        let result = datetime(Some(2), None, None, false, false);
+        let result = datetime(&Arc::new(Mutex::new(vec![2])), None, None, false, false);
         assert_eq!(result, Ok(DateTimeInput::None));
     }
 
@@ -387,7 +395,7 @@ mod tests {
         // With the correct code, the else branch fires with options:
         // [SELECT_DATE(0), NAT_LANG(1), NO_DATE(2)]
         // mock_select=2 selects NO_DATE.
-        let result = datetime(Some(2), None, None, false, false);
+        let result = datetime(&Arc::new(Mutex::new(vec![2])), None, None, false, false);
         assert_eq!(result, Ok(DateTimeInput::None));
     }
 
@@ -395,7 +403,7 @@ mod tests {
     fn bool_select_returns_false_when_cursor_starts_on_true() {
         // default_value=true → cursor starts on false (index 1)
         // mock_select=0 overrides and picks the first option (true)
-        let result = bool("test", true, Some(0));
+        let result = bool("test", true, &Arc::new(Mutex::new(vec![0])));
         assert_eq!(result, Ok(true));
     }
 
@@ -403,7 +411,7 @@ mod tests {
     fn bool_select_returns_true_when_cursor_starts_on_false() {
         // default_value=false → cursor starts on true (index 0)
         // mock_select=1 picks the second option (false)
-        let result = bool("test", false, Some(1));
+        let result = bool("test", false, &Arc::new(Mutex::new(vec![1])));
         assert_eq!(result, Ok(false));
     }
 
@@ -412,7 +420,7 @@ mod tests {
         // no_natural_language=true, skip_or_complete=false
         // Must not match no_natural_language && skip_or_complete.
         // Goes to else branch with options: [SELECT_DATE(0), NAT_LANG(1), NO_DATE(2)]
-        let result = datetime(Some(2), None, None, true, false);
+        let result = datetime(&Arc::new(Mutex::new(vec![2])), None, None, true, false);
         assert_eq!(result, Ok(DateTimeInput::None));
     }
 
@@ -422,7 +430,7 @@ mod tests {
         // no_natural_language=false, skip_or_complete=false
         // Original (&&): !false && false = false → else (3 options) → mock_select=3 panics
         // Mutant  (||): !false || false = true  → branch (5 options) → mock_select=3 → SKIP
-        let _ = datetime(Some(3), None, None, false, false);
+        let _ = datetime(&Arc::new(Mutex::new(vec![3])), None, None, false, false);
     }
 
     #[test]

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -521,7 +521,8 @@ pub async fn edit_task(config: &Config, project: &Project) -> Result<String, Err
 
     let options = tasks::edit_task_attributes();
 
-    let selections = input::multi_select("Choose attributes to edit", options, &config.mock_select)?;
+    let selections =
+        input::multi_select("Choose attributes to edit", options, &config.mock_select)?;
 
     if selections.is_empty() {
         return Err(Error {

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -318,7 +318,7 @@ pub async fn remove_all(config: &mut Config) -> Result<String, Error> {
     let selection = input::select(
         "Confirm removing all projects from config",
         options,
-        config.mock_select,
+        &config.mock_select,
     )?;
 
     if selection == "Cancel" {
@@ -495,7 +495,7 @@ async fn maybe_add_project(
 
     let options = vec!["add", "skip"];
     println!("{project}");
-    match input::select("Select an option", options, config.mock_select) {
+    match input::select("Select an option", options, &config.mock_select) {
         Ok(string) => {
             if string == "add" {
                 add(config, &project).await
@@ -516,12 +516,12 @@ pub async fn edit_task(config: &Config, project: &Project) -> Result<String, Err
     let task = input::select(
         "Choose a task of the project:",
         project_tasks,
-        config.mock_select,
+        &config.mock_select,
     )?;
 
     let options = tasks::edit_task_attributes();
 
-    let selections = input::multi_select("Choose attributes to edit", options, config.mock_select)?;
+    let selections = input::multi_select("Choose attributes to edit", options, &config.mock_select)?;
 
     if selections.is_empty() {
         return Err(Error {
@@ -674,7 +674,7 @@ pub async fn move_task_to_project(
         .iter()
         .map(std::string::ToString::to_string)
         .collect::<Vec<String>>();
-    let selection = input::select("Choose", options, config.mock_select)?;
+    let selection = input::select("Choose", options, &config.mock_select)?;
 
     match selection.as_str() {
         "Complete" => Ok(tasks::spawn_complete_task(config.clone(), task.id)),
@@ -683,7 +683,7 @@ pub async fn move_task_to_project(
         "Skip" => Ok(tokio::spawn(async move {})),
         _ => {
             let projects = config.projects().await?;
-            let project = input::select("Select project", projects, config.mock_select)?;
+            let project = input::select("Select project", projects, &config.mock_select)?;
 
             let sections: Vec<Section> = sections
                 .iter()
@@ -706,7 +706,7 @@ pub async fn move_task_to_project(
                 }))
             } else {
                 let section_name =
-                    input::select("Select section", section_names, config.mock_select)?;
+                    input::select("Select section", section_names, &config.mock_select)?;
                 let section = sections
                     .iter()
                     .find(|x| x.name == section_name.as_str())

--- a/src/sections.rs
+++ b/src/sections.rs
@@ -61,7 +61,7 @@ pub async fn select_section(config: &Config, project: &Project) -> Result<Option
         Ok(None)
     } else {
         section_names.insert(0, "No section".to_string());
-        let section_name = input::select(input::SECTION, section_names, config.mock_select)?;
+        let section_name = input::select(input::SECTION, section_names, &config.mock_select)?;
 
         let section = sections
             .iter()

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -465,7 +465,7 @@ pub async fn update_task(
             let value = &task.priority;
             let priorities = priority::all_priorities();
 
-            let new_value = input::select("Select your priority:", priorities, config.mock_select)?;
+            let new_value = input::select("Select your priority:", priorities, &config.mock_select)?;
             if *value == new_value {
                 Ok(None)
             } else {
@@ -503,7 +503,7 @@ pub async fn label_task(
     println!("{text}");
     let mut options = labels.to_vec();
     options.push(input::SKIP.to_string());
-    let label = input::select("Select label", options, config.mock_select)?;
+    let label = input::select("Select label", options, &config.mock_select)?;
 
     let config = config.clone();
     Ok(tokio::spawn(async move {
@@ -541,7 +541,7 @@ pub async fn process_task(
     let tasks_completed = reloaded_config.tasks_completed()?;
     println!("{formatted_task}{tasks_completed} completed today, {task_count} remaining");
     *task_count -= 1;
-    let selection = input::select(input::OPTION, options, config.mock_select)?;
+    let selection = input::select(input::OPTION, options, &config.mock_select)?;
     match selection.as_str() {
         input::COMPLETE => {
             if let Err(e) = reloaded_config.save().await {
@@ -605,7 +605,7 @@ pub async fn timebox_task(
         .await?;
     println!("{formatted_task}{task_count} task(s) remaining");
     *task_count -= 1;
-    let selection = input::select("Select an option", options, config.mock_select)?;
+    let selection = input::select("Select an option", options, &config.mock_select)?;
     match selection.as_str() {
         input::TIMEBOX => {
             let (due_string, duration) = get_timebox(config, &task)?;
@@ -675,7 +675,7 @@ pub async fn spawn_schedule_task(
         .await?;
     println!("{text}");
     let datetime_input = input::datetime(
-        config.mock_select,
+        &config.mock_select,
         config.mock_string.clone(),
         config.natural_language_only,
         false,
@@ -709,7 +709,7 @@ pub async fn spawn_deadline_task(
         .await?;
     println!("{text}");
     let datetime_input = input::datetime(
-        config.mock_select,
+        &config.mock_select,
         config.mock_string.clone(),
         config.natural_language_only,
         true,
@@ -979,7 +979,7 @@ pub async fn set_priority(
         Priority::Medium,
         Priority::High,
     ];
-    let priority = input::select(input::PRIORITY, options, config.mock_select)?;
+    let priority = input::select(input::PRIORITY, options, &config.mock_select)?;
 
     let config = config.clone();
     Ok(tokio::spawn(async move {
@@ -995,7 +995,7 @@ pub async fn create_reminder(config: &Config, task: Task) -> Result<Option<JoinH
     let text = task.fmt(comments, config, FormatType::Single, true).await?;
     println!("{text}");
     let datetime_input = input::datetime(
-        config.mock_select,
+        &config.mock_select,
         config.mock_string.clone(),
         // We only want to use natural language for this input
         Some(true),

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -849,17 +849,13 @@ fn format_comment_option(comment: &Comment, config: &Config) -> String {
     } else {
         comment.content.clone()
     };
-    let formatted_date = match config.get_timezone() {
-        Ok(tz) => match time::timezone_from_str(&tz) {
-            Ok(tz) => match time::datetime_from_str(&comment.posted_at, tz) {
-                Ok(dt) => time::datetime_to_string(&dt, config)
-                    .unwrap_or_else(|_| comment.posted_at[..10].to_string()),
-                Err(_) => comment.posted_at[..10].to_string(),
-            },
-            Err(_) => comment.posted_at[..10].to_string(),
-        },
-        Err(_) => comment.posted_at[..10].to_string(),
-    };
+    let formatted_date = config
+        .get_timezone()
+        .ok()
+        .and_then(|tz| time::timezone_from_str(&tz).ok())
+        .and_then(|tz| time::datetime_from_str(&comment.posted_at, tz).ok())
+        .and_then(|dt| time::datetime_to_string(&dt, config).ok())
+        .unwrap_or_else(|| comment.posted_at[..10].to_string());
     format!("{truncated} — {formatted_date}")
 }
 

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -465,7 +465,8 @@ pub async fn update_task(
             let value = &task.priority;
             let priorities = priority::all_priorities();
 
-            let new_value = input::select("Select your priority:", priorities, &config.mock_select)?;
+            let new_value =
+                input::select("Select your priority:", priorities, &config.mock_select)?;
             if *value == new_value {
                 Ok(None)
             } else {
@@ -562,7 +563,7 @@ pub async fn process_task(
                 .iter()
                 .map(|c| format_comment_option(c, config))
                 .collect();
-            comment_options.push("New comment".to_string());
+            comment_options.push(input::NEW_COMMENT.to_string());
 
             let selected = input::select(
                 "Select a comment",
@@ -570,7 +571,7 @@ pub async fn process_task(
                 &config.mock_select,
             )?;
 
-            if selected == "New comment" {
+            if selected == input::NEW_COMMENT {
                 let content = input::string(CONTENT, config.mock_string.clone())?;
                 return Ok(Some(spawn_comment_task(config.clone(), task.id, content)));
             }
@@ -583,15 +584,11 @@ pub async fn process_task(
             let comment = &comments[comment_index];
 
             // Sub-submenu: Edit / Delete / Back
-            let action_options = vec!["Edit", "Delete", "Back"];
-            let action = input::select(
-                "Choose an action",
-                action_options,
-                &config.mock_select,
-            )?;
+            let action_options = vec![input::EDIT_COMMENT, input::DELETE_COMMENT, input::BACK];
+            let action = input::select("Choose an action", action_options, &config.mock_select)?;
 
             match action {
-                "Edit" => {
+                input::EDIT_COMMENT => {
                     let content = input::string(CONTENT, config.mock_string.clone())?;
                     Ok(Some(spawn_update_comment(
                         config.clone(),
@@ -599,11 +596,11 @@ pub async fn process_task(
                         content,
                     )))
                 }
-                "Delete" => Ok(Some(spawn_delete_comment(
+                input::DELETE_COMMENT => Ok(Some(spawn_delete_comment(
                     config.clone(),
                     comment.id.clone(),
                 ))),
-                "Back" => {
+                input::BACK => {
                     // Return a no-op handle to continue the loop
                     Ok(Some(tokio::spawn(async move {})))
                 }
@@ -855,7 +852,8 @@ fn format_comment_option(comment: &Comment, config: &Config) -> String {
     let formatted_date = match config.get_timezone() {
         Ok(tz) => match time::timezone_from_str(&tz) {
             Ok(tz) => match time::datetime_from_str(&comment.posted_at, tz) {
-                Ok(dt) => time::datetime_to_string(&dt, config).unwrap_or_else(|_| comment.posted_at[..10].to_string()),
+                Ok(dt) => time::datetime_to_string(&dt, config)
+                    .unwrap_or_else(|_| comment.posted_at[..10].to_string()),
                 Err(_) => comment.posted_at[..10].to_string(),
             },
             Err(_) => comment.posted_at[..10].to_string(),
@@ -2408,129 +2406,122 @@ mod tests {
         // ── properties ─────────────────────────────────────────────
 
         // Phase 2: COMMENT submenu tests
-    #[tokio::test]
-    async fn test_process_task_comment_empty() {
-        // Empty comments: goes straight to new comment prompt
-        let config = test::fixtures::config()
-            .await
-            .mock_selects(vec![3]) // COMMENT is option index 3 in process menu
-            .with_mock_string("new comment text")
-            .create()
-            .await
-            .expect("config should be created");
-        let task = test::fixtures::today_task().await;
-        let mut task_count = 1;
-        let result = process_task(
-            vec![],
-            &config,
-            task.clone(),
-            &mut task_count,
-            false,
-        )
-        .await;
-        // Should return a handle (spawned create_comment)
-        assert!(result.is_ok(), "got error: {result:?}");
-        assert!(result.unwrap().is_some());
-    }
+        #[tokio::test]
+        async fn test_process_task_comment_empty() {
+            // Empty comments: goes straight to new comment prompt
+            let config = test::fixtures::config()
+                .await
+                .mock_selects(vec![3]) // COMMENT is option index 3 in process menu
+                .with_mock_string("new comment text")
+                .create()
+                .await
+                .expect("config should be created");
+            let task = test::fixtures::today_task().await;
+            let mut task_count = 1;
+            let result = process_task(vec![], &config, task.clone(), &mut task_count, false).await;
+            // Should return a handle (spawned create_comment)
+            assert!(result.is_ok(), "got error: {result:?}");
+            assert!(result.unwrap().is_some());
+        }
 
-    #[tokio::test]
-    async fn test_process_task_comment_with_existing_new() {
-        let config = test::fixtures::config()
-            .await
-            .mock_selects(vec![3, 1]) // COMMENT (index 3), then "New comment" (index 1 in comment list with 1 existing)
-            .with_mock_string("brand new comment")
-            .create()
-            .await
-            .expect("config should be created");
-        let task = test::fixtures::today_task().await;
-        let comments = vec![crate::test::fixtures::comment()];
-        let mut task_count = 1;
-        let result = process_task(
-            comments.clone(),
-            &config,
-            task.clone(),
-            &mut task_count,
-            false,
-        )
-        .await;
-        assert!(result.is_ok(), "got error: {result:?}");
-        assert!(result.unwrap().is_some());
-    }
+        #[tokio::test]
+        async fn test_process_task_comment_with_existing_new() {
+            let config = test::fixtures::config()
+                .await
+                .mock_selects(vec![3, 1]) // COMMENT (index 3), then "New comment" (index 1 in comment list with 1 existing)
+                .with_mock_string("brand new comment")
+                .create()
+                .await
+                .expect("config should be created");
+            let task = test::fixtures::today_task().await;
+            let comments = vec![crate::test::fixtures::comment()];
+            let mut task_count = 1;
+            let result = process_task(
+                comments.clone(),
+                &config,
+                task.clone(),
+                &mut task_count,
+                false,
+            )
+            .await;
+            assert!(result.is_ok(), "got error: {result:?}");
+            assert!(result.unwrap().is_some());
+        }
 
-    #[tokio::test]
-    async fn test_process_task_comment_edit() {
-        let config = test::fixtures::config()
-            .await
-            .mock_selects(vec![3, 0, 0]) // COMMENT, pick first existing comment, then Edit
-            .with_mock_string("updated text")
-            .create()
-            .await
-            .expect("config should be created");
-        let task = test::fixtures::today_task().await;
-        let comments = vec![crate::test::fixtures::comment()];
-        let mut task_count = 1;
-        let result = process_task(
-            comments.clone(),
-            &config,
-            task.clone(),
-            &mut task_count,
-            false,
-        )
-        .await;
-        assert!(result.is_ok(), "got error: {result:?}");
-        assert!(result.unwrap().is_some());
-    }
+        #[tokio::test]
+        async fn test_process_task_comment_edit() {
+            let config = test::fixtures::config()
+                .await
+                .mock_selects(vec![3, 0, 0]) // COMMENT, pick first existing comment, then Edit
+                .with_mock_string("updated text")
+                .create()
+                .await
+                .expect("config should be created");
+            let task = test::fixtures::today_task().await;
+            let comments = vec![crate::test::fixtures::comment()];
+            let mut task_count = 1;
+            let result = process_task(
+                comments.clone(),
+                &config,
+                task.clone(),
+                &mut task_count,
+                false,
+            )
+            .await;
+            assert!(result.is_ok(), "got error: {result:?}");
+            assert!(result.unwrap().is_some());
+        }
 
-    #[tokio::test]
-    async fn test_process_task_comment_delete() {
-        let config = test::fixtures::config()
-            .await
-            .mock_selects(vec![3, 0, 1]) // COMMENT, pick first existing comment, then Delete
-            .with_mock_string("unused")
-            .create()
-            .await
-            .expect("config should be created");
-        let task = test::fixtures::today_task().await;
-        let comments = vec![crate::test::fixtures::comment()];
-        let mut task_count = 1;
-        let result = process_task(
-            comments.clone(),
-            &config,
-            task.clone(),
-            &mut task_count,
-            false,
-        )
-        .await;
-        assert!(result.is_ok(), "got error: {result:?}");
-        assert!(result.unwrap().is_some());
-    }
+        #[tokio::test]
+        async fn test_process_task_comment_delete() {
+            let config = test::fixtures::config()
+                .await
+                .mock_selects(vec![3, 0, 1]) // COMMENT, pick first existing comment, then Delete
+                .with_mock_string("unused")
+                .create()
+                .await
+                .expect("config should be created");
+            let task = test::fixtures::today_task().await;
+            let comments = vec![crate::test::fixtures::comment()];
+            let mut task_count = 1;
+            let result = process_task(
+                comments.clone(),
+                &config,
+                task.clone(),
+                &mut task_count,
+                false,
+            )
+            .await;
+            assert!(result.is_ok(), "got error: {result:?}");
+            assert!(result.unwrap().is_some());
+        }
 
-    #[tokio::test]
-    async fn test_process_task_comment_back() {
-        let config = test::fixtures::config()
-            .await
-            .mock_selects(vec![3, 0, 2]) // COMMENT, pick first existing comment, then Back
-            .with_mock_string("unused")
-            .create()
-            .await
-            .expect("config should be created");
-        let task = test::fixtures::today_task().await;
-        let comments = vec![crate::test::fixtures::comment()];
-        let mut task_count = 1;
-        let result = process_task(
-            comments.clone(),
-            &config,
-            task.clone(),
-            &mut task_count,
-            false,
-        )
-        .await;
-        // Back returns a no-op spawn handle (still Some)
-        assert!(result.is_ok(), "got error: {result:?}");
-        assert!(result.unwrap().is_some());
-    }
+        #[tokio::test]
+        async fn test_process_task_comment_back() {
+            let config = test::fixtures::config()
+                .await
+                .mock_selects(vec![3, 0, 2]) // COMMENT, pick first existing comment, then Back
+                .with_mock_string("unused")
+                .create()
+                .await
+                .expect("config should be created");
+            let task = test::fixtures::today_task().await;
+            let comments = vec![crate::test::fixtures::comment()];
+            let mut task_count = 1;
+            let result = process_task(
+                comments.clone(),
+                &config,
+                task.clone(),
+                &mut task_count,
+                false,
+            )
+            .await;
+            // Back returns a no-op spawn handle (still Some)
+            assert!(result.is_ok(), "got error: {result:?}");
+            assert!(result.unwrap().is_some());
+        }
 
-    proptest! {
+        proptest! {
             #[test]
             fn priority_serde_roundtrip(priority in arb_priority()) {
                 let json = serde_json::to_string(&priority).unwrap();

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -535,7 +535,7 @@ pub async fn process_task(
     .map(std::string::ToString::to_string)
     .collect();
     let formatted_task = task
-        .fmt(comments, config, FormatType::Single, with_project)
+        .fmt(comments.clone(), config, FormatType::Single, with_project)
         .await?;
     let mut reloaded_config = config.reload().await?.increment_completed()?;
     let tasks_completed = reloaded_config.tasks_completed()?;
@@ -551,9 +551,64 @@ pub async fn process_task(
         }
         input::DELETE => Ok(Some(spawn_delete_task(config.clone(), task.id))),
         input::COMMENT => {
-            let content = input::string(CONTENT, config.mock_string.clone())?;
+            if comments.is_empty() {
+                // No existing comments — go straight to new comment prompt
+                let content = input::string(CONTENT, config.mock_string.clone())?;
+                return Ok(Some(spawn_comment_task(config.clone(), task.id, content)));
+            }
 
-            Ok(Some(spawn_comment_task(config.clone(), task.id, content)))
+            // Build options: each existing comment + "New comment"
+            let mut comment_options: Vec<String> = comments
+                .iter()
+                .map(|c| format_comment_option(c, config))
+                .collect();
+            comment_options.push("New comment".to_string());
+
+            let selected = input::select(
+                "Select a comment",
+                comment_options.clone(),
+                &config.mock_select,
+            )?;
+
+            if selected == "New comment" {
+                let content = input::string(CONTENT, config.mock_string.clone())?;
+                return Ok(Some(spawn_comment_task(config.clone(), task.id, content)));
+            }
+
+            // User picked an existing comment — find it by matching the formatted string
+            let comment_index = comment_options
+                .iter()
+                .position(|opt| *opt == selected)
+                .expect("selected option must exist");
+            let comment = &comments[comment_index];
+
+            // Sub-submenu: Edit / Delete / Back
+            let action_options = vec!["Edit", "Delete", "Back"];
+            let action = input::select(
+                "Choose an action",
+                action_options,
+                &config.mock_select,
+            )?;
+
+            match action {
+                "Edit" => {
+                    let content = input::string(CONTENT, config.mock_string.clone())?;
+                    Ok(Some(spawn_update_comment(
+                        config.clone(),
+                        comment.id.clone(),
+                        content,
+                    )))
+                }
+                "Delete" => Ok(Some(spawn_delete_comment(
+                    config.clone(),
+                    comment.id.clone(),
+                ))),
+                "Back" => {
+                    // Return a no-op handle to continue the loop
+                    Ok(Some(tokio::spawn(async move {})))
+                }
+                _ => unreachable!(),
+            }
         }
 
         input::REMIND => {
@@ -790,10 +845,48 @@ pub fn spawn_update_task_deadline(
     })
 }
 
+/// Formats a comment as a one-line summary for display in select menus.
+fn format_comment_option(comment: &Comment, config: &Config) -> String {
+    let truncated = if comment.content.len() > 60 {
+        format!("{}…", &comment.content[..60])
+    } else {
+        comment.content.clone()
+    };
+    let formatted_date = match config.get_timezone() {
+        Ok(tz) => match time::timezone_from_str(&tz) {
+            Ok(tz) => match time::datetime_from_str(&comment.posted_at, tz) {
+                Ok(dt) => time::datetime_to_string(&dt, config).unwrap_or_else(|_| comment.posted_at[..10].to_string()),
+                Err(_) => comment.posted_at[..10].to_string(),
+            },
+            Err(_) => comment.posted_at[..10].to_string(),
+        },
+        Err(_) => comment.posted_at[..10].to_string(),
+    };
+    format!("{truncated} — {formatted_date}")
+}
+
 /// Updates task inside another thread
 pub fn spawn_comment_task(config: Config, task_id: String, task_comment: String) -> JoinHandle<()> {
     tokio::spawn(async move {
         if let Err(e) = todoist::create_comment(&config, &task_id, &task_comment, false).await {
+            let _ = config.tx().send(e);
+        }
+    })
+}
+
+/// Updates a comment inside another thread
+pub fn spawn_update_comment(config: Config, comment_id: String, content: String) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        if let Err(e) = todoist::update_comment(&config, &comment_id, &content, false).await {
+            let _ = config.tx().send(e);
+        }
+    })
+}
+
+/// Deletes a comment inside another thread
+pub fn spawn_delete_comment(config: Config, comment_id: String) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        if let Err(e) = todoist::delete_comment(&config, &comment_id, false).await {
             let _ = config.tx().send(e);
         }
     })
@@ -1247,7 +1340,7 @@ mod tests {
             }),
             ..test::fixtures::today_task().await
         };
-        let comments = vec![test::fixtures::comment()];
+        let comments = vec![crate::test::fixtures::comment()];
 
         let task_text = task
             .fmt(comments, &config, FormatType::Single, true)
@@ -2314,7 +2407,130 @@ mod tests {
 
         // ── properties ─────────────────────────────────────────────
 
-        proptest! {
+        // Phase 2: COMMENT submenu tests
+    #[tokio::test]
+    async fn test_process_task_comment_empty() {
+        // Empty comments: goes straight to new comment prompt
+        let config = test::fixtures::config()
+            .await
+            .mock_selects(vec![3]) // COMMENT is option index 3 in process menu
+            .with_mock_string("new comment text")
+            .create()
+            .await
+            .expect("config should be created");
+        let task = test::fixtures::today_task().await;
+        let mut task_count = 1;
+        let result = process_task(
+            vec![],
+            &config,
+            task.clone(),
+            &mut task_count,
+            false,
+        )
+        .await;
+        // Should return a handle (spawned create_comment)
+        assert!(result.is_ok(), "got error: {result:?}");
+        assert!(result.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_process_task_comment_with_existing_new() {
+        let config = test::fixtures::config()
+            .await
+            .mock_selects(vec![3, 1]) // COMMENT (index 3), then "New comment" (index 1 in comment list with 1 existing)
+            .with_mock_string("brand new comment")
+            .create()
+            .await
+            .expect("config should be created");
+        let task = test::fixtures::today_task().await;
+        let comments = vec![crate::test::fixtures::comment()];
+        let mut task_count = 1;
+        let result = process_task(
+            comments.clone(),
+            &config,
+            task.clone(),
+            &mut task_count,
+            false,
+        )
+        .await;
+        assert!(result.is_ok(), "got error: {result:?}");
+        assert!(result.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_process_task_comment_edit() {
+        let config = test::fixtures::config()
+            .await
+            .mock_selects(vec![3, 0, 0]) // COMMENT, pick first existing comment, then Edit
+            .with_mock_string("updated text")
+            .create()
+            .await
+            .expect("config should be created");
+        let task = test::fixtures::today_task().await;
+        let comments = vec![crate::test::fixtures::comment()];
+        let mut task_count = 1;
+        let result = process_task(
+            comments.clone(),
+            &config,
+            task.clone(),
+            &mut task_count,
+            false,
+        )
+        .await;
+        assert!(result.is_ok(), "got error: {result:?}");
+        assert!(result.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_process_task_comment_delete() {
+        let config = test::fixtures::config()
+            .await
+            .mock_selects(vec![3, 0, 1]) // COMMENT, pick first existing comment, then Delete
+            .with_mock_string("unused")
+            .create()
+            .await
+            .expect("config should be created");
+        let task = test::fixtures::today_task().await;
+        let comments = vec![crate::test::fixtures::comment()];
+        let mut task_count = 1;
+        let result = process_task(
+            comments.clone(),
+            &config,
+            task.clone(),
+            &mut task_count,
+            false,
+        )
+        .await;
+        assert!(result.is_ok(), "got error: {result:?}");
+        assert!(result.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_process_task_comment_back() {
+        let config = test::fixtures::config()
+            .await
+            .mock_selects(vec![3, 0, 2]) // COMMENT, pick first existing comment, then Back
+            .with_mock_string("unused")
+            .create()
+            .await
+            .expect("config should be created");
+        let task = test::fixtures::today_task().await;
+        let comments = vec![crate::test::fixtures::comment()];
+        let mut task_count = 1;
+        let result = process_task(
+            comments.clone(),
+            &config,
+            task.clone(),
+            &mut task_count,
+            false,
+        )
+        .await;
+        // Back returns a no-op spawn handle (still Some)
+        assert!(result.is_ok(), "got error: {result:?}");
+        assert!(result.unwrap().is_some());
+    }
+
+    proptest! {
             #[test]
             fn priority_serde_roundtrip(priority in arb_priority()) {
                 let json = serde_json::to_string(&priority).unwrap();

--- a/src/todoist/mod.rs
+++ b/src/todoist/mod.rs
@@ -1290,9 +1290,7 @@ mod tests {
             .create_async()
             .await;
 
-        let config = test::fixtures::config()
-            .await
-            .with_mock_url(server.url());
+        let config = test::fixtures::config().await.with_mock_url(server.url());
 
         let comment = update_comment(&config, "123", "updated content", false)
             .await
@@ -1312,9 +1310,7 @@ mod tests {
             .create_async()
             .await;
 
-        let config = test::fixtures::config()
-            .await
-            .with_mock_url(server.url());
+        let config = test::fixtures::config().await.with_mock_url(server.url());
 
         let result = delete_comment(&config, "123", false)
             .await

--- a/src/todoist/mod.rs
+++ b/src/todoist/mod.rs
@@ -862,6 +862,33 @@ pub async fn create_comment(
     Comment::from_json(&response)
 }
 
+/// Updates the content of a comment by ID.
+pub async fn update_comment(
+    config: &Config,
+    comment_id: &str,
+    content: &str,
+    spinner: bool,
+) -> Result<Comment, Error> {
+    let body = json!({"content": content});
+    let url = format!("{COMMENTS_URL}{comment_id}");
+
+    let response = request::post_todoist(config, &url, body, spinner).await?;
+    Comment::from_json(&response)
+}
+
+/// Deletes a comment by ID. The Todoist API returns 204 No Content.
+pub async fn delete_comment(
+    config: &Config,
+    comment_id: &str,
+    spinner: bool,
+) -> Result<String, Error> {
+    let url = format!("{COMMENTS_URL}{comment_id}");
+
+    request::delete_todoist(config, &url, json!({}), spinner).await?;
+    // Does not pass back a comment
+    Ok("✓".into())
+}
+
 /// Fetches the authenticated user's data.
 pub async fn get_user_data(config: &Config) -> Result<User, Error> {
     let url = USER_URL.to_string();
@@ -1249,6 +1276,51 @@ mod tests {
             create_comment(&config, &task.id, "New comment", true).await,
             Ok(comment)
         );
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_update_comment() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/api/v1/comments/123")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(ResponseFromFile::Comment.read().await)
+            .create_async()
+            .await;
+
+        let config = test::fixtures::config()
+            .await
+            .with_mock_url(server.url());
+
+        let comment = update_comment(&config, "123", "updated content", false)
+            .await
+            .expect("expected value or result, got None or Err");
+
+        assert_eq!(comment.id, "2992679862");
+        assert_eq!(comment.content, "Need one bottle of milk");
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_delete_comment() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("DELETE", "/api/v1/comments/123")
+            .with_status(204)
+            .create_async()
+            .await;
+
+        let config = test::fixtures::config()
+            .await
+            .with_mock_url(server.url());
+
+        let result = delete_comment(&config, "123", false)
+            .await
+            .expect("expected value or result, got None or Err");
+
+        assert_eq!(result, "✓");
         mock.assert();
     }
 


### PR DESCRIPTION
## Summary

Adds update and delete operations for Todoist comments, both via the interactive process menu and CLI subcommands.

### Changes

1. **API client** (\`src/todoist/mod.rs\`)
   - Add \`update_comment\` — POST to \`/api/v1/comments/{id}\` with new content
   - Add \`delete_comment\` — DELETE to \`/api/v1/comments/{id}\`

2. **Interactive COMMENT submenu** (\`src/tasks/mod.rs\`)
   - Empty comments: goes straight to new comment prompt (existing behavior)
   - Existing comments: select a comment, then choose Edit/Delete/Back
   - \`format_comment_option\` helper formats comments as one-line summary
   - \`spawn_update_comment\` and \`spawn_delete_comment\` spawn functions

3. **CLI subcommands** (\`src/commands/task_commands.rs\`)
   - \`tod task edit-comment <id> [content]\` (alias: ec)
   - \`tod task delete-comment <id>\` (alias: dc)
   - JSON mode support: edit returns comment object, delete returns ✓
   - Missing content arg in JSON mode returns json_mode error

4. **Mock select infrastructure** (\`src/config/mod.rs\`, \`src/input.rs\`)
   - Changed from \`Option<usize>\` to \`Arc<Mutex<Vec<usize>>>\`
   - Singleton values peek (backward-compatible)
   - Multi-value sequences pop (enables multi-step COMMENT submenu tests)

5. **Documentation** (\`docs/usage.md\`)
   - Added edit-comment and delete-comment to help output and examples

### Testing
- 516 tests pass, 3 skipped (unchanged)
- 12 new tests covering API functions, CLI handlers, and COMMENT submenu flows

### Related
- Closes #1778
- Part of #1760